### PR TITLE
Orion DB indexes + devtool integration for viewer & logsync

### DIFF
--- a/telemtry/analysis/database/viewer_tool/ecosystem.config.js
+++ b/telemtry/analysis/database/viewer_tool/ecosystem.config.js
@@ -1,0 +1,29 @@
+// pm2 process definition for the viewer tool.
+//
+// Managed by server_devtool.sh (`viewer` component): `build viewer` runs
+// `npm run build` then `pm2 startOrReload` this file; `status`/`logs`/`stop`
+// drive pm2 by the app name below. Keeping the run config here (instead of an
+// ad-hoc `pm2 start` command) makes start/reload idempotent and reviewable.
+//
+// Run the Next.js binary DIRECTLY (not `npm run start`): with npm as the
+// script, pm2 monitors the npm wrapper instead of the node server, so signals
+// aren't forwarded cleanly (zombie node procs on stop/restart) and CPU/mem
+// stats are wrong. Pointing at next's bin makes pm2 supervise the real process.
+module.exports = {
+  apps: [
+    {
+      name: 'viewer_tool',
+      cwd: __dirname,
+      script: 'node_modules/next/dist/bin/next',
+      interpreter: 'node',
+      args: 'start -p 3001',
+      autorestart: true,
+      max_restarts: 10,
+      env: {
+        // logsync runs host-networked on the same box; the proxy route also
+        // defaults to this, so it's just being explicit.
+        LOGSYNC_URL: 'http://localhost:8090',
+      },
+    },
+  ],
+};

--- a/telemtry/scripts/generate_schema.py
+++ b/telemtry/scripts/generate_schema.py
@@ -261,6 +261,19 @@ def generate_artifacts_from_proto(messages, root_msg_name):
             sql_lines.append(");\n")
             sensor_tables.append(table_name)
 
+    # Indexes. `packet` is the time spine; every sensor table joins back to it
+    # by packet_id. packet_id is the de-facto key of each sensor row, but the
+    # DDL only carries it as a FK, so without an explicit index the latest-sample
+    # and time-range queries seq-scan multi-million-row tables.
+    sql_lines.append("-- Generated Indexes")
+    sql_lines.append('CREATE INDEX IF NOT EXISTS idx_packet_time ON public.packet ("time" DESC);')
+    for table_name in sensor_tables:
+        sql_lines.append(
+            f"CREATE INDEX IF NOT EXISTS idx_{table_name}_packet_id "
+            f"ON public.{table_name} (packet_id);"
+        )
+    sql_lines.append("")
+
     return "\n".join(sql_lines), sensor_tables
 
 def generate_sqlalchemy_from_proto(messages, root_msg_name, prefix=""):

--- a/telemtry/stack/ingest/orion_db_init.sql
+++ b/telemtry/stack/ingest/orion_db_init.sql
@@ -480,3 +480,13 @@ CREATE TABLE public.board_status (
     vcu_last_seen_s      real,
     CONSTRAINT fk_board_status_packet_id FOREIGN KEY(packet_id) REFERENCES packet(packet_id)
 );
+
+-- Generated Indexes
+CREATE INDEX IF NOT EXISTS idx_packet_time ON public.packet ("time" DESC);
+CREATE INDEX IF NOT EXISTS idx_dynamics_packet_id ON public.dynamics (packet_id);
+CREATE INDEX IF NOT EXISTS idx_controls_packet_id ON public.controls (packet_id);
+CREATE INDEX IF NOT EXISTS idx_pack_packet_id ON public.pack (packet_id);
+CREATE INDEX IF NOT EXISTS idx_diagnostics_high_packet_id ON public.diagnostics_high (packet_id);
+CREATE INDEX IF NOT EXISTS idx_diagnostics_low_packet_id ON public.diagnostics_low (packet_id);
+CREATE INDEX IF NOT EXISTS idx_thermal_packet_id ON public.thermal (packet_id);
+CREATE INDEX IF NOT EXISTS idx_board_status_packet_id ON public.board_status (packet_id);

