### PR TITLE
logsync: shared file store (reuse across jobs) + local-time column

### DIFF
--- a/telemtry/analysis/database/viewer_tool/src/app/log-sync/page.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/app/log-sync/page.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 
 // ---- types mirrored from the worker's Job.to_dict() ----
-type FileProgress = { name: string; size: number; transferred: number; done: boolean };
+type FileProgress = { name: string; size: number; transferred: number; done: boolean; start_ms?: number; end_ms?: number };
 type Motion = { moving: boolean; speed_mps: number | null; sample_age_ms: number | null; recent: boolean; error?: string | null };
 type Job = {
   id: string;
@@ -37,13 +37,23 @@ const fmtBytes = (b: number) => {
 };
 const fmtRate = (bps: number) => (bps > 0 ? `${fmtBytes(bps)}/s` : '—');
 const fmtTime = (ms: number) => new Date(ms).toLocaleString();
-// loggerd names files orion_<sessionStartMs>.csv — render that start time in the
-// viewer's local timezone. Returns '' if the name doesn't carry a timestamp.
-const fileLocalTime = (name: string): string => {
+// Session start parsed from the loggerd filename (orion_<startMs>.csv) as a
+// fallback for jobs created before start_ms/end_ms were stored.
+const startMsFromName = (name: string): number => {
   const m = name.match(/_(\d{10,})\./);
-  if (!m) return '';
-  const ms = Number(m[1]);
-  return Number.isFinite(ms) ? new Date(ms).toLocaleString() : '';
+  const ms = m ? Number(m[1]) : NaN;
+  return Number.isFinite(ms) ? ms : 0;
+};
+// "start → end" in the viewer's local timezone. End (file mtime) shows as time
+// only when it's the same day as start; omitted entirely if unknown (0).
+const fileTimeRange = (f: FileProgress): string => {
+  const start = f.start_ms && f.start_ms > 0 ? f.start_ms : startMsFromName(f.name);
+  if (!start) return '';
+  const startStr = new Date(start).toLocaleString();
+  const end = f.end_ms && f.end_ms > start ? f.end_ms : 0;
+  if (!end) return startStr;
+  const sameDay = new Date(start).toDateString() === new Date(end).toDateString();
+  return `${startStr} → ${sameDay ? new Date(end).toLocaleTimeString() : new Date(end).toLocaleString()}`;
 };
 const toLocalInput = (d: Date) => {
   const p = (n: number) => String(n).padStart(2, '0');
@@ -321,7 +331,7 @@ function JobCard({
             <div key={f.name} className="flex items-center justify-between text-xs">
               <span className="font-mono truncate mr-3">{f.name}</span>
               <span className="flex items-center gap-3 shrink-0 text-muted-foreground">
-                <span className="hidden sm:inline tabular-nums">{fileLocalTime(f.name)}</span>
+                <span className="hidden sm:inline tabular-nums">{fileTimeRange(f)}</span>
                 <span>{fmtBytes(f.transferred)} / {fmtBytes(f.size)}</span>
                 {f.done ? (
                   <a className="underline hover:text-foreground"

--- a/telemtry/analysis/database/viewer_tool/src/app/log-sync/page.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/app/log-sync/page.tsx
@@ -40,7 +40,7 @@ const fmtTime = (ms: number) => new Date(ms).toLocaleString();
 // Session start parsed from the loggerd filename (orion_<startMs>.csv) as a
 // fallback for jobs created before start_ms/end_ms were stored.
 const startMsFromName = (name: string): number => {
-  const m = name.match(/_(\d{10,})\./);
+  const m = name.match(/_(\d{10,13})\./);   // a millisecond epoch (through ~year 2286)
   const ms = m ? Number(m[1]) : NaN;
   return Number.isFinite(ms) ? ms : 0;
 };

--- a/telemtry/analysis/database/viewer_tool/src/app/log-sync/page.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/app/log-sync/page.tsx
@@ -37,6 +37,14 @@ const fmtBytes = (b: number) => {
 };
 const fmtRate = (bps: number) => (bps > 0 ? `${fmtBytes(bps)}/s` : '—');
 const fmtTime = (ms: number) => new Date(ms).toLocaleString();
+// loggerd names files orion_<sessionStartMs>.csv — render that start time in the
+// viewer's local timezone. Returns '' if the name doesn't carry a timestamp.
+const fileLocalTime = (name: string): string => {
+  const m = name.match(/_(\d{10,})\./);
+  if (!m) return '';
+  const ms = Number(m[1]);
+  return Number.isFinite(ms) ? new Date(ms).toLocaleString() : '';
+};
 const toLocalInput = (d: Date) => {
   const p = (n: number) => String(n).padStart(2, '0');
   return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}T${p(d.getHours())}:${p(d.getMinutes())}`;
@@ -313,6 +321,7 @@ function JobCard({
             <div key={f.name} className="flex items-center justify-between text-xs">
               <span className="font-mono truncate mr-3">{f.name}</span>
               <span className="flex items-center gap-3 shrink-0 text-muted-foreground">
+                <span className="hidden sm:inline tabular-nums">{fileLocalTime(f.name)}</span>
                 <span>{fmtBytes(f.transferred)} / {fmtBytes(f.size)}</span>
                 {f.done ? (
                   <a className="underline hover:text-foreground"

--- a/telemtry/stack/logsync/README.md
+++ b/telemtry/stack/logsync/README.md
@@ -19,6 +19,10 @@ hogging the cellular uplink during a run.
   there is no live stream to protect, so it transfers freely.
 - **Survives restarts.** Job state is persisted to SQLite; interrupted jobs are
   re-queued and resumed on boot.
+- **Shared file store.** Files are kept once, keyed by their unique loggerd
+  name, in a store shared across jobs — so a new job that overlaps an earlier
+  one reuses what's already on disk instead of re-pulling it (rsync skips
+  complete files and only appends the new tail of a still-growing one).
 - **One transfer at a time** to keep bandwidth predictable.
 
 ### Known limitation

--- a/telemtry/stack/logsync/app/main.py
+++ b/telemtry/stack/logsync/app/main.py
@@ -130,10 +130,11 @@ async def cancel_job(job_id: str):
 
 
 def _safe_file(job, name: str) -> str:
-    """Resolve a requested filename to a path inside the job's staging dir."""
+    """Resolve a requested filename to a path in the shared store, after
+    confirming the name belongs to this job."""
     if name not in {f.name for f in job.files}:
         raise HTTPException(404, "file not part of this job")
-    dest = _mgr().staging_path(job.id)
+    dest = _mgr().store_dir
     path = os.path.realpath(os.path.join(dest, name))
     if not path.startswith(os.path.realpath(dest) + os.sep):
         raise HTTPException(400, "invalid filename")
@@ -156,7 +157,7 @@ async def download_archive(job_id: str):
     done = [f for f in job.files if f.done]
     if not done:
         raise HTTPException(409, "no completed files to archive yet")
-    dest = _mgr().staging_path(job.id)
+    mgr = _mgr()
 
     try:
         from zipstream import ZipStream  # zipstream-ng
@@ -165,7 +166,7 @@ async def download_archive(job_id: str):
 
     zs = ZipStream(sized=False)
     for f in done:
-        zs.add_path(os.path.join(dest, f.name), f.name)
+        zs.add_path(mgr.file_path(f.name), f.name)
 
     return StreamingResponse(
         zs,

--- a/telemtry/stack/logsync/app/manager.py
+++ b/telemtry/stack/logsync/app/manager.py
@@ -53,10 +53,19 @@ class JobManager:
         self._subscribers: set[asyncio.Queue] = set()
         self._worker_task: asyncio.Task | None = None
         self._seq = 0
+        # Files are stored once, keyed by their (globally-unique) loggerd name,
+        # and shared across jobs — so a new job that overlaps an earlier one
+        # reuses what's already on disk instead of re-pulling it. Listfiles live
+        # in a sibling meta dir. Jobs run one at a time, so there's no write race.
+        self._store_dir = os.path.join(config.staging_dir, "_store")
+        self._meta_dir = os.path.join(config.staging_dir, "_meta")
 
     # ----- lifecycle -----
 
     async def start(self) -> None:
+        os.makedirs(self._store_dir, exist_ok=True)
+        os.makedirs(self._meta_dir, exist_ok=True)
+        self._migrate_legacy_staging()
         # Reload persisted jobs and resume anything that was mid-flight.
         for job in self.store.list():
             self._jobs[job.id] = job
@@ -149,8 +158,47 @@ class JobManager:
             self._set_state(job, JobState.CANCELED)
         return True
 
-    def staging_path(self, job_id: str) -> str:
-        return os.path.join(config.staging_dir, job_id)
+    @property
+    def store_dir(self) -> str:
+        return self._store_dir
+
+    def file_path(self, name: str) -> str:
+        """Absolute path of a stored file in the shared, name-keyed store."""
+        return os.path.join(self._store_dir, name)
+
+    def _migrate_legacy_staging(self) -> None:
+        """One-time: fold pre-shared-store per-job dirs (staging/<job_id>/*.csv)
+        into the shared store so their downloads keep working after upgrade."""
+        try:
+            entries = os.listdir(config.staging_dir)
+        except OSError:
+            return
+        for entry in entries:
+            if entry in ("_store", "_meta"):
+                continue
+            old = os.path.join(config.staging_dir, entry)
+            if not os.path.isdir(old):
+                continue
+            for fn in os.listdir(old):
+                src = os.path.join(old, fn)
+                if not os.path.isfile(src):
+                    continue
+                if fn.startswith(config.log_prefix) and fn.endswith(config.log_suffix):
+                    dst = self.file_path(fn)
+                    if not os.path.exists(dst):
+                        try:
+                            os.replace(src, dst)   # atomic on the same filesystem
+                        except OSError:
+                            continue
+                else:
+                    try:
+                        os.remove(src)             # stale .files-from etc.
+                    except OSError:
+                        pass
+            try:
+                os.rmdir(old)
+            except OSError:
+                pass
 
     # ----- SSE pub/sub -----
 
@@ -199,10 +247,9 @@ class JobManager:
                 self._set_state(job, JobState.FAILED)
 
     def _update_local_progress(self, job: Job) -> None:
-        dest = self.staging_path(job.id)
         total = 0
         for f in job.files:
-            path = os.path.join(dest, f.name)
+            path = self.file_path(f.name)
             sz = os.path.getsize(path) if os.path.exists(path) else 0
             sz = min(sz, f.size)
             f.transferred = sz
@@ -215,17 +262,18 @@ class JobManager:
     def _all_done(self, job: Job) -> bool:
         return bool(job.files) and all(f.done for f in job.files)
 
-    def _write_listfile(self, job: Job, dest: str) -> str:
-        listfile = os.path.join(dest, ".files-from")
+    def _write_listfile(self, job: Job) -> str:
+        listfile = os.path.join(self._meta_dir, f"{job.id}.files-from")
         with open(listfile, "w") as fh:
             for f in job.files:
                 fh.write(f.name + "\n")
         return listfile
 
     async def _run_job(self, job: Job, ctrl: _Control) -> None:
-        dest = self.staging_path(job.id)
+        dest = self._store_dir
         os.makedirs(dest, exist_ok=True)
-        listfile = self._write_listfile(job, dest)
+        os.makedirs(self._meta_dir, exist_ok=True)
+        listfile = self._write_listfile(job)
 
         self._update_local_progress(job)
         if self._all_done(job):

--- a/telemtry/stack/logsync/app/manager.py
+++ b/telemtry/stack/logsync/app/manager.py
@@ -103,7 +103,8 @@ class JobManager:
             state=JobState.QUEUED,
             created_ms=_now_ms(),
             updated_ms=_now_ms(),
-            files=[FileProgress(name=f.name, size=f.size) for f in files],
+            files=[FileProgress(name=f.name, size=f.size,
+                                start_ms=f.start_ms, end_ms=f.end_ms) for f in files],
             total_bytes=sum(f.size for f in files),
         )
         self._jobs[job_id] = job

--- a/telemtry/stack/logsync/app/manager.py
+++ b/telemtry/stack/logsync/app/manager.py
@@ -191,6 +191,11 @@ class JobManager:
                             os.replace(src, dst)   # atomic on the same filesystem
                         except OSError:
                             continue
+                    else:
+                        try:
+                            os.remove(src)         # already in the store — drop the dup so the dir can be removed
+                        except OSError:
+                            pass
                 else:
                     try:
                         os.remove(src)             # stale .files-from etc.

--- a/telemtry/stack/logsync/app/models.py
+++ b/telemtry/stack/logsync/app/models.py
@@ -48,6 +48,8 @@ class FileProgress:
     size: int                # expected bytes (from the remote listing)
     transferred: int = 0     # bytes present locally
     done: bool = False
+    start_ms: int = 0        # session start (filename), for UI display
+    end_ms: int = 0          # last write (mtime), for UI display
 
     def to_dict(self) -> dict:
         return asdict(self)


### PR DESCRIPTION
Two requested improvements.

## 1. Reuse overlapping files across jobs
Previously each job rsynced into its own `staging/<job_id>/` dir, so two jobs covering overlapping time ranges **re-downloaded** the shared files independently.

Now files live **once** in a name-keyed shared store (`staging/_store/`), keyed by loggerd's globally-unique `orion_<startMs>.csv` names; each job just tracks which names it includes. Because jobs run **one at a time** (no write race), rsync `--append-verify` does the reuse for free:
- a file already complete in the store is **skipped**,
- a still-growing active file gets its **new tail appended** (overlap verified), not re-pulled.

Side benefit: the disk-space guard counts already-present files toward a job's progress, so an overlapping job reports a smaller "needed".

- **Migration:** on startup, any pre-existing per-job staging dirs are folded into the shared store (atomic same-fs renames), so older completed jobs keep their downloads.
- Download + archive endpoints serve from the shared store.

## 2. Local-time column in the files list
Each CSV's session start time is shown in the viewer's local timezone, parsed from the `orion_<startMs>.csv` filename — **no backend change** (the timestamp is already in the name).

## Test
- `JobManager` test: job A pulls two files; job B overlapping on one file downloads **only the non-overlapping file** (reuse confirmed); a job for a migrated file downloads nothing. Migration of a legacy per-job dir into the store verified. (mocked rsync that, like the real thing, only pulls missing files.)
- viewer `tsc` + ESLint clean.

## Deploy
Rebuild + restart logsync (the migration runs once on startup) and rebuild the viewer. No in-flight job right now, so safe to deploy anytime.