### PR TITLE
kafka: move KRaft logs onto the NVMe SSD + bound retention

### DIFF
--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -50,6 +50,7 @@ jobs:
           docker network create telemetry_network || true
           docker volume create grafana_storage || true
           docker volume create telemetry_db || true
+          docker volume create kafka_data || true
 
       - name: Create .env file for Docker
         run: |

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -37,6 +37,7 @@ jobs:
           docker network create telemetry_network || true
           docker volume create grafana_storage || true
           docker volume create telemetry_db || true
+          docker volume create kafka_data || true
 
       - name: Create .env file for Docker
         run: |

--- a/telemtry/stack/kafka/docker-compose.yml
+++ b/telemtry/stack/kafka/docker-compose.yml
@@ -20,6 +20,17 @@ services:
       KAFKA_CONTROLLER_QUORUM_VOTERS: "1@kafka:9093"
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE: "true"
+      # KRaft logs live on the NVMe SSD (via the bind mount below), off the small
+      # root disk where they previously filled the container layer. Retention is
+      # bounded so the realtime buffer can't grow unbounded — Postgres is the
+      # system of record; kafka here is just live + recent history.
+      KAFKA_LOG_DIRS: /var/lib/kafka/data
+      KAFKA_LOG_RETENTION_MS: ${KAFKA_LOG_RETENTION_MS:-21600000}          # 6h
+      KAFKA_LOG_RETENTION_BYTES: ${KAFKA_LOG_RETENTION_BYTES:-1073741824}  # 1 GiB/partition cap
+    volumes:
+      # Defaults to ./kafka-data locally; server_devtool.sh points it at the NVMe
+      # (/mnt/server_ssd/kafka-data) on the deploy box.
+      - ${KAFKA_DATA_DIR:-./kafka-data}:/var/lib/kafka/data
     healthcheck:
       test: ["CMD-SHELL", "/opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list || exit 1"]
       interval: 10s

--- a/telemtry/stack/kafka/docker-compose.yml
+++ b/telemtry/stack/kafka/docker-compose.yml
@@ -28,9 +28,12 @@ services:
       KAFKA_LOG_RETENTION_MS: ${KAFKA_LOG_RETENTION_MS:-21600000}          # 6h
       KAFKA_LOG_RETENTION_BYTES: ${KAFKA_LOG_RETENTION_BYTES:-1073741824}  # 1 GiB/partition cap
     volumes:
-      # Defaults to ./kafka-data locally; server_devtool.sh points it at the NVMe
-      # (/mnt/server_ssd/kafka-data) on the deploy box.
-      - ${KAFKA_DATA_DIR:-./kafka-data}:/var/lib/kafka/data
+      # A NAMED volume (not a host bind): an empty named volume inherits the
+      # image's /var/lib/kafka/data ownership (appuser, uid 1000), so kafka can
+      # write. A bind mount to a fresh host dir would be root-owned and kafka
+      # would crash-loop. server_devtool.sh backs this with the NVMe SSD on the
+      # deploy box; elsewhere docker auto-creates it (CI, local dev).
+      - kafka_data:/var/lib/kafka/data
     healthcheck:
       test: ["CMD-SHELL", "/opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list || exit 1"]
       interval: 10s
@@ -54,6 +57,13 @@ services:
       kafka:
         condition: service_healthy
     restart: unless-stopped
+
+volumes:
+  # External (like telemetry_db): created out-of-band — CI's "Create volumes"
+  # step makes it plain (inherits the image's appuser ownership); server_devtool
+  # makes it NVMe-backed on the deploy box.
+  kafka_data:
+    external: true
 
 networks:
   telemetry_network:

--- a/telemtry/stack/server_devtool.sh
+++ b/telemtry/stack/server_devtool.sh
@@ -52,7 +52,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DASHBOARD_SOURCE_DIR="$SCRIPT_DIR/../analysis/database/dashboards"
 
 NETWORK="telemetry_network"        # external in every compose file → we own it
