### PR TITLE
BEVO: loggerd CSV headers + publishd MQTT client_id PID suffix + cell.py pin 26

### DIFF
--- a/BEVO/cell.py
+++ b/BEVO/cell.py
@@ -9,7 +9,11 @@ PORT = "/dev/ttyUSB2"
 BAUDRATE = 115200
 
 # GPIO setup
-FULL_CARD_POWER_OFF = 16
+# Pin 26 is what's wired to the Quectel RM520N-GL's W_DISABLE / power-off on
+# the BEVO board. Verified empirically 2026-05-22: pin 16 does not power the
+# modem; pin 26 brings it up cleanly (USB enumerates as Quectel 2c7c:0801,
+# ttyUSB0-3 appear, RNDIS usb0 DHCPs onto T-Mobile 5G).
+FULL_CARD_POWER_OFF = 26
 CHIP = 0  # Default GPIO chip on Raspberry Pi 5
 
 # Open GPIO chip

--- a/BEVO/loggerd/main.rs
+++ b/BEVO/loggerd/main.rs
@@ -92,7 +92,8 @@ fn canonical_csv_headers() -> Vec<String> {
         thermal: Some(Thermal::default()),
         board_status: Some(BoardStatus::default()),
     };
-    let value = serde_json::to_value(&template).unwrap_or(Value::Null);
+    let value = serde_json::to_value(&template)
+        .expect("OrionSensorData::default() must always serialize to JSON");
     let mut row = BTreeMap::new();
     flatten_json_value("", &value, &mut row);
     row.keys().cloned().collect()

--- a/BEVO/loggerd/main.rs
+++ b/BEVO/loggerd/main.rs
@@ -13,7 +13,10 @@ use std::thread;
 use std::time::SystemTime;
 use std::time::Duration;
 
-use sensor_proto::proto::orion::OrionSensorData;
+use sensor_proto::proto::orion::{
+    BoardStatus, Controls, DiagnosticsHigh, DiagnosticsLow, Dynamics, OrionSensorData, Pack,
+    Thermal,
+};
 
 const SOCKET_PATH: &str = "/tmp/BEVO_cand.sock";
 const DEFAULT_LOG_DIR: &str = "BEVO/loggerd/logs";
@@ -34,11 +37,20 @@ impl CsvLogger {
             .write(true)
             .truncate(true)
             .open(&csv_path)?;
-        let writer = BufWriter::new(file);
+        let mut writer = BufWriter::new(file);
+
+        // Pre-populate the header from the full proto schema rather than the
+        // first-seen row. Without this, if the first packet has any nested
+        // sub-message as None, flatten_json_value emits a bare top-level key
+        // (e.g. "pack") instead of the per-field keys (e.g. "pack.hv_pack_v")
+        // that later populated packets produce. The header would lock to the
+        // bare form and silently drop every nested value thereafter.
+        let headers = canonical_csv_headers();
+        write_csv_record(&mut writer, headers.iter().map(|s| s.as_str()))?;
 
         Ok(Self {
             writer,
-            headers: Vec::new(),
+            headers,
             rows_since_flush: 0,
         })
     }
