### PR TITLE
logsync: file annotations, search, all-files view & column-selective download

### DIFF
--- a/telemtry/analysis/database/viewer_tool/src/app/api/logsync/[...path]/route.ts
+++ b/telemtry/analysis/database/viewer_tool/src/app/api/logsync/[...path]/route.ts
@@ -67,6 +67,9 @@ export async function GET(req: NextRequest, ctx: Ctx) {
 export async function POST(req: NextRequest, ctx: Ctx) {
   return proxy(req, (await ctx.params).path);
 }
+export async function PUT(req: NextRequest, ctx: Ctx) {
+  return proxy(req, (await ctx.params).path);
+}
 export async function DELETE(req: NextRequest, ctx: Ctx) {
   return proxy(req, (await ctx.params).path);
 }

--- a/telemtry/analysis/database/viewer_tool/src/app/log-sync/page.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/app/log-sync/page.tsx
@@ -1,9 +1,17 @@
 'use client';
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'react-toastify';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
+import {
+  FileAnnotationModal,
+  type AnnotationData,
+  emptyAnnotation,
+  hasAnnotation,
+} from '@/components/logsync/FileAnnotationModal';
+import { FilePreviewModal } from '@/components/logsync/FilePreviewModal';
 
 // ---- types mirrored from the worker's Job.to_dict() ----
 type FileProgress = { name: string; size: number; transferred: number; done: boolean; start_ms?: number; end_ms?: number };
@@ -95,6 +103,17 @@ export default function LogSyncPage() {
   const [jobs, setJobs] = useState<Record<string, Job>>({});
   const [motion, setMotion] = useState<Motion | null>(null);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  // Per-file trackside annotations, keyed by loggerd filename (shared across jobs).
+  const [annotations, setAnnotations] = useState<Record<string, AnnotationData>>({});
+  const [modalFile, setModalFile] = useState<{ name: string; subtitle: string } | null>(null);
+  const [previewFile, setPreviewFile] = useState<{ jobId: string; name: string; subtitle: string } | null>(null);
+  // 'jobs' = per-job cards; 'files' = flat deduped list of every file.
+  const [view, setView] = useState<'jobs' | 'files'>('jobs');
+  // File search / filtering across all jobs.
+  const [query, setQuery] = useState('');
+  const [starredOnly, setStarredOnly] = useState(false);
+  const [qualityFilter, setQualityFilter] = useState<Set<string>>(new Set());
+  const [tagFilter, setTagFilter] = useState<Set<string>>(new Set());
   const esRef = useRef<EventSource | null>(null);
 
   const fromMs = () => new Date(from).getTime();
@@ -128,6 +147,18 @@ export default function LogSyncPage() {
     tick();
     const id = setInterval(tick, 5000);
     return () => { alive = false; clearInterval(id); };
+  }, []);
+
+  // Load all file annotations once; merged into the file rows by filename.
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      try {
+        const r = await fetch('/api/logsync/annotations');
+        if (alive && r.ok) setAnnotations(await r.json());
+      } catch {/* annotations are non-critical; ignore */}
+    })();
+    return () => { alive = false; };
   }, []);
 
   const doPreview = async () => {
@@ -186,7 +217,62 @@ export default function LogSyncPage() {
       return next;
     });
 
+  const fileSubtitle = (f: FileProgress) => [fileTimeRange(f), fmtBytes(f.size)].filter(Boolean).join(' · ');
+  const openFile = (f: FileProgress) => setModalFile({ name: f.name, subtitle: fileSubtitle(f) });
+  const openPreview = (jobId: string, f: FileProgress) =>
+    setPreviewFile({ jobId, name: f.name, subtitle: fileSubtitle(f) });
+
+  // Every tag in use, for the filter chips.
+  const allTags = useMemo(() => {
+    const s = new Set<string>();
+    Object.values(annotations).forEach((a) => a.tags.forEach((t) => s.add(t)));
+    return [...s].sort();
+  }, [annotations]);
+
+  const filterActive = query.trim() !== '' || starredOnly || qualityFilter.size > 0 || tagFilter.size > 0;
+
+  // Does a file pass the active filters? Matches filename + all annotation text.
+  const matchFile = useCallback((name: string): boolean => {
+    const a = annotations[name];
+    if (starredOnly && !a?.starred) return false;
+    if (qualityFilter.size > 0 && !(a && qualityFilter.has(a.quality))) return false;
+    if (tagFilter.size > 0 && !(a && [...tagFilter].some((t) => a.tags.includes(t)))) return false;
+    const q = query.trim().toLowerCase();
+    if (q) {
+      const hay = [name, a?.notes, a?.driver, a?.track, a?.session, a?.weather, a?.tires, a?.setup, ...(a?.tags ?? [])]
+        .filter(Boolean).join(' ').toLowerCase();
+      if (!hay.includes(q)) return false;
+    }
+    return true;
+  }, [annotations, query, starredOnly, qualityFilter, tagFilter]);
+
+  const toggleSetItem = (set: Set<string>, setter: (s: Set<string>) => void, v: string) => {
+    const next = new Set(set);
+    next.has(v) ? next.delete(v) : next.add(v);
+    setter(next);
+  };
+  const clearFilters = () => { setQuery(''); setStarredOnly(false); setQualityFilter(new Set()); setTagFilter(new Set()); };
+
   const jobList = Object.values(jobs).sort((a, b) => b.created_ms - a.created_ms);
