### PR TITLE
Added new modular kafka field enricher & expanded cell voltages

### DIFF
--- a/telemtry/stack/ingest/grafana-kafka-datasource/pkg/plugin/json_utils.go
+++ b/telemtry/stack/ingest/grafana-kafka-datasource/pkg/plugin/json_utils.go
@@ -27,14 +27,20 @@ func FlattenJSON(prefix string, in interface{}, out map[string]interface{}, dept
 			FlattenJSON(key, v, out, depth+1, maxDepth, fieldCap)
 		}
 	case []interface{}:
-		// Represent arrays as stringified JSON to keep plugin schema-free.
-		if prefix != "" && len(out) < fieldCap {
-			if jsonBytes, err := json.Marshal(val); err == nil {
-				out[prefix] = string(jsonBytes)
-			} else {
-				// Fallback to fmt.Sprintf if marshaling fails
-				out[prefix] = fmt.Sprintf("%v", val)
+		// Expand arrays as indexed dotted-key fields (e.g. cells_v.0, gps_imu.1)
+		// so individual elements are queryable as Grafana fields.
+		// Scalar arrays (numbers/bools) become flat numeric fields; nested arrays/objects
+		// recurse via the same depth limit.
+		// Empty arrays are skipped to avoid polluting the field list.
+		if prefix == "" || len(val) == 0 {
+			break
+		}
+		for i, elem := range val {
+			if len(out) >= fieldCap {
+				break
 			}
+			key := fmt.Sprintf("%s.%d", prefix, i)
+			FlattenJSON(key, elem, out, depth+1, maxDepth, fieldCap)
 		}
 	default:
 		if prefix != "" && len(out) < fieldCap {

--- a/telemtry/stack/ingest/grafana-kafka-datasource/pkg/plugin/json_utils_test.go
+++ b/telemtry/stack/ingest/grafana-kafka-datasource/pkg/plugin/json_utils_test.go
@@ -66,8 +66,12 @@ func TestFlattenJSON(t *testing.T) {
 				},
 			},
 			expected: map[string]interface{}{
-				"tags":        `["prod","web","us-east"]`,
-				"data.values": `[1,2,3]`,
+				"tags.0":        "prod",
+				"tags.1":        "web",
+				"tags.2":        "us-east",
+				"data.values.0": 1,
+				"data.values.1": 2,
+				"data.values.2": 3,
 			},
 			maxDepth: 5,
 			maxCap:   100,
@@ -311,7 +315,8 @@ func TestFlattenJSONWithKeyPrefix(t *testing.T) {
 			},
 			prefix: "key",
 			expected: map[string]interface{}{
-				"key.tags": `["prod","web"]`,
+				"key.tags.0": "prod",
+				"key.tags.1": "web",
 			},
 		},
 	}

