### PR TITLE
Add Argus library for ride height sensor

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -67,6 +67,18 @@ use_repo(openocd, "openocd")
 dfu = use_extension("//tools/dfu:dfu.bzl", "dfu")
 use_repo(dfu, "dfu")
 
+# AFBR-S50 API Library
+git_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+git_repository(
+    name = "afbr_s50_lib",
+    remote = "https://github.com/Broadcom/AFBR-S50-API.git",
+    commit = "68b16693bedae0704b49edcfa2a79e82e5520ae3",
+    shallow_since = "2024-01-01",
+    build_file = "//drivers:afbr-s50/afbr-s50.BUILD", 
+)
+
+
 # Hermetic Rust Toolchain
 # rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
 # rust.toolchain(

--- a/drivers/README.md
+++ b/drivers/README.md
@@ -195,3 +195,19 @@ Then, in your main loop, add the following:
 // you may want to replace the 0.01f with the amount of time (in seconds) between LED updates
 led_rainbow(0.01f); // updates the LED colors
 ```
+
+### Other Drivers
+
+#### AFBR-S50 API
+
+To use the AFBR-S50 API, include the following in your Bazel BUILD file's `firmware_project_g4` declaration:
+
+```bazel
+extra_deps = [
+        "@afbr_s50_lib//:afbr_s50_lib"
+],
+```
+
+If you already have an `extra_deps` attribute, just add the above line to the list.
+
+Then, in your code, use the API as specified by the official documentation.

--- a/drivers/afbr-s50/afbr-s50.BUILD
+++ b/drivers/afbr-s50/afbr-s50.BUILD
@@ -1,0 +1,18 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "afbr_s50_lib",
+    
+    srcs = glob(
+        ["AFBR-S50/Lib/**/*.a"], 
+        allow_empty = True
+    ),
+    
+    hdrs = glob(
+        ["AFBR-S50/Include/**/*.h"], 
+        allow_empty = True
+    ),
+    
+    includes = ["AFBR-S50/Include"],
+    visibility = ["//visibility:public"], 
+)


### PR DESCRIPTION
closes #97 

The library can be used by adding:
```bazel
extra_deps = [
        "@afbr_s50_lib//:afbr_s50_lib"
    ],
```
to a `firmware_project_g4` target.