-EXTERNAL_VOLUMES="telemetry_db grafana_storage"
+EXTERNAL_VOLUMES="telemetry_db grafana_storage kafka_data"
 # telemetry_db is bind-mounted onto the SSD so Postgres data lives on /mnt, not the root disk.
 TELEMETRY_DB_DIR="${TELEMETRY_DB_DIR:-/mnt/server_ssd/app_data/telemetry_db}"
 
@@ -168,23 +168,10 @@ ensure_logsync_dirs() {
     export LOGSYNC_DATA_DIR
     mkdir -p "$LOGSYNC_DATA_DIR/staging" "$LOGSYNC_DATA_DIR/state" 2>/dev/null || true
 }
-# kafka data dir: default to the NVMe SSD on the deploy box, else compose's ./kafka-data
+# Ensure the external kafka_data volume exists before bringing kafka up (it's
+# NVMe-backed on the deploy box — see create_external_volume).
 ensure_kafka_dirs() {
-    if [[ -z "${KAFKA_DATA_DIR:-}" ]]; then
-        if [[ -d /mnt/server_ssd ]]; then
-            KAFKA_DATA_DIR=/mnt/server_ssd/kafka-data
-        else
-            KAFKA_DATA_DIR="$SCRIPT_DIR/kafka/kafka-data"
-        fi
-    fi
-    # Created by the current user (uid 1000) — matches kafka's appuser so it's
-    # writable. Don't swallow a real failure: if the dir can't be created (e.g.
-    # a root-owned mount), say so loudly — otherwise docker makes it root-owned
-    # and kafka (uid 1000) silently crash-loops on permission-denied.
-    export KAFKA_DATA_DIR
-    if ! mkdir -p "$KAFKA_DATA_DIR" 2>/dev/null; then
-        warn "could not create kafka data dir $KAFKA_DATA_DIR — create it writable by uid 1000 (kafka's appuser), or kafka will fail to start"
-    fi
+    dk volume inspect kafka_data >/dev/null 2>&1 || create_external_volume kafka_data
 }
 # compose's default project name is the lowercased dir basename with [^a-z0-9_-] stripped
 comp_project() {
@@ -257,7 +244,17 @@ create_external_volume() {
         $SUDO mkdir -p "$TELEMETRY_DB_DIR"
         dk volume create --driver local \
             --opt type=none --opt o=bind --opt device="$TELEMETRY_DB_DIR" "$v" >/dev/null
+    elif [[ "$v" == "kafka_data" && -d /mnt/server_ssd ]]; then
+        # NVMe-backed on the deploy box (KRaft logs off the small root disk).
+        # The dir is owned by the current user (uid 1000 = kafka's appuser).
+        KAFKA_DATA_DIR="${KAFKA_DATA_DIR:-/mnt/server_ssd/kafka-data}"
+        if ! mkdir -p "$KAFKA_DATA_DIR" 2>/dev/null; then
+            warn "could not create $KAFKA_DATA_DIR — make it writable by uid 1000, or kafka will fail to start"
+        fi
+        dk volume create --driver local \
+            --opt type=none --opt o=bind --opt device="$KAFKA_DATA_DIR" "$v" >/dev/null
     else
+        # plain volume — kafka_data inherits the image's appuser ownership here
         dk volume create "$v" >/dev/null
     fi
 }

--- a/telemtry/stack/server_devtool.sh
+++ b/telemtry/stack/server_devtool.sh
@@ -177,9 +177,14 @@ ensure_kafka_dirs() {
             KAFKA_DATA_DIR="$SCRIPT_DIR/kafka/kafka-data"
         fi
     fi
-    # Created by the current user (uid 1000) — matches kafka's appuser so it's writable.
+    # Created by the current user (uid 1000) — matches kafka's appuser so it's
+    # writable. Don't swallow a real failure: if the dir can't be created (e.g.
+    # a root-owned mount), say so loudly — otherwise docker makes it root-owned
+    # and kafka (uid 1000) silently crash-loops on permission-denied.
     export KAFKA_DATA_DIR
-    mkdir -p "$KAFKA_DATA_DIR" 2>/dev/null || true
+    if ! mkdir -p "$KAFKA_DATA_DIR" 2>/dev/null; then
+        warn "could not create kafka data dir $KAFKA_DATA_DIR — create it writable by uid 1000 (kafka's appuser), or kafka will fail to start"
+    fi
 }
 # compose's default project name is the lowercased dir basename with [^a-z0-9_-] stripped
 comp_project() {

--- a/telemtry/stack/server_devtool.sh
+++ b/telemtry/stack/server_devtool.sh
@@ -82,6 +82,8 @@ ALL_ORDER="kafka ingest field_enricher gps_classifier lap_timer track_mapper kaf
 
 # logsync stages multi-GB CSVs; keep them off the small root disk.
 LOGSYNC_DATA_DIR="${LOGSYNC_DATA_DIR:-}"
+# kafka's KRaft log dir — keep it off root (it grows fast) and on the NVMe.
+KAFKA_DATA_DIR="${KAFKA_DATA_DIR:-}"
 
 # ----------------------------------------------------------------------------- colors
 if [[ -t 1 ]]; then
@@ -165,6 +167,19 @@ ensure_logsync_dirs() {
     # Pre-create as the current user so docker doesn't make them root-owned.
     export LOGSYNC_DATA_DIR
     mkdir -p "$LOGSYNC_DATA_DIR/staging" "$LOGSYNC_DATA_DIR/state" 2>/dev/null || true
+}
+# kafka data dir: default to the NVMe SSD on the deploy box, else compose's ./kafka-data
+ensure_kafka_dirs() {
+    if [[ -z "${KAFKA_DATA_DIR:-}" ]]; then
+        if [[ -d /mnt/server_ssd ]]; then
+            KAFKA_DATA_DIR=/mnt/server_ssd/kafka-data
+        else
+            KAFKA_DATA_DIR="$SCRIPT_DIR/kafka/kafka-data"
+        fi
+    fi
+    # Created by the current user (uid 1000) — matches kafka's appuser so it's writable.
+    export KAFKA_DATA_DIR
+    mkdir -p "$KAFKA_DATA_DIR" 2>/dev/null || true
 }
 # compose's default project name is the lowercased dir basename with [^a-z0-9_-] stripped
 comp_project() {
@@ -294,6 +309,7 @@ up_component() {  # up_component <name> <build:1|0>
         ensure_volumes; ensure_dashboards; free_db_port
     fi
     [[ "$name" == "logsync" ]] && ensure_logsync_dirs
+    [[ "$name" == "kafka" ]] && ensure_kafka_dirs
     if [[ "$build" == "1" ]]; then
         preflight_disk
         info "Building + starting $name ..."


### PR DESCRIPTION
## Why
Kafka's `log.dirs` defaulted to `/tmp/kraft-combined-logs` **inside the container**, so its segments piled onto the container writable layer on the **root** disk and filled it (~47 GB → root hit 100% on 06-02). Root is a SATA SSD; `/mnt/server_ssd` is a Gen5 NVMe. Postgres already lives on the NVMe, so this colocates the other heavy writer there and gets kafka off root for good.

## What
- **Bind-mount** kafka's log dir to `${KAFKA_DATA_DIR}` → `server_devtool.sh` sets it to `/mnt/server_ssd/kafka-data` on the deploy box (defaults to `./kafka-data` locally). NVMe-backed, off root.
- **Static retention** in the compose (`KAFKA_LOG_RETENTION_MS` 6h, `KAFKA_LOG_RETENTION_BYTES` 1 GiB/partition), env-overridable — survives container recreates, unlike a dynamic broker config (which lives in the ephemeral KRaft metadata). Postgres is the system of record; kafka is just the live + recent realtime buffer.
- `ensure_kafka_dirs` in the dev tool mirrors `ensure_logsync_dirs`.

## Deploy note
Recreating kafka starts on the fresh NVMe dir → KRaft re-formats (loses the current realtime buffer only; PG untouched, bridge/consumers reconnect). Same brief realtime reset as the 06-02 recovery.