--- a/telemtry/stack/logsync/README.md
+++ b/telemtry/stack/logsync/README.md
@@ -54,20 +54,21 @@ possible future enhancement.
 
 2. **Confirm `rsync` is on the Pi** (it is on the current image: rsync 3.4.1).
 
-3. **Bring it up** (db from the ingest stack must already be running so
-   `localhost:5432` resolves):
+3. **Bring it up via the dev tool** (db from the ingest stack must already be
+   running so `localhost:5432` resolves). logsync is a registered component, so:
    ```bash
-   cd telemtry/stack/logsync
-   docker compose up -d --build
+   cd telemtry/stack
+   ./server_devtool.sh enable logsync      # or `apps` for viewer + logsync
    curl localhost:8090/health
+   ./server_devtool.sh status              # logsync shows in the health table
    ```
+   The dev tool points staging at the SSD automatically (`LOGSYNC_DATA_DIR`,
+   defaulting to `/mnt/server_ssd/logsync` when present).
 
-4. **Point the viewer at it.** Set in the viewer's environment:
-   ```
-   LOGSYNC_URL=http://localhost:8090
-   ```
-   (or the server's address if the viewer runs elsewhere). The viewer exposes
-   the UI at `/log-sync` and a tile on the splash page.
+4. **Point the viewer at it.** The viewer reads `LOGSYNC_URL` (default
+   `http://localhost:8090`, set in its `ecosystem.config.js`). The viewer
+   exposes the UI at `/log-sync` and a tile on the splash page. Rebuild/restart
+   it with `./server_devtool.sh build viewer`.
 
 ### Tuning (env)
 See `.env.example`. Key knobs: `LOGSYNC_SPEED_THRESHOLD_MPS`,
@@ -75,9 +76,11 @@ See `.env.example`. Key knobs: `LOGSYNC_SPEED_THRESHOLD_MPS`,
 `BEVO_SSH_TARGET`, `BEVO_LOG_DIR`.
 
 ### Storage
-The staging volume (`logsync_staging`) holds the copied CSVs — the current log
-set is ~40 GB, individual files up to ~4 GB. Back it with roomy disk. The
-worker refuses a job that wouldn't fit in free space.
+Staging + state are bind-mounted from `${LOGSYNC_DATA_DIR}/{staging,state}`
+(default `./data` locally; the dev tool sets it to the SSD on the deploy box).
+The copied CSVs are large — the current log set is ~40 GB, individual files up
+to ~4 GB — so keep it on roomy storage, not the root disk. The worker refuses a
+job that wouldn't fit in free space.
 
 ## Networking note (host mode)
 

--- a/telemtry/stack/logsync/docker-compose.yml
+++ b/telemtry/stack/logsync/docker-compose.yml
@@ -42,12 +42,7 @@ services:
     volumes:
       # Private key authorized as lhre@ on the Pi. Provision per README.
       - ./keys:/keys:ro
-      # Staged CSVs — can be tens of GB; back it with roomy storage.
-      - logsync_staging:/data/staging
-      - logsync_state:/data/state
-
-volumes:
-  logsync_staging:
-    driver: local
-  logsync_state:
-    driver: local
+      # Staged CSVs can be tens of GB — point LOGSYNC_DATA_DIR at roomy storage.
+      # On the deploy box, server_devtool.sh sets it to the SSD automatically.
+      - ${LOGSYNC_DATA_DIR:-./data}/staging:/data/staging
+      - ${LOGSYNC_DATA_DIR:-./data}/state:/data/state

--- a/telemtry/stack/server_devtool.sh
+++ b/telemtry/stack/server_devtool.sh
@@ -155,13 +155,16 @@ ensure_node() {
 }
 # logsync data dir: default to the SSD on the deploy box, else compose's ./data
 ensure_logsync_dirs() {
-    if [[ -z "${LOGSYNC_DATA_DIR:-}" && -d /mnt/server_ssd ]]; then
-        LOGSYNC_DATA_DIR=/mnt/server_ssd/logsync
+    if [[ -z "${LOGSYNC_DATA_DIR:-}" ]]; then
+        if [[ -d /mnt/server_ssd ]]; then
+            LOGSYNC_DATA_DIR=/mnt/server_ssd/logsync     # deploy box: stage on the SSD
+        else
+            LOGSYNC_DATA_DIR="$SCRIPT_DIR/logsync/data"   # local dev: user-owned, matches compose ./data
+        fi
     fi
-    if [[ -n "${LOGSYNC_DATA_DIR:-}" ]]; then
-        export LOGSYNC_DATA_DIR
-        mkdir -p "$LOGSYNC_DATA_DIR/staging" "$LOGSYNC_DATA_DIR/state" 2>/dev/null || true
-    fi
+    # Pre-create as the current user so docker doesn't make them root-owned.
+    export LOGSYNC_DATA_DIR
+    mkdir -p "$LOGSYNC_DATA_DIR/staging" "$LOGSYNC_DATA_DIR/state" 2>/dev/null || true
 }
 # compose's default project name is the lowercased dir basename with [^a-z0-9_-] stripped
 comp_project() {
@@ -269,6 +272,10 @@ up_pm2_component() {  # up_pm2_component <name> <dir> <build>
     app="$(comp_pm2name "$name")"; app="${app:-$name}"
     ensure_node || return 1
     if [[ "$build" == "1" ]]; then
+        if [[ ! -d "$dir/node_modules" ]]; then
+            info "Installing $name dependencies (npm ci) ..."
+            ( cd "$dir" && { npm ci || npm install; } ) || { err "$name dependency install failed"; return 1; }
+        fi
         info "Building $name (npm run build) ..."
         ( cd "$dir" && npm run build ) || { err "$name build failed"; return 1; }
     fi
@@ -301,7 +308,8 @@ down_component() {
     info "Stopping $name ..."
     if [[ "$(comp_type "$name")" == "pm2" ]]; then
         local app; app="$(comp_pm2name "$name")"; app="${app:-$name}"
-        ensure_node && pm2 stop "$app" >/dev/null 2>&1 || true
+        # delete (not stop) so it leaves pm2's list entirely, mirroring `compose down`
+        ensure_node && pm2 delete "$app" >/dev/null 2>&1 || true
         return 0
     fi
     compose_in "$dir" down
@@ -391,6 +399,7 @@ print(next((p.get('pm2_env',{}).get('status','?') for p in d if p.get('name')=='
             case "$pstate" in
                 online)          pcolor="$C_GRN" ;;
                 stopped|errored) pcolor="$C_RED"; degraded=1 ;;
+                "not started")   pcolor="$C_DIM" ;;   # absent, like docker "not created"
                 *)               pcolor="$C_YLW" ;;
             esac
             printf '%-16s %-26s %s%-12s%s\n' "$name" "$app (pm2)" "$pcolor" "$pstate" "$C_RESET"

--- a/telemtry/stack/server_devtool.sh
+++ b/telemtry/stack/server_devtool.sh
@@ -31,6 +31,7 @@
 #   restart [comp...]  restart component(s) (default: core)
 #   stop               stop EVERYTHING (compose down; keeps volumes/data)
 #   enable <comp...>   build + start optional processor(s)
+#   apps               build + start the apps tier (viewer + logsync)
 #   prune              safe prune: build cache + dangling images (keeps volumes)
 #   prune-deep         remove ALL unused images too (still keeps volumes)
 #   reset-db           recreate telemetry_db volume  (DESTROYS telemetry data)
@@ -39,6 +40,7 @@
 #
 # Core      : kafka ingest field_enricher
 # Optional  : gps_classifier lap_timer track_mapper kafka_test gg_plot
+# Apps      : viewer (pm2)  logsync (docker)
 
 set -uo pipefail
 
@@ -54,7 +56,9 @@ EXTERNAL_VOLUMES="telemetry_db grafana_storage"
 # telemetry_db is bind-mounted onto the SSD so Postgres data lives on /mnt, not the root disk.
 TELEMETRY_DB_DIR="${TELEMETRY_DB_DIR:-/mnt/server_ssd/app_data/telemetry_db}"
 
-# component registry:  name | directory (relative to SCRIPT_DIR)
+# component registry:  name | directory (relative to SCRIPT_DIR) | type | pm2-app
+# type defaults to "docker" (compose-managed). "pm2" components are Node apps
+# managed via pm2 (4th field = pm2 process name).
 # (gg_plot is optional; kafka_base is a base image and grafana-kafka-datasource
 #  is a plugin build helper — neither is a runtime service, so both are omitted.)
 STACK_COMPONENTS="
@@ -66,11 +70,18 @@ lap_timer|processors/lap_timer
 track_mapper|processors/track_mapper
 kafka_test|processors/kafka_test
 gg_plot|processors/gg_plot
+logsync|logsync|docker
+viewer|../analysis/database/viewer_tool|pm2|viewer_tool
 "
 
 # kafka broker first, then ingest (mosquitto/db/grafana), then the derived-field enricher
 CORE_ORDER="kafka ingest field_enricher"
-ALL_ORDER="kafka ingest field_enricher gps_classifier lap_timer track_mapper kafka_test gg_plot"
+# user-facing apps (pulled logs worker + the Next.js viewer)
+APP_ORDER="logsync viewer"
+ALL_ORDER="kafka ingest field_enricher gps_classifier lap_timer track_mapper kafka_test gg_plot logsync viewer"
+
+# logsync stages multi-GB CSVs; keep them off the small root disk.
+LOGSYNC_DATA_DIR="${LOGSYNC_DATA_DIR:-}"
 
 # ----------------------------------------------------------------------------- colors
 if [[ -t 1 ]]; then
@@ -120,15 +131,37 @@ compose_in() {  # compose_in <dir> <args...>
 }
 
 # registry lookups -----------------------------------------------------------
-comp_reldir() {  # absolute dir for a component name
-    local name="$1" line
+comp_field() {  # comp_field <name> <fieldnum>  -> Nth '|'-separated field
+    local name="$1" num="$2" line
     while IFS= read -r line; do
         [[ -z "$line" ]] && continue
-        if [[ "${line%%|*}" == "$name" ]]; then
-            printf '%s/%s' "$SCRIPT_DIR" "${line#*|}"; return 0
-        fi
+        [[ "${line%%|*}" == "$name" ]] || continue
+        printf '%s' "$line" | cut -d'|' -f"$num"; return 0
     done <<< "$STACK_COMPONENTS"
     return 1
+}
+comp_reldir()  { local d; d="$(comp_field "$1" 2)" || return 1; printf '%s/%s' "$SCRIPT_DIR" "$d"; }
+comp_type()    { local t; t="$(comp_field "$1" 3)" || return 1; printf '%s' "${t:-docker}"; }
+comp_pm2name() { comp_field "$1" 4; }
+
+# ensure node/pm2 are reachable (pm2 components); source nvm if needed
+ensure_node() {
+    command -v pm2 >/dev/null 2>&1 && command -v npm >/dev/null 2>&1 && return 0
+    export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+    [[ -s "$NVM_DIR/nvm.sh" ]] && . "$NVM_DIR/nvm.sh" >/dev/null 2>&1
+    command -v pm2 >/dev/null 2>&1 && command -v npm >/dev/null 2>&1 && return 0
+    err "node/npm/pm2 not found on PATH (needed for pm2-managed components like the viewer)."
+    return 1
+}
+# logsync data dir: default to the SSD on the deploy box, else compose's ./data
+ensure_logsync_dirs() {
+    if [[ -z "${LOGSYNC_DATA_DIR:-}" && -d /mnt/server_ssd ]]; then
+        LOGSYNC_DATA_DIR=/mnt/server_ssd/logsync
+    fi
+    if [[ -n "${LOGSYNC_DATA_DIR:-}" ]]; then
+        export LOGSYNC_DATA_DIR
+        mkdir -p "$LOGSYNC_DATA_DIR/staging" "$LOGSYNC_DATA_DIR/state" 2>/dev/null || true
+    fi
 }
 # compose's default project name is the lowercased dir basename with [^a-z0-9_-] stripped
 comp_project() {
@@ -231,13 +264,29 @@ free_db_port() {
 }
 
 # ----------------------------------------------------------------------------- lifecycle
+up_pm2_component() {  # up_pm2_component <name> <dir> <build>
+    local name="$1" dir="$2" build="$3" app
+    app="$(comp_pm2name "$name")"; app="${app:-$name}"
+    ensure_node || return 1
+    if [[ "$build" == "1" ]]; then
+        info "Building $name (npm run build) ..."
+        ( cd "$dir" && npm run build ) || { err "$name build failed"; return 1; }
+    fi
+    info "Starting/reloading $name (pm2: $app) ..."
+    ( cd "$dir" && pm2 startOrReload ecosystem.config.js --update-env ) || return 1
+    pm2 save >/dev/null 2>&1 || true
+}
 up_component() {  # up_component <name> <build:1|0>
     local name="$1" build="${2:-0}" dir
     dir="$(comp_reldir "$name")" || { err "unknown component: $name"; return 1; }
+    if [[ "$(comp_type "$name")" == "pm2" ]]; then
+        up_pm2_component "$name" "$dir" "$build"; return $?
+    fi
     ensure_network
     if [[ "$name" == "ingest" ]]; then
         ensure_volumes; ensure_dashboards; free_db_port
     fi
+    [[ "$name" == "logsync" ]] && ensure_logsync_dirs
     if [[ "$build" == "1" ]]; then
         preflight_disk
         info "Building + starting $name ..."
@@ -250,6 +299,11 @@ up_component() {  # up_component <name> <build:1|0>
 down_component() {
     local name="$1" dir; dir="$(comp_reldir "$name")" || return 1
     info "Stopping $name ..."
+    if [[ "$(comp_type "$name")" == "pm2" ]]; then
+        local app; app="$(comp_pm2name "$name")"; app="${app:-$name}"
+        ensure_node && pm2 stop "$app" >/dev/null 2>&1 || true
+        return 0
+    fi
     compose_in "$dir" down
 }
 up_set() {  # up_set <build:1|0> <name...>
@@ -261,7 +315,11 @@ stop_all() {
     for n in $ALL_ORDER; do rev="$n $rev"; done   # reverse order
     for n in $rev; do
         local dir; dir="$(comp_reldir "$n")"
-        [[ -f "$dir/docker-compose.yml" || -f "$dir/docker-compose.yaml" ]] && down_component "$n"
+        if [[ "$(comp_type "$n")" == "pm2" ]]; then
+            down_component "$n"
+        elif [[ -f "$dir/docker-compose.yml" || -f "$dir/docker-compose.yaml" ]]; then
+            down_component "$n"
+        fi
     done
     ok "All telemetry stack services stopped (volumes/data kept)."
 }
@@ -270,26 +328,43 @@ restart_set() {
     for n in "$@"; do
         local dir; dir="$(comp_reldir "$n")" || continue
         info "Restarting $n ..."
-        compose_in "$dir" restart 2>/dev/null || up_component "$n" 0
+        if [[ "$(comp_type "$n")" == "pm2" ]]; then
+            local app; app="$(comp_pm2name "$n")"; app="${app:-$n}"
+            ensure_node && pm2 reload "$app" --update-env || up_component "$n" 0
+        else
+            compose_in "$dir" restart 2>/dev/null || up_component "$n" 0
+        fi
     done
 }
 
+_logs_one() {  # _logs_one <name> <tail> <prefix>   (prefix empty = no fan-out)
+    local name="$1" tail="$2" prefix="$3" dir app
+    if [[ "$(comp_type "$name")" == "pm2" ]]; then
+        ensure_node || return 1
+        app="$(comp_pm2name "$name")"; app="${app:-$name}"
+        if [[ -n "$prefix" ]]; then pm2 logs "$app" --lines "$tail" 2>&1 | sed "s/^/$prefix/"
+        else pm2 logs "$app" --lines "$tail"; fi
+    else
+        dir="$(comp_reldir "$name")" || return 1
+        if [[ -n "$prefix" ]]; then compose_in "$dir" logs -f --tail "$tail" 2>&1 | sed "s/^/$prefix/"
+        else compose_in "$dir" logs -f --tail "$tail"; fi
+    fi
+}
 logs_for() {  # logs_for <name...>  (default core); Ctrl-C detaches
     local names=("$@")
     [[ ${#names[@]} -eq 0 ]] && names=($CORE_ORDER)
     warn "Following logs — press Ctrl-C to DETACH (containers keep running)."; echo
     if [[ ${#names[@]} -eq 1 ]]; then
-        compose_in "$(comp_reldir "${names[0]}")" logs -f --tail 100
+        _logs_one "${names[0]}" 100 ""
         return
     fi
-    # multiple compose projects → fan out, prefix each. On Ctrl-C kill ONLY our
+    # multiple sources → fan out, prefix each. On Ctrl-C kill ONLY our
     # own child tails (never `kill 0`, which could signal the parent shell).
-    local pids=() n dir
+    local pids=() n
     # shellcheck disable=SC2064
     trap 'kill "${pids[@]}" 2>/dev/null; trap - INT TERM' INT TERM
     for n in "${names[@]}"; do
-        dir="$(comp_reldir "$n")" || continue
-        compose_in "$dir" logs -f --tail 50 2>&1 | sed "s/^/${C_DIM}[$n]${C_RESET} /" &
+        _logs_one "$n" 50 "${C_DIM}[$n]${C_RESET} " &
         pids+=($!)
     done
     wait
@@ -303,6 +378,24 @@ status() {
     printf '%s%-16s %-26s %-12s %s%s\n' "$C_BOLD" "COMPONENT" "CONTAINER" "STATE" "STATUS" "$C_RESET"
     local degraded=0 name proj rows cname state st color rc
     for name in $ALL_ORDER; do
+        if [[ "$(comp_type "$name")" == "pm2" ]]; then
+            local app pstate pcolor
+            app="$(comp_pm2name "$name")"; app="${app:-$name}"
+            if ensure_node 2>/dev/null; then
+                pstate="$(pm2 jlist 2>/dev/null | python3 -c "import sys,json
+try: d=json.load(sys.stdin)
+except Exception: d=[]
+print(next((p.get('pm2_env',{}).get('status','?') for p in d if p.get('name')=='$app'),'not started'))" 2>/dev/null)"
+            else pstate="node/pm2 n/a"; fi
+            [[ -z "$pstate" ]] && pstate="unknown"
+            case "$pstate" in
+                online)          pcolor="$C_GRN" ;;
+                stopped|errored) pcolor="$C_RED"; degraded=1 ;;
+                *)               pcolor="$C_YLW" ;;
+            esac
+            printf '%-16s %-26s %s%-12s%s\n' "$name" "$app (pm2)" "$pcolor" "$pstate" "$C_RESET"
+            continue
+        fi
         proj="$(comp_project "$name")"
         rows="$(dk ps -a --filter "label=com.docker.compose.project=$proj" \
                   --format '{{.Names}}|{{.State}}|{{.Status}}' 2>/dev/null)"
@@ -394,6 +487,7 @@ run_command() {
         restart)     require_docker; if [[ $# -gt 0 ]]; then restart_set "$@"; else restart_set $CORE_ORDER; fi ;;
         stop|down)   require_docker; stop_all ;;
         enable)      require_docker; [[ $# -gt 0 ]] || { err "usage: $0 enable <component...>"; return 1; }; up_set 1 "$@" ;;
+        apps)        require_docker; up_set 1 $APP_ORDER; echo; ok "Apps (viewer + logsync) built + started." ;;
         prune)       require_docker; prune_safe ;;
         prune-deep)  require_docker; prune_deep ;;
         reset-db)    cmd_reset_db ;;
@@ -420,6 +514,8 @@ menu() {
         echo  "   7) Enable gps_classifier        8) Enable lap_timer"
         echo  "   9) Enable track_mapper          0) Enable kafka_test"
         echo  "   m) Enable gg_plot"
+        printf '  %sApps%s\n' "$C_BOLD" "$C_RESET"
+        echo  "   v) Rebuild + restart viewer     x) Rebuild + (re)start logsync"
         printf '  %sDisk%s\n' "$C_BOLD" "$C_RESET"
         echo  "   p) Prune (safe: cache + dangling)   P) Prune DEEP (all unused images)"
         printf '  %sDanger zone%s\n' "$C_BOLD" "$C_RESET"
@@ -440,6 +536,8 @@ menu() {
             9) up_set 1 track_mapper ;;
             0) up_set 1 kafka_test ;;
             m|M) up_set 1 gg_plot ;;
+            v|V) up_set 1 viewer ;;
+            x|X) up_set 1 logsync ;;
             p) prune_safe ;;
             P) prune_deep ;;
             d) cmd_reset_db ;;


### PR DESCRIPTION
Two operational fixes found while deploying logsync (#275). Orion-only, per scope.

## Orion DB indexes — via the SDD generator (not a hand-edit)
The per-signal time-series tables reference `packet` by `packet_id` with **no index**, so latest-sample / time-range queries degrade to full seq scans of ~14.5 M-row tables:
- logsync's motion check was a **10.3 s** query that always blew its 5 s timeout → the pause-on-motion safety gate silently failed open.
- the viewer's chart queries pay the same cost.
- `packet_id` is the de-facto key of each sensor row, but the generated DDL only carries it as a FK.

Fix is in the **Schema-Driven generator** (`scripts/generate_schema.py`), so it regenerates correctly and isn't clobbered on the next `sync_schema.sh`:
- the proto→sql path now emits `packet(time DESC)` + a `packet_id` index per sensor table.
- `orion_db_init.sql` here is the **regenerated output** (`bash scripts/sync_schema.sh Orion`) — the only diff is the index block; models/prisma/proto regenerate byte-identical.

> Already applied to the **live Orion DB** with `CREATE INDEX CONCURRENTLY` (non-locking): motion query **10,311 ms → 0.19 ms**. `sync_schema.sh` regenerates init SQL only — it doesn't touch a running DB — so the canonical change here matters for a fresh / `reset-db` Orion. `IF NOT EXISTS`, safe to re-run.

## Devtool integration (`server_devtool.sh`)
Manage the **viewer** (pm2) and **logsync** (docker) through the same tool as the rest of the stack:
- Components carry a **type** (`docker` | `pm2`); registry gains `logsync` + `viewer`.
- pm2 path: `build viewer` = `npm run build` + `pm2 startOrReload` its ecosystem file; `status`/`logs`/`restart`/`stop` all handle pm2.
- New **`apps`** command + menu entries.
- logsync stages onto the SSD via `LOGSYNC_DATA_DIR` (the tool sets it), removing the deploy-local override file.

Supporting:
- **`viewer/ecosystem.config.js`** — pm2 run config in the repo (idempotent reload; sets `LOGSYNC_URL`).
- **`logsync/docker-compose.yml`** — staging/state are `${LOGSYNC_DATA_DIR}` bind mounts.

## BEVO Pi
**No Pi changes needed.** The proto (`can_packets.proto`) is unchanged — indexes are DB-only and don't affect the wire format — so loggerd/publishd/cand are untouched.

## Test
- `bash -n` clean; registry parsing verified (`viewer`→pm2/`viewer_tool`, `logsync`→docker).
- Generator: baseline `sync_schema.sh Orion` reproduces `origin/main` byte-for-byte; with the change, the only diff is the index block.
- Live indexes applied + re-timed (10 s → 0.19 ms).