@@ -47,11 +59,6 @@ impl CsvLogger {
         let value = serde_json::to_value(data)?;
         let mut row = BTreeMap::new();
         flatten_json_value("", &value, &mut row);
-
-        if self.headers.is_empty() {
-            self.headers = row.keys().cloned().collect();
-            write_csv_record(&mut self.writer, self.headers.iter().map(|s| s.as_str()))?;
-        }
 
         let values = self
             .headers
@@ -67,6 +74,28 @@ impl CsvLogger {
 
         Ok(())
     }
+}
+
+fn canonical_csv_headers() -> Vec<String> {
+    // Build a fully-populated OrionSensorData template (all sub-messages
+    // present as Some(default)) so that flatten_json_value enumerates every
+    // reachable scalar key once. Repeated fields stay empty and contribute
+    // no indexed columns; this only fixes the nested-message-presence gap.
+    let template = OrionSensorData {
+        time: 0,
+        packet_id: 0,
+        dynamics: Some(Dynamics::default()),
+        controls: Some(Controls::default()),
+        pack: Some(Pack::default()),
+        diagnostics_high: Some(DiagnosticsHigh::default()),
+        diagnostics_low: Some(DiagnosticsLow::default()),
+        thermal: Some(Thermal::default()),
+        board_status: Some(BoardStatus::default()),
+    };
+    let value = serde_json::to_value(&template).unwrap_or(Value::Null);
+    let mut row = BTreeMap::new();
+    flatten_json_value("", &value, &mut row);
+    row.keys().cloned().collect()
 }
 
 fn flatten_json_value(prefix: &str, value: &Value, output: &mut BTreeMap<String, String>) {

--- a/BEVO/publishd/main.rs
+++ b/BEVO/publishd/main.rs
@@ -251,7 +251,13 @@ fn main() -> Result<()> {
         .ok()
         .and_then(|value| value.parse::<u16>().ok())
         .unwrap_or(MQTT_PORT);
-    let mqtt_client_id = env_or_default("PUBLISHD_MQTT_CLIENT_ID", MQTT_CLIENT_ID);
+    // Append PID so multiple publishd instances (e.g. orphan from a botched
+    // test kill, or dev laptop + on-car) don't collide on the same MQTT
+    // client_id and kick each other off the broker in a reconnect loop. The
+    // server-side device identity is carried in announce_payload (which keeps
+    // using MQTT_ANNOUNCE_CLIENT_ID verbatim), so this is broker-level only.
+    let mqtt_client_id_base = env_or_default("PUBLISHD_MQTT_CLIENT_ID", MQTT_CLIENT_ID);
+    let mqtt_client_id = format!("{}-{}", mqtt_client_id_base, std::process::id());
     let announce_payload = packet_id_announce_payload(MQTT_ANNOUNCE_CLIENT_ID);
 
     let mqtt_client = MqttClient::new(&mqtt_host, mqtt_port, &mqtt_client_id)?;


### PR DESCRIPTION
## Summary

Three small BEVO fixes bundled, all verified on hardware 2026-05-22.

### 1. loggerd: pre-populate CSV headers from proto schema

`CsvLogger` was locking its CSV header to whatever keys the *first* row happened to produce. If the first packet had any nested sub-message as `None` (e.g. `pack: None`), `flatten_json_value` emitted `{"pack": ""}` — a bare top-level key. The header locked to that. Subsequent packets with `pack: Some(Pack { ... })` flattened to `pack.hv_pack_v`, etc., which didn't match the locked `pack` header. All nested values silently dropped.

Confirmed empirically: a 2000-row mock-stack CSV had only `packet_id` + `time` populated; every other column was empty.

**Fix:** pre-populate the header at `CsvLogger::new` time by building a fully-populated `OrionSensorData` template (all 7 sub-messages as `Some(default())`) and flattening it. Tightened error handling per Gemini's suggestion: `unwrap_or(Value::Null)` → `.expect("...")`.

### 2. publishd: PID-suffix MQTT client_id

publishd's MQTT `client_id` was hardcoded to `BEVO-ORION`. If two publishd processes connect to the broker with the same client_id (orphan from a botched test kill, dev laptop + on-car), the broker kicks them in a tight reconnect loop. Observed empirically: orphaned mock-stack publishd collided with systemd-started publishd, producing ~1/sec `connection closed by peer` storm.

Same hardening as dashd in #228 — append `std::process::id()`. Server-side device identity uses `announce_payload` (kept unchanged as `BEVO-Orion`), so server ingestion is unaffected.

### 3. cell.py: GPIO 26 (not 16) for modem power-on

`cell.py`'s `FULL_CARD_POWER_OFF` was set to GPIO 16 on main, but on the BEVO board the Quectel RM520N-GL's power-control line is wired to GPIO 26. With pin 16 the modem never enumerates; the script reports "powered ON successfully" but no USB devices appear. With pin 26 it brings up cleanly:

- `lsusb` shows `2c7c:0801 Quectel ... RM520N-GL`
- `/dev/ttyUSB0–3` enumerate
- RNDIS `usb0` interface DHCPs onto T-Mobile 5G (RSRP -86, SINR 25, RSRQ -10)
- Public IP via cellular confirmed via `curl --interface usb0 https://api.ipify.org` → T-Mobile IP

**Caveat:** if the pin number is board-revision-specific (Rev A vs Rev B), Rev A boards may need a different value. Empirically confirmed only on the BEVO box we're holding 2026-05-22. @samuelLi05 — flagging for your call whether 26 is universal or rev-specific. Easy to revert if needed.

## Test plan

- [x] **loggerd:** CSV header now contains nested keys (`pack.hv_pack_v`, etc.); data rows have populated values matching debugd output. Verified on Pi 2026-05-21.
- [x] **publishd:** journal shows `BEVO-ORION-<pid>` instead of plain `BEVO-ORION`. Verified on Pi 2026-05-22.
- [x] **cell.py:** modem powers up and enumerates with pin 26. Verified on Pi 2026-05-22 with full AT-command + curl-over-usb0 confirmation.