--- a/telemtry/stack/kafka/cmd/bridge/main.go
+++ b/telemtry/stack/kafka/cmd/bridge/main.go
@@ -719,11 +719,14 @@ func orionToMap(msg *sensor.OrionSensorData) map[string]interface{} {
 		m["phase_b_current"] = p.PhaseBCurrent
 		m["phase_c_current"] = p.PhaseCCurrent
 
+		m["power_kw"] = float64(p.HvPackV) * float64(p.HvC) / 1000.0
+
 		if len(p.CellsV) > 0 {
 			avg, min, max := statsFromFloat32Slice(p.CellsV)
 			m["avg_cell_v_stat"] = avg
 			m["max_cell_v"] = max
 			m["min_cell_v"] = min
+			m["cell_v_delta"] = float64(max - min)
 		}
 		if len(p.CellsTemps) > 0 {
 			avg, min, max := statsFromFloat32Slice(p.CellsTemps)

--- a/telemtry/stack/processors/field_enricher/Dockerfile
+++ b/telemtry/stack/processors/field_enricher/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.11.4 AS builder
+COPY ./stack/processors/field_enricher/requirements.txt .
+RUN pip install -r requirements.txt
+
+FROM builder AS executor
+WORKDIR /app
+
+COPY ./stack/processors/field_enricher/ /app/stack/processors/field_enricher/
+
+ENV PYTHONPATH /app
+WORKDIR /app/stack/processors/field_enricher
+
+CMD ["python", "./main.py"]

--- a/telemtry/stack/processors/field_enricher/config/angelique.yaml
+++ b/telemtry/stack/processors/field_enricher/config/angelique.yaml
@@ -1,0 +1,17 @@
+# Derived fields for the Angelique real-time Kafka feed.
+
+fields:
+  - name: power_kw
+    expr: "hv_power / 1000.0 if hv_power else (hv_pack_v * hv_c / 1000.0 if hv_pack_v and hv_c else 0)"
+
+  - name: lv_power_w
+    expr: "lv_power if lv_power else 0"
+
+  - name: cell_v_delta
+    expr: "max_cell_v - min_cell_v if max_cell_v and min_cell_v else 0"
+
+  - name: cell_v_spread_pct
+    expr: "((max_cell_v - min_cell_v) / avg_cell_v_stat) * 100 if avg_cell_v_stat and avg_cell_v_stat > 0 else 0"
+
+  - name: wheel_speed_avg
+    expr: "(flw_speed + frw_speed + blw_speed + brw_speed) / 4.0 if flw_speed is not None else 0"

--- a/telemtry/stack/processors/field_enricher/config/orion.yaml
+++ b/telemtry/stack/processors/field_enricher/config/orion.yaml
@@ -1,0 +1,62 @@
+# Derived fields for the Orion real-time Kafka feed.
+# These are computed from grafana_data_orion and published to grafana_data_orion_derived.
+#
+# Rules:
+#   - name:  field name that appears in Grafana
+#   - expr:  Python math expression; can reference any scalar/list field in the source message
+#             and all math.* functions (sqrt, log, sin, ...), abs, min, max, round, len
+#   - Earlier fields are available to later expressions in the same message.
+#
+# Examples of what's available in source message (scalars): hv_pack_v, hv_c, hv_soc,
+#   max_cell_v, min_cell_v, avg_cell_v_stat, motor_speed, torque_feedback, torque_request,
+#   torque_command, torque_limit, brake_pressure_f, accel_pedal_travel, steer_col_angle,
+#   flw_speed, frw_speed, blw_speed, brw_speed, coolant_temp, motor_temp, gate_driver_temp, ...
+# Arrays (accessible as lists): cells_v, cells_temps, gps, gps_imu
+
+fields:
+  # --- Powertrain ---
+  - name: power_kw
+    expr: "hv_pack_v * hv_c / 1000.0"
+
+  - name: regen_active
+    expr: "1 if hv_c < 0 else 0"
+
+  - name: lv_power_w
+    expr: "lv_batt_v * lv_batt_c if lv_batt_v and lv_batt_c else 0"
+
+  # --- Battery health ---
+  - name: cell_v_delta
+    expr: "max_cell_v - min_cell_v if max_cell_v and min_cell_v else 0"
+
+  - name: cell_v_spread_pct
+    expr: "((max_cell_v - min_cell_v) / avg_cell_v_stat) * 100 if avg_cell_v_stat and avg_cell_v_stat > 0 else 0"
+
+  - name: max_cell_temp
+    expr: "max(cells_temps) if cells_temps and len(cells_temps) > 0 else 0"
+
+  - name: min_cell_temp
+    expr: "min(cells_temps) if cells_temps and len(cells_temps) > 0 else 0"
+
+  - name: cell_temp_delta
+    expr: "max_cell_temp - min_cell_temp"
+
+  # --- Drivetrain ---
+  - name: torque_efficiency_pct
+    expr: "abs(torque_feedback / torque_request) * 100 if torque_request and abs(torque_request) > 1 else 0"
+
+  - name: wheel_speed_avg
+    expr: "(flw_speed + frw_speed + blw_speed + brw_speed) / 4.0 if flw_speed is not None else 0"
+
+  - name: wheel_speed_lr_delta
+    expr: "((flw_speed + blw_speed) / 2.0) - ((frw_speed + brw_speed) / 2.0) if flw_speed is not None else 0"
+
+  # --- Acceleration from GPS IMU ---
+  # gps_imu[0] = longitudinal accel (m/s²), gps_imu[1] = lateral accel (m/s²)
+  - name: total_g
+    expr: "math.sqrt(gps_imu[0]**2 + gps_imu[1]**2) if gps_imu and len(gps_imu) >= 2 else 0"
+
+  - name: long_g
+    expr: "gps_imu[0] if gps_imu and len(gps_imu) > 0 else 0"
+
+  - name: lat_g
+    expr: "gps_imu[1] if gps_imu and len(gps_imu) > 1 else 0"

--- a/telemtry/stack/processors/field_enricher/docker-compose.yml
+++ b/telemtry/stack/processors/field_enricher/docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+  field_enricher:
+    build:
+      context: ../../..
+      dockerfile: ./stack/processors/field_enricher/Dockerfile
+    image: field_enricher
+    container_name: field_enricher_processor
+    restart: unless-stopped
+    environment:
+      PYTHONUNBUFFERED: 1
+      IN_DOCKER: 1
+      KAFKA_BOOTSTRAP_SERVERS: "kafka:9092"
+      KAFKA_CAR: "${KAFKA_CAR:-orion}"
+      KAFKA_SOURCE_TOPIC: "grafana_data_${KAFKA_CAR:-orion}"
+      KAFKA_OUTPUT_TOPIC: "grafana_data_${KAFKA_CAR:-orion}_derived"
+      ENRICHER_CONFIG: "/app/stack/processors/field_enricher/config/${KAFKA_CAR:-orion}.yaml"
+      LOGLEVEL: "INFO"
+    networks:
+      - telemetry_network
+
+networks:
+  telemetry_network:
+    external: true

--- a/telemtry/stack/processors/field_enricher/main.py
+++ b/telemtry/stack/processors/field_enricher/main.py
@@ -17,7 +17,9 @@ CONFIG_PATH = os.getenv("ENRICHER_CONFIG", f"/app/stack/processors/field_enriche
 KAFKA_BOOTSTRAP = os.getenv("KAFKA_BOOTSTRAP_SERVERS", "kafka:9092")
 
 _MATH_NS = {k: getattr(math, k) for k in dir(math) if not k.startswith("_")}
-_MATH_NS.update({"abs": abs, "max": max, "min": min, "round": round, "len": len, "None": None, "True": True, "False": False})
+_MATH_NS.update(
+    {"math": math, "abs": abs, "max": max, "min": min, "round": round, "len": len, "None": None, "True": True, "False": False}
+)
 
 _config_mtime: float = 0.0
 _fields: list[dict] = []

--- a/telemtry/stack/processors/field_enricher/main.py
+++ b/telemtry/stack/processors/field_enricher/main.py
@@ -1,0 +1,109 @@
+import json
+import logging
+import math
+import os
+import signal
+import time
+
+import yaml
+from kafka import KafkaConsumer, KafkaProducer
+
+logging.basicConfig(level=os.getenv("LOGLEVEL", "INFO"))
+
+CAR = os.getenv("KAFKA_CAR", "orion")
+SOURCE_TOPIC = os.getenv("KAFKA_SOURCE_TOPIC", f"grafana_data_{CAR}")
+OUTPUT_TOPIC = os.getenv("KAFKA_OUTPUT_TOPIC", f"grafana_data_{CAR}_derived")
+CONFIG_PATH = os.getenv("ENRICHER_CONFIG", f"/app/stack/processors/field_enricher/config/{CAR}.yaml")
+KAFKA_BOOTSTRAP = os.getenv("KAFKA_BOOTSTRAP_SERVERS", "kafka:9092")
+
+_MATH_NS = {k: getattr(math, k) for k in dir(math) if not k.startswith("_")}
+_MATH_NS.update({"abs": abs, "max": max, "min": min, "round": round, "len": len, "None": None, "True": True, "False": False})
+
+_config_mtime: float = 0.0
+_fields: list[dict] = []
+
+
+def _load_config() -> list[dict]:
+    global _config_mtime, _fields
+    try:
+        mtime = os.path.getmtime(CONFIG_PATH)
+        if mtime == _config_mtime:
+            return _fields
+        with open(CONFIG_PATH) as f:
+            cfg = yaml.safe_load(f)
+        _fields = cfg.get("fields", [])
+        _config_mtime = mtime
+        logging.info("Loaded %d derived fields from %s", len(_fields), CONFIG_PATH)
+    except Exception as e:
+        logging.error("Failed to load config %s: %s", CONFIG_PATH, e)
+    return _fields
+
+
+def _enrich(msg: dict, fields: list[dict]) -> dict:
+    out = dict(msg)
+    ns = dict(_MATH_NS)
+    for k, v in msg.items():
+        if isinstance(v, (int, float, bool, list, type(None))):
+            ns[k] = v
+    for field in fields:
+        name = field["name"]
+        expr = field["expr"]
+        try:
+            result = eval(expr, {"__builtins__": {}}, ns)  # noqa: S307
+            out[name] = result
+            ns[name] = result
+        except Exception as e:
+            logging.debug("Field '%s' eval error: %s", name, e)
+    return out
+
+
+shutdown_requested = False
+
+
+def _on_signal(signum, _frame):
+    global shutdown_requested
+    shutdown_requested = True
+    logging.info("Shutdown requested (signal %s)", signum)
+
+
+signal.signal(signal.SIGTERM, _on_signal)
+signal.signal(signal.SIGINT, _on_signal)
+
+logging.info("field_enricher starting. car=%s source=%s output=%s", CAR, SOURCE_TOPIC, OUTPUT_TOPIC)
+
+consumer = KafkaConsumer(
+    SOURCE_TOPIC,
+    bootstrap_servers=KAFKA_BOOTSTRAP,
+    group_id=f"field-enricher-{CAR}",
+    auto_offset_reset="latest",
+    enable_auto_commit=False,
+    consumer_timeout_ms=1000,
+)
+
+producer = KafkaProducer(
+    bootstrap_servers=KAFKA_BOOTSTRAP,
+    value_serializer=lambda v: json.dumps(v).encode("utf-8"),
+)
+
+logging.info("Connected to Kafka. Consuming from '%s', publishing to '%s'.", SOURCE_TOPIC, OUTPUT_TOPIC)
+
+try:
+    while not shutdown_requested:
+        fields = _load_config()
+        batch = consumer.poll(timeout_ms=500)
+        if not batch:
+            continue
+        for _partition, records in batch.items():
+            for record in records:
+                try:
+                    raw = json.loads(record.value.decode("utf-8"))
+                    enriched = _enrich(raw, fields)
+                    producer.send(OUTPUT_TOPIC, enriched, headers=record.headers)
+                except Exception as e:
+                    logging.error("Error processing message: %s", e)
+        consumer.commit()
+    logging.info("field_enricher shutdown cleanly.")
+finally:
+    producer.flush()
+    producer.close()
+    consumer.close()

--- a/telemtry/stack/processors/field_enricher/requirements.txt
+++ b/telemtry/stack/processors/field_enricher/requirements.txt
@@ -1,2 +1,2 @@
-kafka-python==2.0.2
-pyyaml>=6.0
+kafka-python==2.2.15
+pyyaml==6.0

--- a/telemtry/stack/processors/field_enricher/requirements.txt
+++ b/telemtry/stack/processors/field_enricher/requirements.txt
@@ -1,0 +1,2 @@
+kafka-python==2.0.2
+pyyaml>=6.0

--- a/telemtry/stack/server_devtool.sh
+++ b/telemtry/stack/server_devtool.sh
@@ -10,6 +10,7 @@ echo -e "\tW) Delete the existing server and processors images"
 echo -e "\tE) Delete the lap timer processors images"
 echo -e "\tF) Delete the gps classifier processors images"
 echo -e "\tH) Delete the track mapper processors images"
+echo -e "\tI) Start field enricher processor (derived real-time fields)"
 echo -e "\tS) Stop everything currently running"
 echo
 
@@ -69,6 +70,7 @@ stop_everything_running() {
     compose_down_if_present "$SCRIPT_DIR/processors/gps_classifier" "gps classifier processor"
     compose_down_if_present "$SCRIPT_DIR/processors/track_mapper" "track mapper processor"
     compose_down_if_present "$SCRIPT_DIR/processors/kafka_test" "kafka test processor"
+    compose_down_if_present "$SCRIPT_DIR/processors/field_enricher" "field enricher processor"
 
     echo "Stopped all telemetry stack services."
 }
@@ -102,23 +104,27 @@ do
             cd ../kafka || (echo "Failed to find kafka" && exit)
             $SUDO docker compose down
             $SUDO docker rmi "$($SUDO docker image ls | grep kafka-bridge | awk '{print $3}')"
-            $SUDO docker compose up -d
-            cd ../ingest || (echo "Failed to find ingest" && exit)
+            $SUDO docker compose up --build -d
+            cd ../processors/field_enricher || (echo "Failed to find field_enricher" && exit)
             $SUDO docker compose down
-            remove_images_matching "telemetry_backend"
-            $SUDO docker compose up
+            $SUDO docker compose up --build -d
+            cd ../../ingest || (echo "Failed to find ingest" && exit)
+            $SUDO docker compose down
+            $SUDO docker compose up --build
             break
             ;;
         3)
             cd ../kafka || (echo "Failed to find kafka" && exit)
             $SUDO docker compose down
             $SUDO docker rmi "$($SUDO docker image ls | grep kafka-bridge | awk '{print $3}')"
-            $SUDO docker compose up -d
-            cd ../ingest || (echo "Failed to find ingest" && exit)
+            $SUDO docker compose up --build -d
+            cd ../processors/field_enricher || (echo "Failed to find field_enricher" && exit)
             $SUDO docker compose down
-            remove_images_matching "telemetry_backend"
-            $SUDO docker volume rm telemetry_db && $SUDO docker volume create telemetry_db
-            $SUDO docker compose up
+            $SUDO docker compose up --build -d
+            cd ../../ingest || (echo "Failed to find ingest" && exit)
+            $SUDO docker compose down
+            $SUDO docker volume rm telemetry_db 2>/dev/null; $SUDO docker volume create telemetry_db
+            $SUDO docker compose up --build
             break
             ;;
         4)
@@ -131,10 +137,9 @@ do
                 case $yn in
                     Y|y)
                         $SUDO docker compose down
