### PR TITLE
logsync: survive the car going offline mid-transfer (auto-resume)

### DIFF
--- a/telemtry/stack/logsync/app/config.py
+++ b/telemtry/stack/logsync/app/config.py
@@ -63,6 +63,9 @@ class Config:
     default_bwlimit_kbps: int = _int("LOGSYNC_DEFAULT_BWLIMIT_KBPS", 0)
     rsync_max_retries: int = _int("LOGSYNC_RSYNC_MAX_RETRIES", 5)
     rsync_retry_backoff_s: float = _float("LOGSYNC_RSYNC_RETRY_BACKOFF_S", 5.0)
+    # Cap on the (linear) backoff between retries. Transient "car unreachable"
+    # failures retry forever, so this bounds how often they poll for the Pi.
+    rsync_max_backoff_s: float = _float("LOGSYNC_RSYNC_MAX_BACKOFF_S", 60.0)
 
     # --- Motion detection (Postgres orion DB) ---
     pg_dsn: str = _str("LOGSYNC_PG_DSN", "")  # if set, overrides the parts below

--- a/telemtry/stack/logsync/app/manager.py
+++ b/telemtry/stack/logsync/app/manager.py
@@ -232,7 +232,9 @@ class JobManager:
             self._set_state(job, JobState.COMPLETED)
             return
 
-        last_progress_bytes = -1
+        # Measure progress from where we actually are (a resumed job already has
+        # its partial on disk), so the first error isn't miscounted as progress.
+        last_progress_bytes = job.transferred_bytes
         stalled_rounds = 0
         consecutive_fail = 0   # consecutive no-progress rsync errors (reset on progress)
 
@@ -322,7 +324,7 @@ class JobManager:
                 self._set_state(job, JobState.RUNNING)
                 backoff = min(config.rsync_max_backoff_s,
                               config.rsync_retry_backoff_s * max(1, consecutive_fail))
-                await asyncio.sleep(backoff)
+                await self._interruptible_sleep(backoff, ctrl)
                 continue
 
             # Non-transient error. If we still made progress, just retry; only
@@ -334,7 +336,15 @@ class JobManager:
                     self._set_state(job, JobState.FAILED)
                     return
             self._persist(job)
