### PR TITLE
Firmware Versioning

### DIFF
--- a/VCU/firmware/BUILD.bazel
+++ b/VCU/firmware/BUILD.bazel
@@ -19,4 +19,5 @@ firmware_project_g4(
     linker_script = "STM32G474XX_FLASH.ld",
     startup_script = "startup_stm32g474xx.s",
     usb_device_name = "Vehicle Control Unit",
+    version = "0.5.5",
 )

--- a/VCU/firmware/STM32G474XX_FLASH.ld
+++ b/VCU/firmware/STM32G474XX_FLASH.ld
@@ -76,6 +76,13 @@ SECTIONS
     . = ALIGN(4);
   } >FLASH
 
+  .ver_info :
+  {
+    . = ALIGN(4);
+    KEEP(*(.ver_info))   /* KEEP prevents the linker from optimizing it away */
+    . = ALIGN(4);
+  } >FLASH
+
   /* The program code and other data goes into FLASH */
   .text :
   {

--- a/drivers/versioning/BUILD.bazel
+++ b/drivers/versioning/BUILD.bazel
@@ -1,0 +1,9 @@
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "fw_version",
+    srcs = [
+        "fw_version.c",
+        "fw_version.h",
+    ],
+)

--- a/drivers/versioning/fw_version.c
+++ b/drivers/versioning/fw_version.c
@@ -1,0 +1,17 @@
+#include <stdint.h>
+
+typedef struct {
+  char magic[4];
+  uint8_t major;
+  uint8_t minor;
+  uint16_t patch;
+  char build_date[12];
+} AppVersion_t;
+
+__attribute__((section(".ver_info"), used)) const AppVersion_t g_app_version = {
+    .magic = {'V', 'E', 'R', 'S'},
+    .major = APP_VERS_MAJOR,
+    .minor = APP_VERS_MINOR,
+    .patch = APP_VERS_PATCH,
+    .build_date = __DATE__,
+};

--- a/drivers/versioning/fw_version.h
+++ b/drivers/versioning/fw_version.h
@@ -1,0 +1,4 @@
+#ifndef FW_VERSION_H
+#define FW_VERSION_H
+
+#endif // FW_VERSION_H

--- a/tools/outputs/build_outputs.bzl
+++ b/tools/outputs/build_outputs.bzl
@@ -122,6 +122,7 @@ def firmware_project_g4(
         enable_freertos = False,
         enable_dfu = False,
         locations = [],
+        version = "0.0.0",
         **kwargs):
     """Creates a firmware project for the STM32G4 family of chips.
 
@@ -140,6 +141,7 @@ def firmware_project_g4(
         locations (list, optional): A list of location identifiers (e.g., ["FR", "FL"]).
                                     For each location, a separate binary will be generated
                                     with a "BOARD_<location>" define. Defaults to [].
+        version (string, optional): The version of the firmware. Defaults to "0.0.0".
         **kwargs: extra args to pass to cc_binary.
     """
 
@@ -151,6 +153,10 @@ def firmware_project_g4(
     final_extra_deps = extra_deps[:]
     final_defines = defines[:]
 
+    final_defines.append("APP_VERS_MAJOR=" + version.split(".")[0])
+    final_defines.append("APP_VERS_MINOR=" + version.split(".")[1])
+    final_defines.append("APP_VERS_PATCH=" + version.split(".")[2])
+
     if (enable_usb):
         final_extra_srcs.append("//drivers/stm32g4:usb_device_srcs")
         final_extra_deps.append("//drivers/stm32g4:usb_device_headers")
@@ -161,6 +167,7 @@ def firmware_project_g4(
         final_extra_deps.append("//drivers/stm32g4:freertos_headers")
 
     final_extra_srcs.append("//drivers/ota:ota_flash_srcs")
+    final_extra_srcs.append("//drivers/versioning:fw_version")
     final_extra_deps.append("//drivers/ota:ota_flash_headers")
 
     # enable DFU if the board has it enabled


### PR DESCRIPTION
TODO: 
- initialize CAN packet to reports version over the bus. 
- shared linker script for projects so no need to change for each project
- add CAN packet to CSV for reporting version
- add SemVer to every project