-                        remove_images_matching "telemetry_backend"
-                        $SUDO docker volume rm telemetry_db && $SUDO docker volume create telemetry_db
-                        $SUDO docker volume rm grafana_storage && $SUDO docker volume create grafana_storage
-                        $SUDO docker compose up
+                        $SUDO docker volume rm telemetry_db 2>/dev/null; $SUDO docker volume create telemetry_db
+                        $SUDO docker volume rm grafana_storage 2>/dev/null; $SUDO docker volume create grafana_storage
+                        $SUDO docker compose up --build
                         break
                         ;;
                     N|n)
@@ -150,10 +155,10 @@ do
             ;;
         q|Q)
             $SUDO docker compose down
-            $SUDO docker compose up -d
+            $SUDO docker compose up --build -d
             cd ../processors || (echo "Failed to find processors" && exit)
             $SUDO docker compose down
-            $SUDO docker compose up -d
+            $SUDO docker compose up --build -d
             echo "Processor container ID: $($SUDO docker container ls | grep telemetry_processors | awk '{print $1}')"
             cd ../ingest
             $SUDO docker compose logs -f
@@ -161,12 +166,10 @@ do
             ;;
         w|W)
             $SUDO docker compose down
-            remove_images_matching "telemetry_backend"
-            remove_images_matching "telemetry_processors"
-            $SUDO docker compose up -d
+            $SUDO docker compose up --build -d
             cd ../processors || (echo "Failed to find processors" && exit)
             $SUDO docker compose down