-            await asyncio.sleep(config.rsync_retry_backoff_s)
+            await self._interruptible_sleep(config.rsync_retry_backoff_s, ctrl)
+
+    async def _interruptible_sleep(self, seconds: float, ctrl: _Control) -> None:
+        """Sleep up to `seconds`, but wake early on cancel/pause so the worker
+        (single-threaded, one job at a time) stays responsive during long
+        'waiting to reconnect' backoffs."""
+        end = time.monotonic() + seconds
+        while time.monotonic() < end and not ctrl.cancel.is_set() and not ctrl.paused:
+            await asyncio.sleep(min(0.5, max(0.0, end - time.monotonic())))
 
     async def _supervise(self, job: Job, ctrl: _Control, run: RsyncRun) -> int | None:
         """Wait for rsync, preempting on cancel / manual pause / motion.

--- a/telemtry/stack/logsync/app/manager.py
+++ b/telemtry/stack/logsync/app/manager.py
@@ -27,7 +27,7 @@ from dataclasses import dataclass, field
 from .config import config
 from .models import FileProgress, Job, JobState, RemoteFile
 from .motion import MotionMonitor
-from .rsync import RSYNC_OK_CODES, Progress, RsyncRun, build_cmd
+from .rsync import RSYNC_OK_CODES, RSYNC_TRANSIENT_CODES, Progress, RsyncRun, build_cmd
 from .store import Store
 
 
@@ -123,12 +123,16 @@ class JobManager:
         ctrl = self._controls.get(job_id)
         if not job or not ctrl:
             return False
-        if job.state not in (JobState.PAUSED, JobState.PAUSED_MOTION, JobState.QUEUED):
+        # FAILED is resumable too: the partial is still on disk under the same
+        # job id, so re-running continues from it (rsync --append-verify).
+        if job.state not in (JobState.PAUSED, JobState.PAUSED_MOTION,
+                             JobState.QUEUED, JobState.FAILED):
             return False
         ctrl.paused = False
         ctrl.resume.set()
-        # If it had yielded the worker (manual pause), put it back in line.
-        if job.state == JobState.PAUSED:
+        # If it had yielded the worker (manual pause / failure), put it back in line.
+        if job.state in (JobState.PAUSED, JobState.FAILED):
+            job.error = None
             self._set_state(job, JobState.QUEUED)
             self._queue.put_nowait(job.id)
         return True
@@ -230,6 +234,7 @@ class JobManager:
 
         last_progress_bytes = -1
         stalled_rounds = 0
+        consecutive_fail = 0   # consecutive no-progress rsync errors (reset on progress)
 
         while True:
             if ctrl.cancel.is_set():
@@ -267,6 +272,7 @@ class JobManager:
 
             # --- transfer ---
             job.attempts += 1
+            job.error = None   # clear any stale "waiting to reconnect" note
             self._set_state(job, JobState.RUNNING)
 
             def on_progress(p: Progress) -> None:
@@ -299,11 +305,34 @@ class JobManager:
                 last_progress_bytes = job.transferred_bytes
                 continue
 
-            # rsync error — retry with backoff, then give up.
-            if job.attempts >= config.rsync_max_retries:
-                job.error = f"rsync failed (exit {rc}): {run.stderr_tail}"
-                self._set_state(job, JobState.FAILED)
-                return
+            # rsync exited with an error.
+            progressed = job.transferred_bytes > last_progress_bytes
+            last_progress_bytes = job.transferred_bytes
+            job.rate_bps = 0.0
+            if progressed:
+                consecutive_fail = 0
+
+            if rc in RSYNC_TRANSIENT_CODES:
+                # The car went away (cellular drop / LV power cycle). This is
+                # expected — wait and keep retrying forever; rsync --append-verify
+                # picks up the partial when the Pi comes back. Never fail here.
+                if not progressed:
+                    consecutive_fail += 1
+                job.error = f"car unreachable (rsync exit {rc}); waiting to reconnect…"
+                self._set_state(job, JobState.RUNNING)
+                backoff = min(config.rsync_max_backoff_s,
+                              config.rsync_retry_backoff_s * max(1, consecutive_fail))
+                await asyncio.sleep(backoff)
+                continue
+
+            # Non-transient error. If we still made progress, just retry; only
+            # give up after several consecutive no-progress attempts.
+            if not progressed:
+                consecutive_fail += 1
+                if consecutive_fail >= config.rsync_max_retries:
+                    job.error = f"rsync failed (exit {rc}): {run.stderr_tail}"
+                    self._set_state(job, JobState.FAILED)
+                    return
             self._persist(job)
             await asyncio.sleep(config.rsync_retry_backoff_s)
 

--- a/telemtry/stack/logsync/app/rsync.py
+++ b/telemtry/stack/logsync/app/rsync.py
@@ -150,3 +150,15 @@ class RsyncRun:
 # rsync exit codes that are safe to treat as "succeeded for our purposes".
 # 0 = ok; 24 = some source files vanished (a rotated/closed log) which is benign.
 RSYNC_OK_CODES = {0, 24}
+
+# Exit codes meaning the source / transport went away rather than a real fault:
+#   5  = error starting client-server protocol
+#   10 = error in socket I/O
+#   12 = error in rsync protocol data stream
+#   30 = timeout in data send/receive
+#   35 = timeout waiting for daemon connection
+#   255 = ssh transport failure (host unreachable / connection refused or closed)
+# This is the EXPECTED failure for a car Pi on a cellular link or being power-
+# cycled overnight. The worker waits and retries these indefinitely (auto-resuming
+# via --append-verify when the Pi returns) instead of failing the job.
+RSYNC_TRANSIENT_CODES = {5, 10, 12, 30, 35, 255}


### PR DESCRIPTION
## Problem
A car Pi on a cellular link being **power-cycled overnight** is the *expected* condition for these pulls — but the worker treated any rsync error as a fault: it retried `rsync_max_retries` (default 5) times then marked the job **FAILED**, and a FAILED job **wasn't resumable** (the resume button only accepted paused/queued). So an overnight power loss would strand the partial, and a new job re-downloads from scratch. Worse, `attempts` was counted across the job's whole life (every motion-pause/resume/migration +1), so a job that had run a while was already most of the way to the limit — observed a live 30 GB job sitting at `attempts=3/5`.

## Fix
- **Connection/transport exit codes** (`5,10,12,30,35,255`) are classified as "car unreachable": the job **waits and retries indefinitely** (capped linear backoff, default 60 s), showing a `waiting to reconnect…` note. rsync `--partial --append-verify` resumes from the partial automatically when the Pi powers back — **no manual pause/resume needed**.
- Failure now keys off **consecutive no-progress attempts** (reset on any progress), and only for genuinely non-transient errors — not the lifetime attempt count.
- `resume()` accepts a **FAILED** job and continues it from its on-disk partial (safety net).

## Test
A `JobManager` driven through repeated transient (255) failures keeps waiting, surfaces the "car unreachable" state, **never FAILs**, and completes once the source returns (4th attempt). `resume()` on a FAILED job re-queues it. Verified locally with mocked rsync/motion.

## Deploy note
Rebuild + restart logsync. An in-flight job persists (RUNNING→reconcile→resume from partial), so it can be deployed mid-transfer.