+  const matchCount = filterActive
+    ? jobList.reduce((n, j) => n + j.files.filter((f) => matchFile(f.name)).length, 0)
+    : 0;
+
+  // Every distinct file across all jobs (the shared store means one file can
+  // appear in several jobs). Deduped by name, preferring a job that has the
+  // file completed so preview/download works, and sorted newest-session-first.
+  const allFiles = useMemo(() => {
+    const m = new Map<string, { f: FileProgress; jobId: string }>();
+    for (const job of jobList) {
+      for (const f of job.files) {
+        const seen = m.get(f.name);
+        if (!seen || (!seen.f.done && f.done)) m.set(f.name, { f, jobId: job.id });
+      }
+    }
+    const startMs = (f: FileProgress) => (f.start_ms && f.start_ms > 0 ? f.start_ms : startMsFromName(f.name));
+    return [...m.values()].sort((a, b) => startMs(b.f) - startMs(a.f));
+  }, [jobList]);
+  const visibleAllFiles = filterActive ? allFiles.filter((x) => matchFile(x.f.name)) : allFiles;
 
   return (
     <div className="min-h-screen pt-20 px-6 max-w-5xl mx-auto">
@@ -228,21 +314,139 @@ export default function LogSyncPage() {
         </div>
       </div>
 
-      {/* Jobs */}
-      <h2 className="text-xl font-semibold mb-3">Jobs</h2>
-      {jobList.length === 0 && <p className="text-sm text-muted-foreground">No jobs yet.</p>}
-      <div className="flex flex-col gap-3">
-        {jobList.map((job) => (
-          <JobCard
-            key={job.id}
-            job={job}
-            expanded={expanded.has(job.id)}
-            onToggle={() => toggleExpand(job.id)}
-            onControl={control}
-          />
-        ))}
+      {/* Jobs / files */}
+      <div className="flex items-center justify-between mb-3 gap-3 flex-wrap">
+        <div className="flex items-center gap-3">
+          <h2 className="text-xl font-semibold">{view === 'jobs' ? 'Jobs' : 'All files'}</h2>
+          {jobList.length > 0 && (
+            <div className="flex rounded-md border overflow-hidden text-xs">
+              {(['jobs', 'files'] as const).map((v) => (
+                <button
+                  key={v}
+                  onClick={() => setView(v)}
+                  className={cn('px-3 py-1 transition-colors', view === v ? 'bg-primary/20 text-primary' : 'text-muted-foreground hover:text-foreground')}
+                >
+                  {v === 'jobs' ? 'By job' : 'All files'}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+        {filterActive && (
+          <span className="text-xs text-muted-foreground">
+            {view === 'files' ? visibleAllFiles.length : matchCount} file{(view === 'files' ? visibleAllFiles.length : matchCount) === 1 ? '' : 's'} match
+          </span>
+        )}
       </div>
+
+      {/* File search / filters */}
+      {jobList.length > 0 && (
+        <div className="rounded-lg border p-3 mb-4 bg-card/30 flex flex-col gap-3">
+          <div className="flex items-center gap-2">
+            <Input
+              placeholder="Search files — name, notes, tags, driver, track…"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+            />
+            {filterActive && (
+              <Button variant="ghost" size="sm" onClick={clearFilters}>Clear</Button>
+            )}
+          </div>
+          <div className="flex items-center gap-2 flex-wrap">
+            <FilterChip on={starredOnly} onClick={() => setStarredOnly((v) => !v)}>★ Starred</FilterChip>
+            {(['good', 'bad', 'corrupt'] as const).map((q) => (
+              <FilterChip key={q} on={qualityFilter.has(q)} onClick={() => toggleSetItem(qualityFilter, setQualityFilter, q)}>
+                {q[0].toUpperCase() + q.slice(1)}
+              </FilterChip>
+            ))}
+            {allTags.length > 0 && <span className="mx-1 h-4 w-px bg-border" />}
+            {allTags.map((t) => (
+              <FilterChip key={t} on={tagFilter.has(t)} onClick={() => toggleSetItem(tagFilter, setTagFilter, t)}>#{t}</FilterChip>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {jobList.length === 0 && <p className="text-sm text-muted-foreground">No jobs yet.</p>}
+
+      {view === 'jobs' ? (
+        <>
+          {filterActive && matchCount === 0 && (
+            <p className="text-sm text-muted-foreground">No files match the current filters.</p>
+          )}
+          <div className="flex flex-col gap-3">
+            {jobList.map((job) => (
+              <JobCard
+                key={job.id}
+                job={job}
+                expanded={expanded.has(job.id) || filterActive}
+                onToggle={() => toggleExpand(job.id)}
+                onControl={control}
+                annotations={annotations}
+                onOpenFile={openFile}
+                onPreviewFile={openPreview}
+                fileFilter={filterActive ? matchFile : null}
+              />
+            ))}
+          </div>
+        </>
+      ) : (
+        <div className="rounded-lg border bg-card/30 divide-y">
+          {visibleAllFiles.length === 0 ? (
+            <p className="text-sm text-muted-foreground p-4">
+              {filterActive ? 'No files match the current filters.' : 'No files yet.'}
+            </p>
+          ) : (
+            visibleAllFiles.map(({ f, jobId }) => (
+              <div key={f.name} className="px-4 py-2">
+                <FileRow jobId={jobId} f={f} ann={annotations[f.name]} onOpenFile={openFile} onPreviewFile={openPreview} />
+              </div>
+            ))
+          )}
+        </div>
+      )}
+
+      {modalFile && (
+        <FileAnnotationModal
+          fileName={modalFile.name}
+          subtitle={modalFile.subtitle}
+          initial={annotations[modalFile.name] ?? emptyAnnotation(modalFile.name)}
+          onClose={() => setModalFile(null)}
+          onSaved={(saved) =>
+            setAnnotations((prev) => {
+              // An emptied annotation comes back blank; drop it so badges clear.
+              const next = { ...prev };
+              if (hasAnnotation(saved)) next[saved.name] = saved;
+              else delete next[saved.name];
+              return next;
+            })
+          }
+        />
+      )}
+
+      {previewFile && (
+        <FilePreviewModal
+          jobId={previewFile.jobId}
+          fileName={previewFile.name}
+          subtitle={previewFile.subtitle}
+          onClose={() => setPreviewFile(null)}
+        />
+      )}
     </div>
+  );
+}
+
+function FilterChip({ on, onClick, children }: { on: boolean; onClick: () => void; children: React.ReactNode }) {
+  return (
+    <button
+      onClick={onClick}
+      className={cn(
+        'rounded-full border px-2.5 py-0.5 text-xs transition-colors',
+        on ? 'bg-primary/20 text-primary border-primary/40' : 'text-muted-foreground border-border hover:text-foreground',
+      )}
+    >
+      {children}
+    </button>
   );
 }
 
@@ -261,17 +465,25 @@ function MotionChip({ motion }: { motion: Motion | null }) {
 }
 
 function JobCard({
-  job, expanded, onToggle, onControl,
+  job, expanded, onToggle, onControl, annotations, onOpenFile, onPreviewFile, fileFilter,
 }: {
   job: Job;
   expanded: boolean;
   onToggle: () => void;
   onControl: (id: string, a: 'pause' | 'resume' | 'cancel') => void;
+  annotations: Record<string, AnnotationData>;
+  onOpenFile: (f: FileProgress) => void;
+  onPreviewFile: (jobId: string, f: FileProgress) => void;
+  fileFilter: ((name: string) => boolean) | null;
 }) {
   const active = !['completed', 'failed', 'canceled'].includes(job.state);
   const canPause = ['running', 'queued', 'paused_motion'].includes(job.state);
   const canResume = ['paused'].includes(job.state);
   const hasDownloads = job.files_done > 0;
+  const visibleFiles = fileFilter ? job.files.filter((f) => fileFilter(f.name)) : job.files;
+
+  // When a filter is active, a job with no matching files drops out entirely.
+  if (fileFilter && visibleFiles.length === 0) return null;
 
   return (
     <div className="rounded-lg border p-4 bg-card/30">
@@ -327,25 +539,75 @@ function JobCard({
 
       {expanded && (
         <div className="mt-3 border-t pt-3 flex flex-col gap-1">
-          {job.files.map((f) => (
-            <div key={f.name} className="flex items-center justify-between text-xs">
-              <span className="font-mono truncate mr-3">{f.name}</span>
-              <span className="flex items-center gap-3 shrink-0 text-muted-foreground">
-                <span className="hidden sm:inline tabular-nums">{fileTimeRange(f)}</span>
-                <span>{fmtBytes(f.transferred)} / {fmtBytes(f.size)}</span>
-                {f.done ? (
-                  <a className="underline hover:text-foreground"
-                     href={`/api/logsync/jobs/${job.id}/files/${encodeURIComponent(f.name)}`}>
-                    download
-                  </a>
-                ) : (
-                  <span>{job.total_bytes ? '…' : ''}</span>
-                )}
-              </span>
-            </div>
+          {visibleFiles.map((f) => (
+            <FileRow
+              key={f.name}
+              jobId={job.id}
+              f={f}
+              ann={annotations[f.name]}
+              onOpenFile={onOpenFile}
+              onPreviewFile={onPreviewFile}
+            />
           ))}
         </div>
       )}
     </div>
+  );
+}
+
+// One file row: clickable name (→ annotation modal) with inline badges, time
+// range, size, and a preview/download action. Shared by the per-job file list
+// and the flat "All files" view.
+function FileRow({
+  jobId, f, ann, onOpenFile, onPreviewFile,
+}: {
+  jobId: string;
+  f: FileProgress;
+  ann?: AnnotationData;
+  onOpenFile: (f: FileProgress) => void;
+  onPreviewFile: (jobId: string, f: FileProgress) => void;
+}) {
+  const annotated = hasAnnotation(ann);
+  return (
+    <div className="flex items-center justify-between text-xs gap-3">
+      <button
+        onClick={() => onOpenFile(f)}
+        title="Add or edit trackside notes"
+        className="group flex items-center gap-2 min-w-0 text-left"
+      >
+        {ann?.starred && <span className="text-yellow-400 shrink-0">★</span>}
+        <span className="font-mono truncate group-hover:text-foreground group-hover:underline">{f.name}</span>
+        {annotated
+          ? <FileBadges ann={ann!} />
+          : <span className="shrink-0 opacity-0 group-hover:opacity-100 transition-opacity text-muted-foreground">✎ annotate</span>}
+      </button>
+      <span className="flex items-center gap-3 shrink-0 text-muted-foreground">
+        <span className="hidden sm:inline tabular-nums">{fileTimeRange(f)}</span>
+        <span>{fmtBytes(f.size)}</span>
+        {f.done
+          ? <button className="underline hover:text-foreground" onClick={() => onPreviewFile(jobId, f)}>preview / download</button>
+          : <span title="still transferring">…</span>}
+      </span>
+    </div>
+  );
+}
+
+// Inline annotation summary shown next to a file name: quality dot, a couple of
+// tags, and a notes indicator — enough to tell at a glance "what this file is".
+const QUALITY_DOT: Record<string, string> = {
+  good: 'bg-emerald-400', bad: 'bg-amber-400', corrupt: 'bg-red-400',
+};
+function FileBadges({ ann }: { ann: AnnotationData }) {
+  return (
+    <span className="flex items-center gap-1.5 shrink-0 min-w-0">
+      {ann.quality && (
+        <span title={`Quality: ${ann.quality}`} className={`h-1.5 w-1.5 rounded-full ${QUALITY_DOT[ann.quality] ?? 'bg-zinc-400'}`} />
+      )}
+      {ann.tags.slice(0, 2).map((t) => (
+        <span key={t} className="rounded-full bg-primary/15 text-primary border border-primary/30 px-1.5 py-px max-w-[7rem] truncate">{t}</span>
+      ))}
+      {ann.tags.length > 2 && <span className="text-muted-foreground">+{ann.tags.length - 2}</span>}
+      {ann.notes && <span title={ann.notes} className="text-muted-foreground">📝</span>}
+    </span>
   );
 }

--- a/telemtry/analysis/database/viewer_tool/src/app/log-sync/page.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/app/log-sync/page.tsx
@@ -254,9 +254,10 @@ export default function LogSyncPage() {
   const clearFilters = () => { setQuery(''); setStarredOnly(false); setQualityFilter(new Set()); setTagFilter(new Set()); };
 
   const jobList = Object.values(jobs).sort((a, b) => b.created_ms - a.created_ms);
-  const matchCount = filterActive
-    ? jobList.reduce((n, j) => n + j.files.filter((f) => matchFile(f.name)).length, 0)
-    : 0;
+  const matchCount = useMemo(
+    () => (filterActive ? jobList.reduce((n, j) => n + j.files.filter((f) => matchFile(f.name)).length, 0) : 0),
+    [filterActive, jobList, matchFile],
+  );
 
   // Every distinct file across all jobs (the shared store means one file can
   // appear in several jobs). Deduped by name, preferring a job that has the

--- a/telemtry/analysis/database/viewer_tool/src/components/logsync/FileAnnotationModal.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/components/logsync/FileAnnotationModal.tsx
@@ -85,9 +85,11 @@ export function FileAnnotationModal({
   }, [onClose]);
 
   const commitTag = () => {
-    const t = tagDraft.trim();
-    if (!t) return;
-    if (!a.tags.includes(t)) set('tags', [...a.tags, t]);
+    // Split on whitespace/commas so a pasted "brake, endurance baseline" adds
+    // three tags at once.
+    const toAdd = tagDraft.split(/[\s,]+/).map((t) => t.trim())
+      .filter((t) => t && !a.tags.includes(t));
+    if (toAdd.length) set('tags', [...a.tags, ...toAdd]);
     setTagDraft('');
   };
   const removeTag = (t: string) => set('tags', a.tags.filter((x) => x !== t));

--- a/telemtry/analysis/database/viewer_tool/src/components/logsync/FileAnnotationModal.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/components/logsync/FileAnnotationModal.tsx
@@ -1,0 +1,240 @@
+'use client';
+
+// Trackside annotation modal for a single log file.
+//
+// Annotations are keyed by the file's loggerd name (orion_<startMs>.csv), not
+// by job — the same file can belong to several jobs, and what an engineer
+// records ("which run was this") belongs to the file. The modal is built for
+// speed at the trackside: one-click flags up top, then notes/tags, then the
+// structured identifiers. Saving PUTs the whole form to the worker.
+
+import { useEffect, useRef, useState } from 'react';
+import { toast } from 'react-toastify';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
+
+export type AnnotationData = {
+  name: string;
+  notes: string;
+  tags: string[];
+  driver: string;
+  track: string;
+  session: string;
+  weather: string;
+  tires: string;
+  setup: string;
+  starred: boolean;
+  quality: string; // '' | 'good' | 'bad' | 'corrupt'
+  updated_ms: number;
+};
+
+export const emptyAnnotation = (name: string): AnnotationData => ({
+  name, notes: '', tags: [],
+  driver: '', track: '', session: '',
+  weather: '', tires: '', setup: '',
+  starred: false, quality: '', updated_ms: 0,
+});
+
+// True if the annotation carries any trackside signal — drives the inline
+// badges/star in the file list.
+export const hasAnnotation = (a?: AnnotationData | null): boolean =>
+  !!a && (
+    a.starred || !!a.quality || a.tags.length > 0 ||
+    !!(a.notes || a.driver || a.track || a.session || a.weather || a.tires || a.setup)
+  );
+
+const QUALITY_OPTIONS: { value: string; label: string; cls: string }[] = [
+  { value: 'good', label: 'Good', cls: 'bg-emerald-500/20 text-emerald-300 border-emerald-500/40' },
+  { value: 'bad', label: 'Bad', cls: 'bg-amber-500/20 text-amber-300 border-amber-500/40' },
+  { value: 'corrupt', label: 'Corrupt', cls: 'bg-red-500/20 text-red-300 border-red-500/40' },
+];
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="flex flex-col gap-1 text-sm">
+      <span className="text-muted-foreground text-xs uppercase tracking-wide">{label}</span>
+      {children}
+    </label>
+  );
+}
+
+export function FileAnnotationModal({
+  fileName, subtitle, initial, onClose, onSaved,
+}: {
+  fileName: string;
+  subtitle?: string;          // e.g. the file's local time range / size
+  initial: AnnotationData;
+  onClose: () => void;
+  onSaved: (a: AnnotationData) => void;
+}) {
+  const [a, setA] = useState<AnnotationData>(initial);
+  const [tagDraft, setTagDraft] = useState('');
+  const [saving, setSaving] = useState(false);
+  const firstRef = useRef<HTMLTextAreaElement | null>(null);
+
+  const set = <K extends keyof AnnotationData>(k: K, v: AnnotationData[K]) =>
+    setA((prev) => ({ ...prev, [k]: v }));
+
+  // Esc to close; focus notes on open.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    window.addEventListener('keydown', onKey);
+    firstRef.current?.focus();
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  const commitTag = () => {
+    const t = tagDraft.trim();
+    if (!t) return;
+    if (!a.tags.includes(t)) set('tags', [...a.tags, t]);
+    setTagDraft('');
+  };
+  const removeTag = (t: string) => set('tags', a.tags.filter((x) => x !== t));
+
+  const save = async () => {
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/logsync/annotations/${encodeURIComponent(fileName)}`, {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          notes: a.notes, tags: a.tags,
+          driver: a.driver, track: a.track, session: a.session,
+          weather: a.weather, tires: a.tires, setup: a.setup,
+          starred: a.starred, quality: a.quality,
+        }),
+      });
+      if (!res.ok) throw new Error((await res.json().catch(() => ({}))).detail ?? res.statusText);
+      const saved: AnnotationData = await res.json();
+      onSaved(saved);
+      toast.success('Annotation saved');
+      onClose();
+    } catch (e) {
+      toast.error(`Save failed: ${String(e)}`);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      onMouseDown={onClose}
+    >
+      <div
+        className="w-full max-w-2xl max-h-[90vh] overflow-y-auto rounded-xl border bg-card shadow-2xl"
+        onMouseDown={(e) => e.stopPropagation()}
+      >
+        {/* header */}
+        <div className="flex items-start justify-between gap-3 border-b p-5">
+          <div className="min-w-0">
+            <p className="font-mono text-sm truncate">{fileName}</p>
+            {subtitle && <p className="text-xs text-muted-foreground mt-1">{subtitle}</p>}
+          </div>
+          <button
+            onClick={() => set('starred', !a.starred)}
+            title={a.starred ? 'Unstar' : 'Star this file'}
+            className={cn(
+              'shrink-0 rounded-md border px-2.5 py-1.5 text-lg leading-none transition-colors',
+              a.starred
+                ? 'bg-yellow-500/20 text-yellow-300 border-yellow-500/40'
+                : 'text-muted-foreground hover:text-foreground',
+            )}
+          >
+            {a.starred ? '★' : '☆'}
+          </button>
+        </div>
+
+        <div className="flex flex-col gap-5 p-5">
+          {/* quick triage: data quality */}
+          <Field label="Data quality">
+            <div className="flex flex-wrap gap-2">
+              {QUALITY_OPTIONS.map((q) => {
+                const on = a.quality === q.value;
+                return (
+                  <button
+                    key={q.value}
+                    onClick={() => set('quality', on ? '' : q.value)}
+                    className={cn(
+                      'rounded-full border px-3 py-1 text-xs transition-colors',
+                      on ? q.cls : 'text-muted-foreground border-border hover:text-foreground',
+                    )}
+                  >
+                    {q.label}
+                  </button>
+                );
+              })}
+            </div>
+          </Field>
+
+          {/* notes */}
+          <Field label="Notes">
+            <textarea
+              ref={firstRef}
+              value={a.notes}
+              onChange={(e) => set('notes', e.target.value)}
+              rows={3}
+              placeholder="What happened on this run? Issues, observations, things to look at…"
+              className="rounded-md border bg-transparent px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring resize-y"
+            />
+          </Field>
+
+          {/* tags */}
+          <Field label="Tags">
+            <div className="flex flex-wrap items-center gap-2 rounded-md border px-2 py-2">
+              {a.tags.map((t) => (
+                <span key={t} className="flex items-center gap-1 rounded-full bg-primary/15 text-primary border border-primary/30 px-2 py-0.5 text-xs">
+                  {t}
+                  <button onClick={() => removeTag(t)} className="hover:text-foreground" title="Remove">×</button>
+                </span>
+              ))}
+              <input
+                value={tagDraft}
+                onChange={(e) => setTagDraft(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ',') { e.preventDefault(); commitTag(); }
+                  else if (e.key === 'Backspace' && !tagDraft && a.tags.length) removeTag(a.tags[a.tags.length - 1]);
+                }}
+                onBlur={commitTag}
+                placeholder={a.tags.length ? 'Add tag…' : 'e.g. endurance, brake-test, baseline'}
+                className="flex-1 min-w-[8rem] bg-transparent text-sm outline-none"
+              />
+            </div>
+          </Field>
+
+          {/* run context */}
+          <div>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground mb-2">Run context</p>
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+              <Field label="Driver"><Input value={a.driver} onChange={(e) => set('driver', e.target.value)} placeholder="Name" /></Field>
+              <Field label="Track"><Input value={a.track} onChange={(e) => set('track', e.target.value)} placeholder="Track / venue" /></Field>
+              <Field label="Session / run"><Input value={a.session} onChange={(e) => set('session', e.target.value)} placeholder="e.g. AM endurance, run 3" /></Field>
+            </div>
+          </div>
+
+          {/* conditions */}
+          <div>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground mb-2">Conditions</p>
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+              <Field label="Weather"><Input value={a.weather} onChange={(e) => set('weather', e.target.value)} placeholder="Dry, 28°C…" /></Field>
+              <Field label="Tires"><Input value={a.tires} onChange={(e) => set('tires', e.target.value)} placeholder="Compound / set" /></Field>
+              <Field label="Setup"><Input value={a.setup} onChange={(e) => set('setup', e.target.value)} placeholder="Setup change" /></Field>
+            </div>
+          </div>
+        </div>
+
+        {/* footer */}
+        <div className="flex items-center justify-between gap-3 border-t p-5">
+          <span className="text-xs text-muted-foreground">
+            {a.updated_ms ? `Last saved ${new Date(a.updated_ms).toLocaleString()}` : 'Not yet saved'}
+          </span>
+          <div className="flex items-center gap-2">
+            <Button variant="outline" onClick={onClose} disabled={saving}>Cancel</Button>
+            <Button onClick={save} disabled={saving}>{saving ? 'Saving…' : 'Save'}</Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/telemtry/analysis/database/viewer_tool/src/components/logsync/FilePreviewModal.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/components/logsync/FilePreviewModal.tsx
@@ -1,0 +1,228 @@
+'use client';
+
+// Preview a log file's first rows and pick which columns to download.
+//
+// loggerd CSVs carry hundreds of columns (140 cell voltages, 92 cell temps,
+// every dynamics/controls/thermal channel…). Rather than pull a multi-GB file
+// to look at three signals, this modal fetches just the header + first rows,
+// lets the engineer tick the columns they want (grouped by subsystem, with a
+// sample value to identify each), and downloads a CSV projected to just those
+// columns server-side.
+
+import { useEffect, useMemo, useState } from 'react';
+import { toast } from 'react-toastify';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
+
+type Head = { columns: string[]; rows: string[][]; total_columns: number; returned_rows: number };
+
+// Subsystem a column belongs to: the bit before the first '.' or '['. Scalars
+// like `time` / `packet_id` (no separator) go under a "(top-level)" group.
+const groupOf = (col: string): string => {
+  const base = col.match(/^[^.[]+/)?.[0] ?? col;
+  return /[.[]/.test(col) ? base : '(top-level)';
+};
+
+// Columns worth pre-selecting so a fresh preview is immediately downloadable.
+const DEFAULT_COLS = ['time', 'packet_id'];
+
+export function FilePreviewModal({
+  jobId, fileName, subtitle, onClose,
+}: {
+  jobId: string;
+  fileName: string;
+  subtitle?: string;
+  onClose: () => void;
+}) {
+  const [head, setHead] = useState<Head | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [colSearch, setColSearch] = useState('');
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      try {
+        const r = await fetch(`/api/logsync/jobs/${jobId}/files/${encodeURIComponent(fileName)}/head?rows=10`);
+        if (!r.ok) throw new Error((await r.json().catch(() => ({}))).detail ?? r.statusText);
+        const h: Head = await r.json();
+        if (!alive) return;
+        setHead(h);
+        setSelected(new Set(DEFAULT_COLS.filter((c) => h.columns.includes(c))));
+      } catch (e) {
+        if (alive) setError(String(e));
+      }
+    })();
+    return () => { alive = false; };
+  }, [jobId, fileName]);
+
+  // First-row sample value per column, to help identify what each channel is.
+  const sample = useMemo(() => {
+    const m: Record<string, string> = {};
+    if (head?.rows[0]) head.columns.forEach((c, i) => { m[c] = head.rows[0][i] ?? ''; });
+    return m;
+  }, [head]);
+
+  // Columns matching the picker search, grouped by subsystem.
+  const groups = useMemo(() => {
+    if (!head) return [] as { name: string; cols: string[] }[];
+    const q = colSearch.trim().toLowerCase();
+    const byGroup = new Map<string, string[]>();
+    for (const c of head.columns) {
+      if (q && !c.toLowerCase().includes(q)) continue;
+      const g = groupOf(c);
+      (byGroup.get(g) ?? byGroup.set(g, []).get(g)!).push(c);
+    }
+    return [...byGroup.entries()].map(([name, cols]) => ({ name, cols }));
+  }, [head, colSearch]);
+
+  const toggle = (c: string) =>
+    setSelected((prev) => {
+      const next = new Set(prev);
+      next.has(c) ? next.delete(c) : next.add(c);
+      return next;
+    });
+  const setMany = (cols: string[], on: boolean) =>
+    setSelected((prev) => {
+      const next = new Set(prev);
+      cols.forEach((c) => (on ? next.add(c) : next.delete(c)));
+      return next;
+    });
+
+  // Selected columns in original file order (download + preview both use this).
+  const orderedSelected = useMemo(
+    () => (head ? head.columns.filter((c) => selected.has(c)) : []),
+    [head, selected],
+  );
+
+  const downloadHref = (cols?: string[]) => {
+    const base = `/api/logsync/jobs/${jobId}/files/${encodeURIComponent(fileName)}`;
+    if (!cols || cols.length === 0) return base;
+    return `${base}?cols=${encodeURIComponent(cols.join(','))}`;
+  };
+
+  const visibleCols = groups.flatMap((g) => g.cols);
+  const allVisibleSelected = visibleCols.length > 0 && visibleCols.every((c) => selected.has(c));
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4" onMouseDown={onClose}>
+      <div
+        className="flex w-full max-w-4xl max-h-[90vh] flex-col rounded-xl border bg-card shadow-2xl"
+        onMouseDown={(e) => e.stopPropagation()}
+      >
+        {/* header */}
+        <div className="flex items-start justify-between gap-3 border-b p-5">
+          <div className="min-w-0">
+            <p className="font-mono text-sm truncate">{fileName}</p>
+            <p className="text-xs text-muted-foreground mt-1">
+              {subtitle ? `${subtitle} · ` : ''}
+              {head ? `${head.total_columns} columns` : error ? 'failed to load' : 'loading…'}
+            </p>
+          </div>
+          <button onClick={onClose} className="shrink-0 text-muted-foreground hover:text-foreground text-xl leading-none">×</button>
+        </div>
+
+        {error && <div className="p-5 text-sm text-red-400">Could not load preview: {error}</div>}
+        {!head && !error && <div className="p-8 text-center text-sm text-muted-foreground">Loading preview…</div>}
+
+        {head && (
+          <div className="flex min-h-0 flex-1 flex-col md:flex-row">
+            {/* column picker */}
+            <div className="flex w-full md:w-80 shrink-0 flex-col border-b md:border-b-0 md:border-r">
+              <div className="p-3 border-b flex flex-col gap-2">
+                <Input placeholder="Search columns…" value={colSearch} onChange={(e) => setColSearch(e.target.value)} />
+                <div className="flex items-center justify-between text-xs text-muted-foreground">
+                  <span>{selected.size} selected</span>
+                  <button className="underline hover:text-foreground" onClick={() => setMany(visibleCols, !allVisibleSelected)}>
+                    {allVisibleSelected ? 'clear shown' : 'select shown'}
+                  </button>
+                </div>
+              </div>
+              <div className="overflow-y-auto max-h-[28rem] md:max-h-none flex-1 p-2">
+                {groups.map((g) => {
+                  const allOn = g.cols.every((c) => selected.has(c));
+                  return (
+                    <div key={g.name} className="mb-2">
+                      <div className="flex items-center justify-between px-1 py-1">
+                        <span className="text-xs font-semibold text-muted-foreground">{g.name}</span>
+                        <button className="text-[10px] underline text-muted-foreground hover:text-foreground"
+                                onClick={() => setMany(g.cols, !allOn)}>
+                          {allOn ? 'none' : 'all'}
+                        </button>
+                      </div>
+                      {g.cols.map((c) => (
+                        <label key={c} className="flex items-center gap-2 px-1 py-0.5 text-xs rounded hover:bg-muted/50 cursor-pointer">
+                          <input type="checkbox" checked={selected.has(c)} onChange={() => toggle(c)} className="shrink-0" />
+                          <span className="font-mono truncate" title={c}>{c}</span>
+                          {sample[c] !== undefined && sample[c] !== '' && (
+                            <span className="ml-auto shrink-0 text-muted-foreground/70 tabular-nums truncate max-w-[6rem]" title={sample[c]}>
+                              {sample[c]}
+                            </span>
+                          )}
+                        </label>
+                      ))}
+                    </div>
+                  );
+                })}
+                {groups.length === 0 && <p className="p-2 text-xs text-muted-foreground">No columns match “{colSearch}”.</p>}
+              </div>
+            </div>
+
+            {/* preview table of the selected columns */}
+            <div className="min-w-0 flex-1 overflow-auto p-3">
+              <p className="text-xs text-muted-foreground mb-2">
+                First {head.returned_rows} rows · {orderedSelected.length} of {head.total_columns} columns
+              </p>
+              {orderedSelected.length === 0 ? (
+                <p className="text-sm text-muted-foreground p-4">Select columns to preview them.</p>
+              ) : (
+                <table className="text-xs border-collapse">
+                  <thead>
+                    <tr>
+                      {orderedSelected.map((c) => (
+                        <th key={c} className="sticky top-0 bg-card border px-2 py-1 text-left font-mono whitespace-nowrap" title={c}>{c}</th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {head.rows.map((row, ri) => (
+                      <tr key={ri}>
+                        {orderedSelected.map((c) => (
+                          <td key={c} className="border px-2 py-1 whitespace-nowrap tabular-nums">
+                            {row[head.columns.indexOf(c)] ?? ''}
+                          </td>
+                        ))}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* footer */}
+        <div className="flex items-center justify-between gap-3 border-t p-4">
+          <a href={downloadHref()} className="text-xs underline text-muted-foreground hover:text-foreground">
+            Download full file
+          </a>
+          <a
+            href={orderedSelected.length ? downloadHref(orderedSelected) : undefined}
+            onClick={(e) => { if (!orderedSelected.length) { e.preventDefault(); toast.error('Select at least one column'); } }}
+          >
+            <Button disabled={!orderedSelected.length}>
+              Download {orderedSelected.length || ''} column{orderedSelected.length === 1 ? '' : 's'}
+            </Button>
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/telemtry/analysis/database/viewer_tool/src/components/logsync/FilePreviewModal.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/components/logsync/FilePreviewModal.tsx
@@ -96,11 +96,13 @@ export function FilePreviewModal({
       return next;
     });
 
-  // Selected columns in original file order (download + preview both use this).
-  const orderedSelected = useMemo(
-    () => (head ? head.columns.filter((c) => selected.has(c)) : []),
+  // Selected columns in original file order, paired with their row index, so
+  // the preview table is a flat lookup instead of an indexOf per cell.
+  const orderedCols = useMemo(
+    () => (head ? head.columns.map((name, index) => ({ name, index })).filter((c) => selected.has(c.name)) : []),
     [head, selected],
   );
+  const orderedSelected = useMemo(() => orderedCols.map((c) => c.name), [orderedCols]);
 
   const downloadHref = (cols?: string[]) => {
     const base = `/api/logsync/jobs/${jobId}/files/${encodeURIComponent(fileName)}`;
@@ -186,17 +188,17 @@ export function FilePreviewModal({
                 <table className="text-xs border-collapse">
                   <thead>
                     <tr>
-                      {orderedSelected.map((c) => (
-                        <th key={c} className="sticky top-0 bg-card border px-2 py-1 text-left font-mono whitespace-nowrap" title={c}>{c}</th>
+                      {orderedCols.map((c) => (
+                        <th key={c.name} className="sticky top-0 bg-card border px-2 py-1 text-left font-mono whitespace-nowrap" title={c.name}>{c.name}</th>
                       ))}
                     </tr>
                   </thead>
                   <tbody>
                     {head.rows.map((row, ri) => (
                       <tr key={ri}>
-                        {orderedSelected.map((c) => (
-                          <td key={c} className="border px-2 py-1 whitespace-nowrap tabular-nums">
-                            {row[head.columns.indexOf(c)] ?? ''}
+                        {orderedCols.map((c) => (
+                          <td key={c.name} className="border px-2 py-1 whitespace-nowrap tabular-nums">
+                            {row[c.index] ?? ''}
                           </td>
                         ))}
                       </tr>

--- a/telemtry/stack/logsync/README.md
+++ b/telemtry/stack/logsync/README.md
@@ -39,10 +39,25 @@ possible future enhancement.
 | POST | `/jobs` | Create a job `{from_ms, to_ms, bwlimit_kbps?}` |
 | GET  | `/jobs` / `/jobs/{id}` | List / get jobs |
 | POST | `/jobs/{id}/pause\|resume\|cancel` | Control a job |
-| GET  | `/jobs/{id}/files/{name}` | Download one CSV |
+| GET  | `/jobs/{id}/files/{name}` | Download one CSV (add `?cols=a,b,c` to project to just those columns) |
+| GET  | `/jobs/{id}/files/{name}/head?rows=N` | Header + first N rows, for preview / column picking |
 | GET  | `/jobs/{id}/archive` | Stream a ZIP of completed files |
 | GET  | `/events` | SSE stream of job progress |
 | GET  | `/motion` | Current motion reading (debug) |
+| GET  | `/annotations` | All file annotations as a `{name: annotation}` map |
+| GET  | `/annotations/{name}` | One file's annotation (blank if none) |
+| PUT  | `/annotations/{name}` | Save trackside notes/tags/flags for a file |
+
+### File annotations
+
+Trackside notes attached to a log **file**, keyed by its loggerd name
+(`orion_<startMs>.csv`) — not by job, since the same file can belong to several
+jobs (shared store) and the notes describe the run, not the transfer. Fields:
+free-text `notes`, `tags[]`, run context (`driver`, `track`, `session`),
+conditions (`weather`, `tires`, `setup`), and quick flags (`starred`,
+`quality` ∈ `good|bad|corrupt`). Stored as JSON rows in an `annotations` table
+in the same SQLite DB as jobs; an annotation cleared back to empty is deleted.
+In the viewer, click any file in a job's file list to open the annotation modal.
 
 ## Deploy
 

--- a/telemtry/stack/logsync/app/main.py
+++ b/telemtry/stack/logsync/app/main.py
@@ -226,7 +226,7 @@ async def file_head(job_id: str, name: str, rows: int = 10):
     rows = max(1, min(rows, 100))
     columns: list[str] = []
     data: list[list[str]] = []
-    with open(path, newline="") as fh:
+    with open(path, newline="", encoding="utf-8") as fh:
         reader = csv.reader(fh)
         columns = next(reader, [])
         for i, row in enumerate(reader):
@@ -253,7 +253,7 @@ async def download_file(job_id: str, name: str, cols: str | None = None):
         return FileResponse(path, filename=name, media_type="text/csv")
 
     requested = [c.strip() for c in cols.split(",") if c.strip()]
-    with open(path, newline="") as fh:
+    with open(path, newline="", encoding="utf-8") as fh:
         header = next(csv.reader(fh), [])
     index_of = {c: i for i, c in enumerate(header)}
     indices = [index_of[c] for c in requested if c in index_of]
@@ -263,15 +263,21 @@ async def download_file(job_id: str, name: str, cols: str | None = None):
     subset_name = (name[:-4] if name.endswith(".csv") else name) + ".subset.csv"
 
     def gen():
-        with open(path, newline="") as fh:
+        # Accumulate rows and flush in ~64KB chunks: yielding per row forces a
+        # threadpool context switch through Starlette for every line, which is
+        # crippling on million-row files.
+        with open(path, newline="", encoding="utf-8") as fh:
             reader = csv.reader(fh)
             buf = io.StringIO()
             writer = csv.writer(buf)
             for row in reader:
                 writer.writerow([row[i] if i < len(row) else "" for i in indices])
+                if buf.tell() >= 65536:
+                    yield buf.getvalue()
+                    buf.seek(0)
+                    buf.truncate(0)
+            if buf.tell():
                 yield buf.getvalue()
-                buf.seek(0)
-                buf.truncate(0)
 
     return StreamingResponse(
         gen(),

--- a/telemtry/stack/logsync/app/main.py
+++ b/telemtry/stack/logsync/app/main.py
@@ -6,8 +6,11 @@ the SSE progress stream and the file/archive downloads.
 from __future__ import annotations
 
 import asyncio
+import csv
+import io
 import json
 import os
+import time
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, HTTPException, Request
@@ -17,15 +20,19 @@ from pydantic import BaseModel
 
 from .config import config
 from .manager import JobManager
+from .models import QUALITY_VALUES, Annotation
 from .pi import list_remote_logs, select_in_range
+from .store import AnnotationStore
 
 manager: JobManager | None = None
+annotations: AnnotationStore | None = None
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    global manager
+    global manager, annotations
     os.makedirs(config.staging_dir, exist_ok=True)
+    annotations = AnnotationStore(config.state_db)
     manager = JobManager()
     await manager.start()
     yield
@@ -44,10 +51,31 @@ def _mgr() -> JobManager:
     return manager
 
 
+def _anno() -> AnnotationStore:
+    if annotations is None:
+        raise HTTPException(503, "worker not ready")
+    return annotations
+
+
 class CreateJobBody(BaseModel):
     from_ms: int
     to_ms: int
     bwlimit_kbps: int | None = None
+
+
+class AnnotationBody(BaseModel):
+    """Editable annotation fields. All optional; omitted fields reset to blank
+    (the client always sends the full form), so a PUT fully replaces the row."""
+    notes: str = ""
+    tags: list[str] = []
+    driver: str = ""
+    track: str = ""
+    session: str = ""
+    weather: str = ""
+    tires: str = ""
+    setup: str = ""
+    starred: bool = False
+    quality: str = ""
 
 
 @app.get("/health")
@@ -91,6 +119,51 @@ async def create_job(body: CreateJobBody):
 @app.get("/jobs")
 async def list_jobs():
     return [j.to_dict() for j in _mgr().list()]
+
+
+# ----- file annotations (trackside notes, keyed by filename) -----
+
+
+@app.get("/annotations")
+async def list_annotations():
+    """All annotations as a {name: annotation} map, for the viewer to merge
+    into its file list in one fetch."""
+    return {a.name: a.to_dict() for a in _anno().list()}
+
+
+@app.get("/annotations/{name}")
+async def get_annotation(name: str):
+    ann = _anno().get(name)
+    return ann.to_dict() if ann else Annotation(name=name).to_dict()
+
+
+@app.put("/annotations/{name}")
+async def put_annotation(name: str, body: AnnotationBody):
+    if body.quality not in QUALITY_VALUES:
+        raise HTTPException(422, f"quality must be one of {QUALITY_VALUES}")
+    store = _anno()
+    ann = Annotation(
+        name=name,
+        notes=body.notes.strip(),
+        # de-dupe, drop blanks, preserve order
+        tags=list(dict.fromkeys(t.strip() for t in body.tags if t.strip())),
+        driver=body.driver.strip(),
+        track=body.track.strip(),
+        session=body.session.strip(),
+        weather=body.weather.strip(),
+        tires=body.tires.strip(),
+        setup=body.setup.strip(),
+        starred=body.starred,
+        quality=body.quality,
+        updated_ms=int(time.time() * 1000),
+    )
+    # An annotation cleared back to empty is deleted rather than stored blank,
+    # so "has notes?" stays a simple presence check on the viewer side.
+    if ann.is_empty():
+        store.delete(name)
+        return Annotation(name=name).to_dict()
+    store.upsert(ann)
+    return ann.to_dict()
 
 
 def _require_job(job_id: str):
@@ -143,11 +216,68 @@ def _safe_file(job, name: str) -> str:
     return path
 
 
-@app.get("/jobs/{job_id}/files/{name}")
-async def download_file(job_id: str, name: str):
+@app.get("/jobs/{job_id}/files/{name}/head")
+async def file_head(job_id: str, name: str, rows: int = 10):
+    """First `rows` data rows + the header, so the viewer can preview a file and
+    let the user choose columns before downloading. Reads only the head — the
+    csv reader stops early, so this is cheap even on multi-GB files."""
     job = _require_job(job_id)
     path = _safe_file(job, name)
-    return FileResponse(path, filename=name, media_type="text/csv")
+    rows = max(1, min(rows, 100))
+    columns: list[str] = []
+    data: list[list[str]] = []
+    with open(path, newline="") as fh:
+        reader = csv.reader(fh)
+        columns = next(reader, [])
+        for i, row in enumerate(reader):
+            if i >= rows:
+                break
+            data.append(row)
+    return {
+        "columns": columns,
+        "rows": data,
+        "total_columns": len(columns),
+        "returned_rows": len(data),
+    }
+
+
+@app.get("/jobs/{job_id}/files/{name}")
+async def download_file(job_id: str, name: str, cols: str | None = None):
+    """Download a file. With `cols` (a comma-separated column list) the CSV is
+    streamed projected to just those columns, in the order requested — so an
+    engineer can pull a handful of channels instead of the whole multi-GB file.
+    Without `cols`, the original file is served as-is."""
+    job = _require_job(job_id)
+    path = _safe_file(job, name)
+    if not cols:
+        return FileResponse(path, filename=name, media_type="text/csv")
+
+    requested = [c.strip() for c in cols.split(",") if c.strip()]
+    with open(path, newline="") as fh:
+        header = next(csv.reader(fh), [])
+    index_of = {c: i for i, c in enumerate(header)}
+    indices = [index_of[c] for c in requested if c in index_of]
+    if not indices:
+        raise HTTPException(400, "none of the requested columns exist in this file")
+
+    subset_name = (name[:-4] if name.endswith(".csv") else name) + ".subset.csv"
+
+    def gen():
+        with open(path, newline="") as fh:
+            reader = csv.reader(fh)
+            buf = io.StringIO()
+            writer = csv.writer(buf)
+            for row in reader:
+                writer.writerow([row[i] if i < len(row) else "" for i in indices])
+                yield buf.getvalue()
+                buf.seek(0)
+                buf.truncate(0)
+
+    return StreamingResponse(
+        gen(),
+        media_type="text/csv",
+        headers={"Content-Disposition": f'attachment; filename="{subset_name}"'},
+    )
 
 
 @app.get("/jobs/{job_id}/archive")

--- a/telemtry/stack/logsync/app/models.py
+++ b/telemtry/stack/logsync/app/models.py
@@ -85,3 +85,46 @@ class Job:
         d["file_count"] = len(self.files)
         d["files_done"] = sum(1 for f in self.files if f.done)
         return d
+
+
+# Allowed data-quality markers for a file. Empty string = unrated.
+QUALITY_VALUES = ("", "good", "bad", "corrupt")
+
+
+@dataclass
+class Annotation:
+    """Trackside notes attached to a single log file.
+
+    Keyed by the file's globally-unique loggerd name (``orion_<startMs>.csv``),
+    NOT by job: the same file can belong to several jobs (shared store), and an
+    engineer annotating "what this run was" cares about the file, not the
+    transfer that fetched it. So annotations live independently of jobs and
+    persist even after the jobs that referenced the file are gone.
+    """
+    name: str                                   # orion_<startMs>.csv (the key)
+    notes: str = ""
+    tags: list[str] = field(default_factory=list)
+    # Run context — the trackside identifiers.
+    driver: str = ""
+    track: str = ""
+    session: str = ""                           # session / run label or number
+    # Conditions.
+    weather: str = ""
+    tires: str = ""
+    setup: str = ""                             # setup change notes
+    # Quick triage flags.
+    starred: bool = False
+    quality: str = ""                           # one of QUALITY_VALUES
+    updated_ms: int = 0
+
+    def is_empty(self) -> bool:
+        """True if nothing has actually been filled in (used to prune blanks)."""
+        return not any((
+            self.notes.strip(), self.tags, self.driver.strip(),
+            self.track.strip(), self.session.strip(), self.weather.strip(),
+            self.tires.strip(), self.setup.strip(), self.starred,
+            self.quality,
+        ))
+
+    def to_dict(self) -> dict:
+        return asdict(self)

--- a/telemtry/stack/logsync/app/store.py
+++ b/telemtry/stack/logsync/app/store.py
@@ -11,7 +11,7 @@ import os
 import sqlite3
 from typing import Optional
 
-from .models import FileProgress, Job, JobState
+from .models import QUALITY_VALUES, Annotation, FileProgress, Job, JobState
 
 
 class Store:
@@ -75,3 +75,70 @@ class Store:
             "SELECT data FROM jobs ORDER BY created_ms DESC"
         ).fetchall()
         return [self._deserialize(r[0]) for r in rows]
+
+
+class AnnotationStore:
+    """Per-file trackside annotations, keyed by loggerd filename.
+
+    Shares the same SQLite file as the job Store (its own table) — the data is
+    tiny and lives next to the jobs it describes. Like jobs, each annotation is
+    a JSON blob in one row; the only column we query on is the file name.
+    """
+
+    def __init__(self, path: str):
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        self._conn = sqlite3.connect(path, check_same_thread=False)
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS annotations (
+                name        TEXT PRIMARY KEY,
+                updated_ms  INTEGER NOT NULL,
+                data        TEXT NOT NULL
+            )
+            """
+        )
+        self._conn.commit()
+
+    @staticmethod
+    def _deserialize(data: str) -> Annotation:
+        d = json.loads(data)
+        quality = d.get("quality", "")
+        if quality not in QUALITY_VALUES:
+            quality = ""
+        return Annotation(
+            name=d["name"],
+            notes=d.get("notes", ""),
+            tags=list(d.get("tags", [])),
+            driver=d.get("driver", ""),
+            track=d.get("track", ""),
+            session=d.get("session", ""),
+            weather=d.get("weather", ""),
+            tires=d.get("tires", ""),
+            setup=d.get("setup", ""),
+            starred=bool(d.get("starred", False)),
+            quality=quality,
+            updated_ms=d.get("updated_ms", 0),
+        )
+
+    def get(self, name: str) -> Optional[Annotation]:
+        row = self._conn.execute(
+            "SELECT data FROM annotations WHERE name=?", (name,)
+        ).fetchone()
+        return self._deserialize(row[0]) if row else None
+
+    def list(self) -> list[Annotation]:
+        rows = self._conn.execute("SELECT data FROM annotations").fetchall()
+        return [self._deserialize(r[0]) for r in rows]
+
+    def upsert(self, ann: Annotation) -> None:
+        self._conn.execute(
+            "INSERT INTO annotations (name, updated_ms, data) VALUES (?, ?, ?) "
+            "ON CONFLICT(name) DO UPDATE SET updated_ms=excluded.updated_ms, "
+            "data=excluded.data",
+            (ann.name, ann.updated_ms, json.dumps(ann.to_dict())),
+        )
+        self._conn.commit()
+
+    def delete(self, name: str) -> None:
+        self._conn.execute("DELETE FROM annotations WHERE name=?", (name,))
+        self._conn.commit()

--- a/telemtry/stack/logsync/app/store.py
+++ b/telemtry/stack/logsync/app/store.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import os
 import sqlite3
+import threading
 from typing import Optional
 
 from .models import QUALITY_VALUES, Annotation, FileProgress, Job, JobState
@@ -88,16 +89,22 @@ class AnnotationStore:
     def __init__(self, path: str):
         os.makedirs(os.path.dirname(path), exist_ok=True)
         self._conn = sqlite3.connect(path, check_same_thread=False)
-        self._conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS annotations (
-                name        TEXT PRIMARY KEY,
-                updated_ms  INTEGER NOT NULL,
-                data        TEXT NOT NULL
+        # The annotation endpoints are async (so calls are already serialized on
+        # the event loop), but guard the connection anyway in case a future
+        # caller hits it from Starlette's threadpool — concurrent use of one
+        # sqlite connection is unsafe.
+        self._lock = threading.Lock()
+        with self._lock:
+            self._conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS annotations (
+                    name        TEXT PRIMARY KEY,
+                    updated_ms  INTEGER NOT NULL,
+                    data        TEXT NOT NULL
+                )
+                """
             )
-            """
-        )
-        self._conn.commit()
+            self._conn.commit()
 
     @staticmethod
     def _deserialize(data: str) -> Annotation:
@@ -121,24 +128,28 @@ class AnnotationStore:
         )
 
     def get(self, name: str) -> Optional[Annotation]:
-        row = self._conn.execute(
-            "SELECT data FROM annotations WHERE name=?", (name,)
-        ).fetchone()
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT data FROM annotations WHERE name=?", (name,)
+            ).fetchone()
         return self._deserialize(row[0]) if row else None
 
     def list(self) -> list[Annotation]:
-        rows = self._conn.execute("SELECT data FROM annotations").fetchall()
+        with self._lock:
+            rows = self._conn.execute("SELECT data FROM annotations").fetchall()
         return [self._deserialize(r[0]) for r in rows]
 
     def upsert(self, ann: Annotation) -> None:
-        self._conn.execute(
-            "INSERT INTO annotations (name, updated_ms, data) VALUES (?, ?, ?) "
-            "ON CONFLICT(name) DO UPDATE SET updated_ms=excluded.updated_ms, "
-            "data=excluded.data",
-            (ann.name, ann.updated_ms, json.dumps(ann.to_dict())),
-        )
-        self._conn.commit()
+        with self._lock:
+            self._conn.execute(
+                "INSERT INTO annotations (name, updated_ms, data) VALUES (?, ?, ?) "
+                "ON CONFLICT(name) DO UPDATE SET updated_ms=excluded.updated_ms, "
+                "data=excluded.data",
+                (ann.name, ann.updated_ms, json.dumps(ann.to_dict())),
+            )
+            self._conn.commit()
 
     def delete(self, name: str) -> None:
-        self._conn.execute("DELETE FROM annotations WHERE name=?", (name,))
-        self._conn.commit()
+        with self._lock:
+            self._conn.execute("DELETE FROM annotations WHERE name=?", (name,))
+            self._conn.commit()


### PR DESCRIPTION
Builds on the logsync feature (#275–#278) to make finding and pulling the right log files much easier at the trackside.

## What's new

### 1. Per-file trackside annotations
Click any file to open an annotation modal. Notes are keyed by the loggerd filename (`orion_<ms>.csv`), **not** by job — the same file can belong to several jobs (shared store), and the notes describe the run, not the transfer.
- Free-text **notes**, **tags**, **run context** (driver / track / session), **conditions** (weather / tires / setup), and **quick flags** (star, data quality good/bad/corrupt).
- Stored as JSON rows in a new `annotations` table in the existing SQLite DB; an annotation cleared back to empty is deleted.
- Inline badges on each file row (star, quality dot, tags, 📝) so you can tell at a glance what a file is.

### 2. File search & filtering
A search/filter bar over **all** jobs: free-text (matches filename + every annotation field) plus quick chips for ★ starred, quality, and any tag in use. Jobs auto-expand and non-matching files/jobs drop out while filtering.

### 3. "All files" view
A `By job` / `All files` toggle. The flat view is a deduped list of every file across jobs (shared store → one file, many jobs), preferring a completed copy so download works, sorted newest-session-first.

### 4. Preview + column-selective download
loggerd CSVs carry **hundreds** of columns (140 cell voltages, 92 cell temps, all dynamics/controls/thermal). Instead of pulling a multi-GB file for three signals:
- `GET /jobs/{id}/files/{name}/head?rows=N` — header + first rows (reads only the head; cheap on huge files).
- `?cols=a,b,c` on the download endpoint — streams the CSV projected to just those columns, in requested order.
- `FilePreviewModal`: grouped, searchable column picker with a sample value per column, a first-rows preview of the selected columns, and selective or full download.

## Endpoints
| Method | Path | Purpose |
| ------ | ---- | ------- |
| GET | `/annotations`, `/annotations/{name}` | List / get file annotations |
| PUT | `/annotations/{name}` | Save annotation |
| GET | `/jobs/{id}/files/{name}/head?rows=N` | Header + first rows (preview) |
| GET | `/jobs/{id}/files/{name}?cols=a,b,c` | Column-projected download |

## Testing
- `tsc --noEmit`: clean for all changed/new files (only pre-existing missing-Prisma-client errors remain).
- Python: syntax OK; standalone tests of the `AnnotationStore` roundtrip and the CSV head/projection logic (quoting/escaping, preserved column order) pass.