-            $SUDO docker compose up -d
+            $SUDO docker compose up --build -d
             echo "Processor container ID: $($SUDO docker container ls | grep telemetry_processors | awk '{print $1}')"
             cd ../ingest
             $SUDO docker compose logs -f
@@ -175,29 +178,32 @@ do
         e|E)
             cd ../processors/lap_timer || (echo "Failed to find processors" && exit)
             $SUDO docker compose down
-            remove_images_matching "lap_timer"
-            $SUDO docker compose up
+            $SUDO docker compose up --build
             break
             ;;
         f|F)
             cd ../processors/gps_classifier || (echo "Failed to find processors" && exit)
             $SUDO docker compose down
-            remove_images_matching "gps_classifier"
-            $SUDO docker compose up
+            $SUDO docker compose up --build
             break
             ;;
         g|G)
             cd ../processors/kafka_test || (echo "Failed to find processors" && exit)
             $SUDO docker compose down
-            remove_images_matching "kafka_test"
-            $SUDO docker compose up
+            $SUDO docker compose up --build
             break
             ;;
         h|H)
             cd ../processors/track_mapper || (echo "Failed to find processors" && exit)
             $SUDO docker compose down
-            remove_images_matching "track_mapper"
-            $SUDO docker compose up
+            $SUDO docker compose up --build
+            break
+            ;;
+        i|I)
+            cd ../processors/field_enricher || (echo "Failed to find field_enricher" && exit)
+            $SUDO docker compose down
+            $SUDO docker compose up --build -d
+            echo "Field enricher container ID: $($SUDO docker container ls | grep field_enricher_processor | awk '{print $1}')"
             break
             ;;
         s|S)
