### PR TITLE
fix(viewer): escape apostrophe in trackside-live breaking next build

### DIFF
--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
@@ -4978,7 +4978,7 @@ const TOUR_STEPS: TourStep[] = [
         The <strong>Exporter</strong> tab pulls historical drive-days from the
         database to plot and export to MoTeC. <strong>Race Ops</strong> tracks
         energy budget across a stint. Pick the car and channel chart in the side
-        panels. That's the tour — have fun!
+        panels. That&apos;s the tour — have fun!
       </>
     ),
   },


### PR DESCRIPTION
`src/app/trackside-live/TracksideApp.tsx` has an unescaped apostrophe in JSX text (`That's the tour`). `react/no-unescaped-entities` is a **build-blocking error** under `next build`, so the viewer production build (`npm run build`) has been failing since #273 merged — caught while deploying the logsync viewer changes.

Fix: `That's` → `That&apos;s` (the one error in the file; the remaining 7 are warnings).

Verified: `eslint` on the file now reports **0 errors**, and `next build` compiles. Already applied as a deploy-box overlay to unblock tonight's deploy.