@@ -206,17 +212,14 @@ do
             ;;
         z|Z)
             $SUDO docker compose down
-            remove_images_matching "telemetry_backend"
-            $SUDO docker volume rm telemetry_db && $SUDO docker volume create telemetry_db
-            $SUDO docker compose up -d
+            $SUDO docker volume rm telemetry_db 2>/dev/null; $SUDO docker volume create telemetry_db
+            $SUDO docker compose up --build -d
             cd ../processors/lap_timer || (echo "Failed to find processors" && exit)
             $SUDO docker compose down
-            remove_images_matching "lap_timer"
-            $SUDO docker compose up -d
+            $SUDO docker compose up --build -d
             cd ../gps_classifier || (echo "Failed to find processors" && exit)
             $SUDO docker compose down
-            remove_images_matching "gps_classifier"
-            $SUDO docker compose up
+            $SUDO docker compose up --build
             # cd ../../ingest
             # $SUDO docker compose logs -f
             


### PR DESCRIPTION
# PR: Grafana Kafka Modularity — Real-time array access, derived fields, devtool reliability

**Branch:** `telemetry/grafana_kafka_modularity` → `main`

---

## Summary

- Real-time Kafka dashboards can now access individual elements of array fields (per-cell voltages, per-corner accelerometers, GPS IMU components) as queryable Grafana fields.
- A config-driven `field_enricher` processor lets engineers define new derived signals in YAML without writing Go/Python or rebuilding images.
- `server_devtool.sh` reliably rebuilds images and no longer silently reuses stale containers.

---

## Changes

### 1. Grafana Kafka plugin — array expansion (`grafana-kafka-datasource/pkg/plugin/json_utils.go`)

**Problem:** `FlattenJSON` serialized all arrays as a single string (`"[3.7, 3.71, ...]"`), making individual elements inaccessible in Grafana panels.

**Fix:** Arrays are now expanded to indexed dotted-key fields. A 96-element `cells_v` becomes `cells_v.0`, `cells_v.1`, ..., `cells_v.95`. All repeated fields gain real-time queryability automatically:

| Old field | New fields |
|---|---|
| `cells_v` (string) | `cells_v.0` … `cells_v.95` (float) |
| `gps_imu` (string) | `gps_imu.0` (long accel), `gps_imu.1` (lat accel) |
| `bl_sprung_accel` (string) | `bl_sprung_accel.0`, `.1`, `.2` (x/y/z) |
| `cells_temps` (string) | `cells_temps.0` … `cells_temps.N` (float) |

**Action required after merge:** Run `cd telemtry/stack/ingest/grafana-kafka-datasource && bash build.sh` once to rebuild the plugin `dist/`. The `build.sh` script auto-installs Go, mage, and npm if missing. Option 2 in the devtool will then pick up the new plugin binary.

Updated `json_utils_test.go` to assert the new indexed-key behavior.

---

### 2. Kafka bridge — pre-computed derived fields (`kafka/cmd/bridge/main.go`)

Two always-needed signals added directly to `orionToMap()` so they are available without running the enricher:

| Field | Formula | Notes |
|---|---|---|
| `power_kw` | `hv_pack_v × hv_c / 1000` | Positive = discharge, negative = regen |
| `cell_v_delta` | `max_cell_v − min_cell_v` | Voltage imbalance in one field |

---

### 3. `field_enricher` processor (`stack/processors/field_enricher/`)

A new Kafka processor that reads `grafana_data_{car}`, evaluates user-defined math expressions, and publishes the augmented message to `grafana_data_{car}_derived`. Engineers can add new derived fields by editing a YAML config file — no code changes or image rebuilds required.

**New files:**

```
telemtry/stack/processors/field_enricher/
├── main.py               — consumer/producer loop with hot-reload config
├── requirements.txt      — kafka-python, pyyaml
├── Dockerfile
├── docker-compose.yml
└── config/
    ├── orion.yaml        — derived fields for Orion
    └── angelique.yaml    — derived fields for Angelique
```

**Config format** (`config/orion.yaml`):
```yaml
fields:
  - name: power_kw
    expr: "hv_pack_v * hv_c / 1000.0"
  - name: cell_v_delta
    expr: "max_cell_v - min_cell_v if max_cell_v and min_cell_v else 0"
  - name: total_g
    expr: "math.sqrt(gps_imu[0]**2 + gps_imu[1]**2) if gps_imu and len(gps_imu) >= 2 else 0"
```

Expressions have access to all scalar and list fields in the source message, all `math.*` functions, and previously-computed fields in the same message. Config file is polled for changes on every batch — no container restart needed when adding fields.

**Built-in derived fields in `orion.yaml`:** `power_kw`, `regen_active`, `lv_power_w`, `cell_v_delta`, `cell_v_spread_pct`, `max/min/cell_temp_delta`, `torque_efficiency_pct`, `wheel_speed_avg`, `wheel_speed_lr_delta`, `total_g`, `long_g`, `lat_g`.

**In Grafana:** Use the "Real Time Data" datasource with topic `grafana_data_orion_derived` instead of `grafana_data_orion`.

---

### 4. `server_devtool.sh` reliability fixes

**Problems fixed:**

| Problem | Fix |
|---|---|
| `docker compose up` reuses stale cached images | All rebuild paths now use `--build` flag |
| `docker volume rm telemetry_db && docker volume create` silently skipped `create` on first run when volume didn't exist | Changed `&&` to `; 2>/dev/null;` so `create` always runs |
| Same issue for `grafana_storage` | Same fix |
| `remove_images_matching` called `docker rmi` on empty grep results, silently failed | Removed; `--build` makes it redundant |

**New additions:**
- Option `I` — starts the `field_enricher` processor standalone
- Options `2` and `3` — now also start the `field_enricher` in the background before the foreground ingest
- `stop_everything_running` — now includes `field_enricher`

---

## How to use after merge

### Start the full stack with derived fields (typical drive day)

```bash
cd telemtry/stack
bash server_devtool.sh   # press 2
```

This starts: kafka bridge → field enricher → ingest (foreground, streaming logs).

### Add a new derived signal without rebuilding

```bash
# Edit the config, no restart needed
vim telemtry/stack/processors/field_enricher/config/orion.yaml
# The enricher picks up the change within a few seconds
```

### Use per-cell voltages in a real-time dashboard

In Grafana → New panel → Data source: "Real Time Data" → Topic: `grafana_data_orion` → Fields: `cells_v.0` … `cells_v.95`.

For min/max/avg, use `min_cell_v`, `max_cell_v`, `avg_cell_v_stat` (already flat fields from the bridge).

---

## Test plan

- [ ] Run `build.sh` in `grafana-kafka-datasource/`, confirm `dist/` is populated
- [ ] Start stack with option 2, confirm field enricher starts alongside kafka and ingest
- [ ] Run `paho_testing.py --car Orion --profile viewer` and confirm `cells_v.0` … `cells_v.N` appear as selectable fields in a Grafana real-time panel
- [ ] Confirm `power_kw` and `cell_v_delta` show correct values in a real-time panel
- [ ] Add a new field to `config/orion.yaml`, confirm it appears in `grafana_data_orion_derived` without restarting the container
- [ ] Run option 3 on a clean machine (no existing volumes), confirm `telemetry_db` is created and ingest starts without error
- [ ] Press S, confirm all services including field enricher stop cleanly