### PR TITLE
Dash endurance pacing: trackside→car signals, on-car GPS laps, ack/parity

### DIFF
--- a/BEVO/dashd/MQTT_CONTRACT.md
+++ b/BEVO/dashd/MQTT_CONTRACT.md
@@ -17,6 +17,27 @@ its data shown on the driver's dashboard in real time.
 | `lhre/dash/lapDelta`       | JSON number    | seconds           | `-0.45`  |
 | `lhre/dash/energyDelta`    | JSON number    | Wh                | `3.2`    |
 | `lhre/dash/lapsRemaining`  | JSON number    | laps (fractional) | `15.3`   |
+| `lhre/dash/targetPower`    | JSON number    | kW                | `32`     |
+| `lhre/dash/lapTrigger`     | JSON number    | monotonic counter | `7`      |
+
+### Endurance pacing signals
+
+`targetPower` and `lapTrigger` are published by the **Dash** tab on the
+trackside-live page (`telemtry/analysis/database/viewer_tool`) over the broker's
+websockets listener (port `8080`). They drive on-dash endurance pacing — the
+dash integrates CAN power locally and compares it to the budget, so only these
+two control values come off-car:
+
+- **`targetPower`** — the live power budget (kW) the strategist dials in. The
+  dash integrates real power against `targetPower * elapsed` per lap; the
+  top energy bar runs green while under budget and red while over. It's a
+  set-point, so the sender **republishes it ~1 Hz** to beat the 5 s staleness
+  null (below).
+- **`lapTrigger`** — a monotonically increasing lap counter. On each **increase**
+  the dash pops a full-screen lap card (lap time + energy used that lap) and
+  resets the per-lap energy integrator, so pacing error can't accumulate across
+  laps. The dash keys off the rising edge, not the absolute value, so staleness
+  nulls between laps are harmless.
 
 ## Payload format
 
@@ -56,4 +77,8 @@ mosquitto_pub -h 18.191.225.118 -t "lhre/dash/lapDelta" -m "-0.45"
 mosquitto_pub -h 18.191.225.118 -t "lhre/dash/lapDelta" -m "-0.45"
 mosquitto_pub -h 18.191.225.118 -t "lhre/dash/energyDelta" -m "3.2"
 mosquitto_pub -h 18.191.225.118 -t "lhre/dash/lapsRemaining" -m "15.3"
+
+# Endurance pacing: set a 32 kW budget, then trigger a lap card:
+mosquitto_pub -h 18.191.225.118 -t "lhre/dash/targetPower" -m "32"
+mosquitto_pub -h 18.191.225.118 -t "lhre/dash/lapTrigger" -m "1"
 ```

--- a/BEVO/dashd/MQTT_CONTRACT.md
+++ b/BEVO/dashd/MQTT_CONTRACT.md
@@ -19,6 +19,7 @@ its data shown on the driver's dashboard in real time.
 | `lhre/dash/lapsRemaining`  | JSON number    | laps (fractional) | `15.3`   |
 | `lhre/dash/targetPower`    | JSON number    | kW                | `32`     |
 | `lhre/dash/lapTrigger`     | JSON number    | monotonic counter | `7`      |
+| `lhre/dash/sfGate`         | JSON `[f64;4]` | `[lat1,lon1,lat2,lon2]` | `[30.39,-97.72,30.39,-97.73]` |
 
 ### Endurance pacing signals
 
@@ -31,13 +32,22 @@ two control values come off-car:
 - **`targetPower`** — the live power budget (kW) the strategist dials in. The
   dash integrates real power against `targetPower * elapsed` per lap; the
   top energy bar runs green while under budget and red while over. It's a
-  set-point, so the sender **republishes it ~1 Hz** to beat the 5 s staleness
-  null (below).
+  set-point, so the sender **republishes it ~1 Hz**. Unlike the other fields it
+  is **held last-known on the dash across a dropout** (not nulled): instead the
+  dash emits `targetPowerStale: true` to the frontend, which dims the bar and
+  shows a "STALE" badge — a held budget beats a blank one for the driver.
 - **`lapTrigger`** — a monotonically increasing lap counter. On each **increase**
   the dash pops a full-screen lap card (lap time + energy used that lap) and
   resets the per-lap energy integrator, so pacing error can't accumulate across
-  laps. The dash keys off the rising edge, not the absolute value, so staleness
-  nulls between laps are harmless.
+  laps. The dash keys off the rising edge, not the absolute value. This is now a
+  **fallback/override**: when an `sfGate` is loaded the car counts its own laps.
+- **`sfGate`** — the start/finish line as `[lat1, lon1, lat2, lon2]`, published
+  **retained, QoS 1** from the Dash tab's "Push S/F to car" button (sourced from
+  the Track Builder gate). Once loaded, dashd watches `dynamics.gps` and bumps
+  the lap counter when the car's path crosses the line — so **the per-lap reset
+  no longer depends on the link at all.** The gate is cached to disk
+  (`DASHD_SFGATE_PATH`, default `/tmp/BEVO_dash_sfgate.json`) so it also survives
+  a reboot if the broker drops its retained copy.
 
 ## Payload format
 

--- a/BEVO/dashd/MQTT_CONTRACT.md
+++ b/BEVO/dashd/MQTT_CONTRACT.md
@@ -41,6 +41,19 @@ two control values come off-car:
   resets the per-lap energy integrator, so pacing error can't accumulate across
   laps. The dash keys off the rising edge, not the absolute value. This is now a
   **fallback/override**: when an `sfGate` is loaded the car counts its own laps.
+**Reverse channel (dash → trackside).** dashd also *publishes* so the strategist
+can confirm the uplink and mirror the driver's screen:
+
+- **`lhre/dash/state`** — JSON snapshot at ~2 Hz of what the driver sees (speed,
+  power, soc, temperature, lap count, and the on-car pacing: `lapEnergyWh`,
+  `budgetDeltaWh`, `lapNumber`, last-lap time/energy). The Dash tab renders this
+  as a live mirror; if it goes silent for >3 s the panel flags the uplink down.
+- **`lhre/dash/ack/{targetPower,lapTrigger,sfGate}`** — retained echoes published
+  the moment dashd ingests each control, so trackside sees "the car heard 32 kW
+  2 s ago" rather than just "I sent it." Energy integration is authoritative
+  on-car (survives a chromium reload), so these are the same numbers, not a
+  re-derivation.
+
 - **`sfGate`** — the start/finish line as `[lat1, lon1, lat2, lon2]`, published
   **retained, QoS 1** from the Dash tab's "Push S/F to car" button (sourced from
   the Track Builder gate). Once loaded, dashd watches `dynamics.gps` and bumps

--- a/BEVO/dashd/deploy/launch_kiosk.sh
+++ b/BEVO/dashd/deploy/launch_kiosk.sh
@@ -37,23 +37,38 @@ done
 #                          so this can be omitted there, but launching by
 #                          hand from SSH (where DISPLAY/WAYLAND_DISPLAY
 #                          weren't set up the same way) needs it explicit.
+CHROMIUM_BIN=""
 for bin in chromium-browser chromium; do
     if command -v "$bin" >/dev/null 2>&1; then
-        exec "$bin" \
-            --kiosk \
-            --incognito \
-            --ozone-platform=wayland \
-            --noerrdialogs \
-            --disable-restore-session-state \
-            --disable-infobars \
-            --disable-translate \
-            --disable-features=TranslateUI \
-            --check-for-update-interval=604800 \
-            --overscroll-history-navigation=0 \
-            --password-store=basic \
-            "$URL"
+        CHROMIUM_BIN="$bin"
+        break
     fi
 done
 
-echo "[BEVO] No chromium binary found (tried: chromium-browser, chromium)" >&2
-exit 1
+if [[ -z "$CHROMIUM_BIN" ]]; then
+    echo "[BEVO] No chromium binary found (tried: chromium-browser, chromium)" >&2
+    exit 1
+fi
+
+# Supervise the kiosk: a renderer/GPU crash or OOM kill must NOT leave a blank
+# dash for the rest of an endurance run. dashd and the static server already
+# auto-restart via systemd, but the browser did not until this loop — XDG
+# autostart launches it once and never again. Relaunch on exit with a short
+# backoff. `|| true` keeps `set -e` from aborting the loop on a nonzero exit.
+while true; do
+    "$CHROMIUM_BIN" \
+        --kiosk \
+        --incognito \
+        --ozone-platform=wayland \
+        --noerrdialogs \
+        --disable-restore-session-state \
+        --disable-infobars \
+        --disable-translate \
+        --disable-features=TranslateUI \
+        --check-for-update-interval=604800 \
+        --overscroll-history-navigation=0 \
+        --password-store=basic \
+        "$URL" || true
+    echo "[BEVO] Chromium kiosk exited; relaunching in 2s" >&2
+    sleep 2
+done

--- a/BEVO/dashd/frontend/src/hooks/useDemoData.ts
+++ b/BEVO/dashd/frontend/src/hooks/useDemoData.ts
@@ -246,6 +246,7 @@ export function useDemoData(enabled: boolean): DashMessage | null {
                     currentLapTime,
                     lapDeltaRate,
                     targetPower,
+                    targetPowerStale: false,
                     lapTrigger: a.lapTrigger,
                 },
             });

--- a/BEVO/dashd/frontend/src/hooks/useDemoData.ts
+++ b/BEVO/dashd/frontend/src/hooks/useDemoData.ts
@@ -36,6 +36,11 @@ export function useDemoData(enabled: boolean): DashMessage | null {
         lastLap: 78.45,
         currentLapStart: Date.now(),
         lapTarget: 75 + Math.random() * 8,
+
+        // Endurance pacing demo state. lapTrigger is bumped each time the demo
+        // lap timer rolls over, so the on-dash lap card + per-lap energy reset
+        // are exercised. targetPower is a steady budget the bar paces against.
+        lapTrigger: 0,
     });
 
     useEffect(() => {
@@ -133,9 +138,14 @@ export function useDemoData(enabled: boolean): DashMessage | null {
                 if (elapsed < a.bestLap) a.bestLap = elapsed;
                 a.currentLapStart = Date.now();
                 a.lapTarget = 75 + Math.random() * 8;
+                a.lapTrigger += 1; // fire the on-dash lap card + per-lap reset
                 elapsed = 0;
             }
             const currentLapTime = elapsed;
+
+            // Steady endurance power budget for the energy-bar demo (kW). The
+            // bar drifts green/red as the simulated power runs under/over this.
+            const targetPower = 32;
 
             // Brake bias: slow drift around 55%, range ~52–58%.
             const brakeBias = 55 + Math.sin(Date.now() / 5000) * 3;
@@ -235,6 +245,8 @@ export function useDemoData(enabled: boolean): DashMessage | null {
                     lastLapTime: a.lastLap,
                     currentLapTime,
                     lapDeltaRate,
+                    targetPower,
+                    lapTrigger: a.lapTrigger,
                 },
             });
         }, 100);

--- a/BEVO/dashd/frontend/src/hooks/useDemoData.ts
+++ b/BEVO/dashd/frontend/src/hooks/useDemoData.ts
@@ -37,10 +37,14 @@ export function useDemoData(enabled: boolean): DashMessage | null {
         currentLapStart: Date.now(),
         lapTarget: 75 + Math.random() * 8,
 
-        // Endurance pacing demo state. lapTrigger is bumped each time the demo
-        // lap timer rolls over, so the on-dash lap card + per-lap energy reset
-        // are exercised. targetPower is a steady budget the bar paces against.
+        // Endurance pacing demo state. Mirrors what dashd computes on-car so the
+        // bar + lap card render in demo mode. lapTrigger is bumped each lap.
         lapTrigger: 0,
+        lapEnergyWh: 0,
+        lapBudgetWh: 0,
+        lastLapNum: null as number | null,
+        lastLapTimeS: null as number | null,
+        lastLapEnergyWh: null as number | null,
     });
 
     useEffect(() => {
@@ -90,6 +94,14 @@ export function useDemoData(enabled: boolean): DashMessage | null {
             s.speed = Math.max(0, Math.min(s.speed, 99));
             const clampedPower = Math.min(Math.max(newPower, -80), 80);
 
+            // Endurance power budget for the energy-bar demo (kW). The bar
+            // drifts green/red as the simulated power runs under/over this.
+            const targetPower = 32;
+            // Integrate per-lap energy + budget at the 100 ms tick (Wh = kW*dt/3.6),
+            // mirroring dashd's on-car integration.
+            a.lapEnergyWh += (clampedPower * 0.1) / 3.6;
+            a.lapBudgetWh += (targetPower * 0.1) / 3.6;
+
             // Accumulate derived values
             a.charge = Math.max(0, a.charge - (newPower > 0 ? 0.005 : -0.001));
 
@@ -136,16 +148,18 @@ export function useDemoData(enabled: boolean): DashMessage | null {
             if (elapsed >= a.lapTarget) {
                 a.lastLap = elapsed;
                 if (elapsed < a.bestLap) a.bestLap = elapsed;
+                a.lapTrigger += 1; // fire the on-dash lap card + per-lap reset
+                // Snapshot the just-finished lap, then reset the integrators.
+                a.lastLapNum = a.lapTrigger;
+                a.lastLapTimeS = elapsed;
+                a.lastLapEnergyWh = a.lapEnergyWh;
+                a.lapEnergyWh = 0;
+                a.lapBudgetWh = 0;
                 a.currentLapStart = Date.now();
                 a.lapTarget = 75 + Math.random() * 8;
-                a.lapTrigger += 1; // fire the on-dash lap card + per-lap reset
                 elapsed = 0;
             }
             const currentLapTime = elapsed;
-
-            // Steady endurance power budget for the energy-bar demo (kW). The
-            // bar drifts green/red as the simulated power runs under/over this.
-            const targetPower = 32;
 
             // Brake bias: slow drift around 55%, range ~52–58%.
             const brakeBias = 55 + Math.sin(Date.now() / 5000) * 3;
@@ -248,6 +262,15 @@ export function useDemoData(enabled: boolean): DashMessage | null {
                     targetPower,
                     targetPowerStale: false,
                     lapTrigger: a.lapTrigger,
+                },
+                pacing: {
+                    lapEnergyWh: a.lapEnergyWh,
+                    budgetDeltaWh: a.lapEnergyWh - a.lapBudgetWh,
+                    lapElapsedS: currentLapTime,
+                    lapNumber: a.lapTrigger + 1,
+                    lastLapNumber: a.lastLapNum,
+                    lastLapTimeS: a.lastLapTimeS,
+                    lastLapEnergyWh: a.lastLapEnergyWh,
                 },
             });
         }, 100);

--- a/BEVO/dashd/frontend/src/hooks/useEnergyPacing.ts
+++ b/BEVO/dashd/frontend/src/hooks/useEnergyPacing.ts
@@ -1,144 +1,74 @@
 import { useEffect, useRef, useState } from 'react';
 import { DashMessage } from '../types/DashData';
 
-// Endurance energy pacing, computed entirely on-dash from the live CAN power
-// stream plus two off-car signals (see BEVO/dashd/MQTT_CONTRACT.md):
+// Endurance energy pacing. The integration + lap detection now live on-car in
+// dashd (BEVO/dashd/main.rs), so this hook is a thin consumer: it reads the
+// authoritative pacing snapshot and only owns the transient full-screen lap
+// card (show on each newly-completed lap, auto-clear after a few seconds).
 //
-//   - mqtt.targetPower (kW): the live power budget the trackside strategist
-//     dials in. The dash integrates it over the same time steps it integrates
-//     real power, so the comparison is apples-to-apples even across stalls.
-//   - mqtt.lapTrigger (monotonic counter): bumped once per lap. Its rising
-//     edge closes the current lap (snapshotting time + energy for the lap
-//     card) and resets the per-lap integrators — so error can't accumulate
-//     across laps (the per-lap reset Andrew asked for).
-//
-// Energy is integrated as Wh += power(kW) * dt(s) / 3.6, matching the
-// trackside exporter's convention. Regen (negative power) credits back
-// automatically.
+// Why on-car: a chromium reload mid-endurance would otherwise zero the lap
+// integrator, and the trackside mirror reads the exact same numbers dashd
+// publishes to `lhre/dash/state`.
 
-// Ignore frame gaps longer than this when integrating — a stall (tab
-// backgrounded, WS hiccup) shouldn't dump a huge slug of phantom energy.
-const MAX_FRAME_DT_S = 0.5;
-
-// How long the full-screen lap card stays up after a lap trigger.
+// How long the full-screen lap card stays up after a lap completes.
 export const LAP_CARD_MS = 5000;
 
 export interface LapSummary {
-    lapNumber: number;   // 1-based lap that just finished
-    timeS: number;       // wall-clock lap duration in seconds
-    energyWh: number;    // net energy used over the lap (drive minus regen)
+    lapNumber: number;   // the lap that just finished
+    timeS: number;       // its duration in seconds
+    energyWh: number;    // net energy used over the lap
 }
 
 export interface EnergyPacing {
-    // Live per-lap integrals (reset on each lap trigger).
     lapEnergyWh: number;
     lapElapsedS: number;
-
-    // used - budget for the current lap, in Wh. Positive = over budget (red),
-    // negative = under budget / banking margin (green). null until a
-    // targetPower signal is present.
-    budgetDeltaWh: number | null;
+    budgetDeltaWh: number | null;  // >0 over budget (red), <0 under (green), null until a target is set
     targetPowerKw: number | null;
-
-    // 1-based number of the lap currently in progress.
-    lapNumber: number;
-
-    // The most recently completed lap, shown full-screen until cardUntilMs.
-    // null once the card has timed out.
-    lapCard: LapSummary | null;
+    lapNumber: number;             // 1-based lap in progress
+    lapCard: LapSummary | null;    // the most recent completed lap, shown briefly
 }
 
-const EMPTY: EnergyPacing = {
-    lapEnergyWh: 0,
-    lapElapsedS: 0,
-    budgetDeltaWh: null,
-    targetPowerKw: null,
-    lapNumber: 1,
-    lapCard: null,
-};
-
 export function useEnergyPacing(data: DashMessage | null): EnergyPacing {
-    const [pacing, setPacing] = useState<EnergyPacing>(EMPTY);
+    const [lapCard, setLapCard] = useState<LapSummary | null>(null);
+    // Highest completed-lap number we've already reacted to. Seeded on first
+    // sight so a reload mid-session doesn't pop a card for an old lap.
+    const lastShownLap = useRef<number | null>(null);
 
-    // Integration state lives in refs so 30 Hz frames don't thrash React.
-    const lastSeq = useRef<number>(-1);
-    const lastFrameMs = useRef<number | null>(null);
-    const lapStartMs = useRef<number>(Date.now());
-    const lapEnergyWh = useRef<number>(0);
-    const lapBudgetWh = useRef<number>(0);
-    const lapNumber = useRef<number>(1);
-    const lastLapTrigger = useRef<number | null>(null);
-    const cardUntilMs = useRef<number>(0);
-    const lastCard = useRef<LapSummary | null>(null);
+    const pacing = data?.pacing;
+    const lastLapNumber = pacing?.lastLapNumber ?? null;
+    const lastLapTimeS = pacing?.lastLapTimeS ?? null;
+    const lastLapEnergyWh = pacing?.lastLapEnergyWh ?? null;
 
     useEffect(() => {
-        if (!data) return;
-        // Only act on genuinely new frames (the WS hook re-renders on other
-        // state too); seq is monotonic per dashd connection.
-        if (data.seq === lastSeq.current) return;
-        lastSeq.current = data.seq;
-
-        const now = Date.now();
-        const power = data.can.power;
-        const targetPower = data.mqtt.targetPower ?? null;
-        const lapTrigger = data.mqtt.lapTrigger ?? null;
-
-        // --- Integrate energy + budget over this frame ---
-        if (lastFrameMs.current !== null && typeof power === 'number') {
-            const dt = Math.min(MAX_FRAME_DT_S, (now - lastFrameMs.current) / 1000);
-            if (dt > 0) {
-                lapEnergyWh.current += (power * dt) / 3.6;
-                if (typeof targetPower === 'number') {
-                    lapBudgetWh.current += (targetPower * dt) / 3.6;
-                }
-            }
+        if (lastLapNumber === null) return;
+        // First observation just sets the baseline (no card).
+        if (lastShownLap.current === null) {
+            lastShownLap.current = lastLapNumber;
+            return;
         }
-        lastFrameMs.current = now;
-
-        // --- Lap trigger: rising edge closes the lap ---
-        // Initialise the baseline on first sight without firing, so a stale
-        // value already on the broker at startup doesn't pop a phantom card.
-        if (typeof lapTrigger === 'number') {
-            if (lastLapTrigger.current === null) {
-                lastLapTrigger.current = lapTrigger;
-            } else if (lapTrigger > lastLapTrigger.current) {
-                lastLapTrigger.current = lapTrigger;
-                const summary: LapSummary = {
-                    lapNumber: lapNumber.current,
-                    timeS: (now - lapStartMs.current) / 1000,
-                    energyWh: lapEnergyWh.current,
-                };
-                lastCard.current = summary;
-                cardUntilMs.current = now + LAP_CARD_MS;
-                // Reset per-lap integrators for the new lap.
-                lapNumber.current += 1;
-                lapStartMs.current = now;
-                lapEnergyWh.current = 0;
-                lapBudgetWh.current = 0;
-            }
+        if (lastLapNumber > lastShownLap.current) {
+            lastShownLap.current = lastLapNumber;
+            setLapCard({
+                lapNumber: lastLapNumber,
+                timeS: lastLapTimeS ?? 0,
+                energyWh: lastLapEnergyWh ?? 0,
+            });
         }
+    }, [lastLapNumber, lastLapTimeS, lastLapEnergyWh]);
 
-        const card = now < cardUntilMs.current ? lastCard.current : null;
-
-        setPacing({
-            lapEnergyWh: lapEnergyWh.current,
-            lapElapsedS: (now - lapStartMs.current) / 1000,
-            budgetDeltaWh: targetPower === null ? null : lapEnergyWh.current - lapBudgetWh.current,
-            targetPowerKw: targetPower,
-            lapNumber: lapNumber.current,
-            lapCard: card,
-        });
-    }, [data]);
-
-    // Tick the card down even when no new frames arrive, so it always clears.
+    // Auto-clear the card after LAP_CARD_MS.
     useEffect(() => {
-        if (!pacing.lapCard) return;
-        const id = window.setTimeout(
-            () => setPacing((p) => (Date.now() >= cardUntilMs.current ? { ...p, lapCard: null } : p)),
-            LAP_CARD_MS,
-        );
+        if (!lapCard) return;
+        const id = window.setTimeout(() => setLapCard(null), LAP_CARD_MS);
         return () => window.clearTimeout(id);
-    }, [pacing.lapCard]);
+    }, [lapCard]);
 
-    return pacing;
+    return {
+        lapEnergyWh: pacing?.lapEnergyWh ?? 0,
+        lapElapsedS: pacing?.lapElapsedS ?? 0,
+        budgetDeltaWh: pacing?.budgetDeltaWh ?? null,
+        targetPowerKw: data?.mqtt.targetPower ?? null,
+        lapNumber: pacing?.lapNumber ?? 1,
+        lapCard,
+    };
 }

--- a/BEVO/dashd/frontend/src/hooks/useEnergyPacing.ts
+++ b/BEVO/dashd/frontend/src/hooks/useEnergyPacing.ts
@@ -1,0 +1,144 @@
+import { useEffect, useRef, useState } from 'react';
+import { DashMessage } from '../types/DashData';
+
+// Endurance energy pacing, computed entirely on-dash from the live CAN power
+// stream plus two off-car signals (see BEVO/dashd/MQTT_CONTRACT.md):
+//
+//   - mqtt.targetPower (kW): the live power budget the trackside strategist
+//     dials in. The dash integrates it over the same time steps it integrates
+//     real power, so the comparison is apples-to-apples even across stalls.
+//   - mqtt.lapTrigger (monotonic counter): bumped once per lap. Its rising
+//     edge closes the current lap (snapshotting time + energy for the lap
+//     card) and resets the per-lap integrators — so error can't accumulate
+//     across laps (the per-lap reset Andrew asked for).
+//
+// Energy is integrated as Wh += power(kW) * dt(s) / 3.6, matching the
+// trackside exporter's convention. Regen (negative power) credits back
+// automatically.
+
+// Ignore frame gaps longer than this when integrating — a stall (tab
+// backgrounded, WS hiccup) shouldn't dump a huge slug of phantom energy.
+const MAX_FRAME_DT_S = 0.5;
+
+// How long the full-screen lap card stays up after a lap trigger.
+export const LAP_CARD_MS = 5000;
+
+export interface LapSummary {
+    lapNumber: number;   // 1-based lap that just finished
+    timeS: number;       // wall-clock lap duration in seconds
+    energyWh: number;    // net energy used over the lap (drive minus regen)
+}
+
+export interface EnergyPacing {
+    // Live per-lap integrals (reset on each lap trigger).
+    lapEnergyWh: number;
+    lapElapsedS: number;
+
+    // used - budget for the current lap, in Wh. Positive = over budget (red),
+    // negative = under budget / banking margin (green). null until a
+    // targetPower signal is present.
+    budgetDeltaWh: number | null;
+    targetPowerKw: number | null;
+
+    // 1-based number of the lap currently in progress.
+    lapNumber: number;
+
+    // The most recently completed lap, shown full-screen until cardUntilMs.
+    // null once the card has timed out.
+    lapCard: LapSummary | null;
+}
+
+const EMPTY: EnergyPacing = {
+    lapEnergyWh: 0,
+    lapElapsedS: 0,
+    budgetDeltaWh: null,
+    targetPowerKw: null,
+    lapNumber: 1,
+    lapCard: null,
+};
+
+export function useEnergyPacing(data: DashMessage | null): EnergyPacing {
+    const [pacing, setPacing] = useState<EnergyPacing>(EMPTY);
+
+    // Integration state lives in refs so 30 Hz frames don't thrash React.
+    const lastSeq = useRef<number>(-1);
+    const lastFrameMs = useRef<number | null>(null);
+    const lapStartMs = useRef<number>(Date.now());
+    const lapEnergyWh = useRef<number>(0);
+    const lapBudgetWh = useRef<number>(0);
+    const lapNumber = useRef<number>(1);
+    const lastLapTrigger = useRef<number | null>(null);
+    const cardUntilMs = useRef<number>(0);
+    const lastCard = useRef<LapSummary | null>(null);
+
+    useEffect(() => {
+        if (!data) return;
+        // Only act on genuinely new frames (the WS hook re-renders on other
+        // state too); seq is monotonic per dashd connection.
+        if (data.seq === lastSeq.current) return;
+        lastSeq.current = data.seq;
+
+        const now = Date.now();
+        const power = data.can.power;
+        const targetPower = data.mqtt.targetPower ?? null;
+        const lapTrigger = data.mqtt.lapTrigger ?? null;
+
+        // --- Integrate energy + budget over this frame ---
+        if (lastFrameMs.current !== null && typeof power === 'number') {
+            const dt = Math.min(MAX_FRAME_DT_S, (now - lastFrameMs.current) / 1000);
+            if (dt > 0) {
+                lapEnergyWh.current += (power * dt) / 3.6;
+                if (typeof targetPower === 'number') {
+                    lapBudgetWh.current += (targetPower * dt) / 3.6;
+                }
+            }
+        }
+        lastFrameMs.current = now;
+
+        // --- Lap trigger: rising edge closes the lap ---
+        // Initialise the baseline on first sight without firing, so a stale
+        // value already on the broker at startup doesn't pop a phantom card.
+        if (typeof lapTrigger === 'number') {
+            if (lastLapTrigger.current === null) {
+                lastLapTrigger.current = lapTrigger;
+            } else if (lapTrigger > lastLapTrigger.current) {
+                lastLapTrigger.current = lapTrigger;
+                const summary: LapSummary = {
+                    lapNumber: lapNumber.current,
+                    timeS: (now - lapStartMs.current) / 1000,
+                    energyWh: lapEnergyWh.current,
+                };
+                lastCard.current = summary;
+                cardUntilMs.current = now + LAP_CARD_MS;
+                // Reset per-lap integrators for the new lap.
+                lapNumber.current += 1;
+                lapStartMs.current = now;
+                lapEnergyWh.current = 0;
+                lapBudgetWh.current = 0;
+            }
+        }
+
+        const card = now < cardUntilMs.current ? lastCard.current : null;
+
+        setPacing({
+            lapEnergyWh: lapEnergyWh.current,
+            lapElapsedS: (now - lapStartMs.current) / 1000,
+            budgetDeltaWh: targetPower === null ? null : lapEnergyWh.current - lapBudgetWh.current,
+            targetPowerKw: targetPower,
+            lapNumber: lapNumber.current,
+            lapCard: card,
+        });
+    }, [data]);
+
+    // Tick the card down even when no new frames arrive, so it always clears.
+    useEffect(() => {
+        if (!pacing.lapCard) return;
+        const id = window.setTimeout(
+            () => setPacing((p) => (Date.now() >= cardUntilMs.current ? { ...p, lapCard: null } : p)),
+            LAP_CARD_MS,
+        );
+        return () => window.clearTimeout(id);
+    }, [pacing.lapCard]);
+
+    return pacing;
+}

--- a/BEVO/dashd/frontend/src/screens/ScreenOne.tsx
+++ b/BEVO/dashd/frontend/src/screens/ScreenOne.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ConnectivityIndicator from '../components/ConnectivityIndicator';
 import { useDash } from '../context/DashContext';
+import { useEnergyPacing } from '../hooks/useEnergyPacing';
 import './ScreenOne.css';
 
 // Screen One: Main Dashboard (Modern EV Style)
@@ -8,6 +9,14 @@ import './ScreenOne.css';
 
 const ScreenOne: React.FC = () => {
     const { data } = useDash();
+
+    // Endurance energy pacing: integrates CAN power on-board against the
+    // trackside-set targetPower budget, resets each lap on lapTrigger, and
+    // surfaces a full-screen lap card when a lap closes. See useEnergyPacing.
+    const pacing = useEnergyPacing(data);
+    // ±Wh that pegs the energy-budget bar end-to-end. A lap is a few hundred
+    // Wh, so ~150 Wh of margin/overage is a meaningful full-scale deflection.
+    const ENERGY_DELTA_MAX_WH = 150;
 
     // Extract values with null fallback
     const speed = data?.can.speed;
@@ -313,12 +322,74 @@ const ScreenOne: React.FC = () => {
                 </div>
             </div>
 
-            {/* Inner square: 2-row grid spanning between sidebars and trays.
-                Top row splits into Speed (left) + Lap-stuff table (right).
-                Bottom row hosts the big bidirectional power bar + readouts. */}
+            {/* Endurance energy-budget bar — sits at the top of the driving
+                area, between the temp/SOC sidebars. Center-zero like the power
+                and s/s bars: green grows left when banking margin (under the
+                trackside power budget), red grows right when over. Resets each
+                lap via lapTrigger. The reference rate is the live targetPower
+                the strategist dials in on the trackside Dash tab. */}
             <div style={{
                 position: 'absolute',
-                top: '60px',
+                top: '64px',
+                left: '90px',
+                right: '90px',
+                height: '24px',
+                zIndex: 100,
+                display: 'flex',
+                alignItems: 'center',
+                gap: '10px',
+                padding: '0 20px'
+            }}>
+                <span className="label-small" style={{ marginBottom: 0, flexShrink: 0 }}>NRG</span>
+                <div style={{ flex: 1, height: '22px', background: 'var(--bar-track)', borderRadius: '4px', position: 'relative', overflow: 'hidden' }}>
+                    {/* Zero marker (dead center) */}
+                    <div style={{ position: 'absolute', left: '50%', top: 0, bottom: 0, width: '2px', background: 'var(--bar-center)', transform: 'translateX(-50%)', zIndex: 2 }} />
+                    {/* Fill — green left = under budget, red right = over budget */}
+                    {pacing.budgetDeltaWh !== null && (
+                        <div style={{
+                            position: 'absolute',
+                            top: 0, bottom: 0,
+                            left: pacing.budgetDeltaWh < 0
+                                ? `${50 - (Math.min(Math.abs(pacing.budgetDeltaWh), ENERGY_DELTA_MAX_WH) / ENERGY_DELTA_MAX_WH) * 50}%`
+                                : '50%',
+                            width: `${(Math.min(Math.abs(pacing.budgetDeltaWh), ENERGY_DELTA_MAX_WH) / ENERGY_DELTA_MAX_WH) * 50}%`,
+                            background: pacing.budgetDeltaWh < 0
+                                ? 'linear-gradient(to right, #00CC00, #00FF66)'
+                                : 'linear-gradient(to left, #FF3333, #FF6600)',
+                            transition: 'all 0.2s linear'
+                        }} />
+                    )}
+                </div>
+                {/* Right: target power + signed Wh delta (fixed width, no shift) */}
+                <span className="value-display" style={{
+                    fontSize: '1.1rem',
+                    fontWeight: 'bold',
+                    lineHeight: 1,
+                    minWidth: '128px',
+                    textAlign: 'right',
+                    color: pacing.budgetDeltaWh === null
+                        ? 'var(--fg-muted)'
+                        : pacing.budgetDeltaWh < 0 ? '#00FF66' : '#FF3333',
+                    whiteSpace: 'nowrap'
+                }}>
+                    {pacing.targetPowerKw === null ? '-- kW' : `${pacing.targetPowerKw.toFixed(0)} kW`}
+                    {pacing.budgetDeltaWh !== null && (
+                        <span style={{ marginLeft: '8px' }}>
+                            {pacing.budgetDeltaWh > 0 ? '+' : pacing.budgetDeltaWh < 0 ? '-' : ''}
+                            {Math.abs(pacing.budgetDeltaWh).toFixed(0)}
+                            <span className="label-small" style={{ fontSize: '0.7rem', marginLeft: '2px' }}>Wh</span>
+                        </span>
+                    )}
+                </span>
+            </div>
+
+            {/* Inner square: 2-row grid spanning between sidebars and trays.
+                Top row splits into Speed (left) + Lap-stuff table (right).
+                Bottom row hosts the big bidirectional power bar + readouts.
+                Top pushed to 92px to clear the energy-budget bar above. */}
+            <div style={{
+                position: 'absolute',
+                top: '92px',
                 bottom: '80px',
                 left: '90px',
                 right: '90px',
@@ -676,6 +747,36 @@ const ScreenOne: React.FC = () => {
                     <ConnectivityIndicator />
                 </div>
             </div>
+
+            {/* Full-screen lap card — pops on each lapTrigger crossing and
+                clears itself after a few seconds (LAP_CARD_MS in the hook).
+                Shows the just-finished lap's time and net energy so the driver
+                gets a clear glance as they cross start/finish. */}
+            {pacing.lapCard && (
+                <div style={{
+                    position: 'absolute',
+                    inset: 0,
+                    zIndex: 1000,
+                    background: 'rgba(8,8,10,0.92)',
+                    backdropFilter: 'blur(6px)',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    gap: '8px'
+                }}>
+                    <div className="label-small" style={{ fontSize: '1.4rem', letterSpacing: '8px', color: '#BF5700' }}>
+                        LAP {pacing.lapCard.lapNumber}
+                    </div>
+                    <div className="value-display" style={{ fontSize: '7rem', fontWeight: 'bold', lineHeight: 0.9 }}>
+                        {fmtLapTime(pacing.lapCard.timeS)}
+                    </div>
+                    <div className="value-display" style={{ fontSize: '3rem', fontWeight: 'bold', color: 'var(--fg-secondary)', lineHeight: 1 }}>
+                        {Math.round(pacing.lapCard.energyWh)}
+                        <span className="label-small" style={{ fontSize: '1.1rem', marginLeft: '8px' }}>Wh / LAP</span>
+                    </div>
+                </div>
+            )}
         </div>
     );
 };

--- a/BEVO/dashd/frontend/src/screens/ScreenOne.tsx
+++ b/BEVO/dashd/frontend/src/screens/ScreenOne.tsx
@@ -14,6 +14,9 @@ const ScreenOne: React.FC = () => {
     // trackside-set targetPower budget, resets each lap on lapTrigger, and
     // surfaces a full-screen lap card when a lap closes. See useEnergyPacing.
     const pacing = useEnergyPacing(data);
+    // Budget held last-known across a dropout — dim it + badge it so the driver
+    // knows it's no longer live rather than trusting a frozen number.
+    const targetPowerStale = data?.mqtt.targetPowerStale ?? false;
     // ±Wh that pegs the energy-budget bar end-to-end. A lap is a few hundred
     // Wh, so ~150 Wh of margin/overage is a meaningful full-scale deflection.
     const ENERGY_DELTA_MAX_WH = 150;
@@ -341,7 +344,7 @@ const ScreenOne: React.FC = () => {
                 padding: '0 20px'
             }}>
                 <span className="label-small" style={{ marginBottom: 0, flexShrink: 0 }}>NRG</span>
-                <div style={{ flex: 1, height: '22px', background: 'var(--bar-track)', borderRadius: '4px', position: 'relative', overflow: 'hidden' }}>
+                <div style={{ flex: 1, height: '22px', background: 'var(--bar-track)', borderRadius: '4px', position: 'relative', overflow: 'hidden', opacity: targetPowerStale ? 0.4 : 1 }}>
                     {/* Zero marker (dead center) */}
                     <div style={{ position: 'absolute', left: '50%', top: 0, bottom: 0, width: '2px', background: 'var(--bar-center)', transform: 'translateX(-50%)', zIndex: 2 }} />
                     {/* Fill — green left = under budget, red right = over budget */}
@@ -367,11 +370,16 @@ const ScreenOne: React.FC = () => {
                     lineHeight: 1,
                     minWidth: '128px',
                     textAlign: 'right',
-                    color: pacing.budgetDeltaWh === null
+                    color: targetPowerStale
                         ? 'var(--fg-muted)'
-                        : pacing.budgetDeltaWh < 0 ? '#00FF66' : '#FF3333',
+                        : pacing.budgetDeltaWh === null
+                            ? 'var(--fg-muted)'
+                            : pacing.budgetDeltaWh < 0 ? '#00FF66' : '#FF3333',
                     whiteSpace: 'nowrap'
                 }}>
+                    {targetPowerStale && (
+                        <span className="label-small" style={{ fontSize: '0.6rem', color: '#FF6600', marginRight: '6px', letterSpacing: '1px' }}>STALE</span>
+                    )}
                     {pacing.targetPowerKw === null ? '-- kW' : `${pacing.targetPowerKw.toFixed(0)} kW`}
                     {pacing.budgetDeltaWh !== null && (
                         <span style={{ marginLeft: '8px' }}>

--- a/BEVO/dashd/frontend/src/types/DashData.ts
+++ b/BEVO/dashd/frontend/src/types/DashData.ts
@@ -68,6 +68,14 @@ export interface MqttData {
     energyDelta: number | null;     // Energy delta vs target in Wh
     lapsRemaining: number | null;   // Estimated session laps remaining
 
+    // Endurance pacing signals from the trackside "Dash" sender tab
+    // (BEVO/dashd/MQTT_CONTRACT.md). targetPower is the live power budget the
+    // strategist dials in; lapTrigger is a monotonic counter bumped each lap.
+    // The dash integrates CAN power on-board against targetPower to drive the
+    // energy-budget bar, and fires the lap card when lapTrigger increases.
+    targetPower?: number | null;    // kW — live target power budget
+    lapTrigger?: number | null;     // monotonic lap counter (rising edge = new lap)
+
     // Optional driver-thread additions. Not yet emitted by dashd; the
     // demo data hook provides synthetic values so the layout is testable.
     lapsRemainingEnergy?: number | null; // Energy-based laps remaining

--- a/BEVO/dashd/frontend/src/types/DashData.ts
+++ b/BEVO/dashd/frontend/src/types/DashData.ts
@@ -73,7 +73,8 @@ export interface MqttData {
     // strategist dials in; lapTrigger is a monotonic counter bumped each lap.
     // The dash integrates CAN power on-board against targetPower to drive the
     // energy-budget bar, and fires the lap card when lapTrigger increases.
-    targetPower?: number | null;    // kW — live target power budget
+    targetPower?: number | null;    // kW — live target power budget (held last-known)
+    targetPowerStale?: boolean | null; // true when the held targetPower is past staleness
     lapTrigger?: number | null;     // monotonic lap counter (rising edge = new lap)
 
     // Optional driver-thread additions. Not yet emitted by dashd; the

--- a/BEVO/dashd/frontend/src/types/DashData.ts
+++ b/BEVO/dashd/frontend/src/types/DashData.ts
@@ -86,10 +86,24 @@ export interface MqttData {
     lapDeltaRate?: number | null;        // d(lapDelta)/dt, s/s
 }
 
+// Endurance pacing, computed authoritatively on-car by dashd (see
+// useEnergyPacing + BEVO/dashd/main.rs PacingData). The frontend just displays
+// these — integrating here would reset the lap on a chromium reload.
+export interface PacingData {
+    lapEnergyWh: number;             // net energy used this lap (Wh)
+    budgetDeltaWh: number | null;    // used - budget; >0 over (red), <0 under (green)
+    lapElapsedS: number;             // seconds since the current lap started
+    lapNumber: number;               // 1-based lap in progress
+    lastLapNumber: number | null;    // most recently completed lap (drives the card)
+    lastLapTimeS: number | null;
+    lastLapEnergyWh: number | null;
+}
+
 export interface DashMessage {
     seq: number;
     can: CanData;
     mqtt: MqttData;
+    pacing: PacingData;
 }
 
 // Shutdown circuit / safety-fault items, in the order dashd emits them.

--- a/BEVO/dashd/main.rs
+++ b/BEVO/dashd/main.rs
@@ -183,14 +183,21 @@ struct MqttData {
 
     /// Live target power budget (kW) entered by the trackside team. The dash
     /// paces per-lap energy against this: expected_Wh = targetPower * elapsed.
-    /// Trackside republishes at ~1 Hz so it doesn't go stale between changes.
+    /// Held last-known across dropouts (NOT nulled on staleness) so a cellular
+    /// blip doesn't blank the driver's pacing reference — see target_power_stale.
     #[serde(rename = "targetPower")]
     target_power: Option<f32>,
 
-    /// Monotonic lap counter. Trackside bumps it each lap; the frontend fires
-    /// the full-screen lap card and resets the per-lap energy integrator when
-    /// the value increases. It's an event, not a reading, so the frontend keys
-    /// off changes rather than freshness.
+    /// True when the held targetPower is older than the staleness window, so
+    /// the frontend can dim it / show a "STALE" badge instead of pretending
+    /// it's live. None when there's no targetPower at all.
+    #[serde(rename = "targetPowerStale")]
+    target_power_stale: Option<bool>,
+
+    /// Monotonic lap counter (DashState.lap_count). Bumped by the on-car GPS
+    /// start/finish detector OR a trackside lapTrigger, whichever fires. The
+    /// frontend pops the lap card + resets the per-lap integrator on each
+    /// increase. Always emitted fresh — it's local state, not a network value.
     #[serde(rename = "lapTrigger")]
     lap_trigger: Option<f32>,
 }
@@ -211,12 +218,10 @@ struct MqttState {
     energy_delta: Option<f32>,
     laps_remaining: Option<f32>,
     target_power: Option<f32>,
-    lap_trigger: Option<f32>,
     last_lap_delta: Instant,
     last_energy_delta: Instant,
     last_laps_remaining: Instant,
     last_target_power: Instant,
-    last_lap_trigger: Instant,
 }
 
 impl MqttState {
@@ -227,18 +232,20 @@ impl MqttState {
             energy_delta: None,
             laps_remaining: None,
             target_power: None,
-            lap_trigger: None,
             last_lap_delta: epoch,
             last_energy_delta: epoch,
             last_laps_remaining: epoch,
             last_target_power: epoch,
-            last_lap_trigger: epoch,
         }
     }
 
-    /// Convert to the JSON-serializable MqttData, nulling out stale fields.
+    /// Convert to the JSON-serializable MqttData. Most fields null out once
+    /// stale; targetPower is the exception — it's held last-known (with a
+    /// staleness flag) so a dropout doesn't strip the driver's pacing
+    /// reference. lap_trigger is filled in by the WS sender from lap_count.
     fn to_mqtt_data(&self) -> MqttData {
         let now = Instant::now();
+        let target_power_age = now.duration_since(self.last_target_power);
         MqttData {
             lap_delta: self
                 .lap_delta
@@ -249,12 +256,13 @@ impl MqttState {
             laps_remaining: self
                 .laps_remaining
                 .filter(|_| now.duration_since(self.last_laps_remaining) < MQTT_STALE_TIMEOUT),
-            target_power: self
+            // Hold last-known; never null on staleness.
+            target_power: self.target_power,
+            target_power_stale: self
                 .target_power
-                .filter(|_| now.duration_since(self.last_target_power) < MQTT_STALE_TIMEOUT),
-            lap_trigger: self
-                .lap_trigger
-                .filter(|_| now.duration_since(self.last_lap_trigger) < MQTT_STALE_TIMEOUT),
+                .map(|_| target_power_age >= MQTT_STALE_TIMEOUT),
+            // Overwritten by the WS sender with lap_count.
+            lap_trigger: None,
         }
     }
 }
@@ -269,6 +277,76 @@ struct DashState {
     /// the bar doesn't twitch under load. None until first qualified read.
     last_qualified_soc: Option<f32>,
     mqtt: MqttState,
+
+    // ---- Endurance lap counting (link-independent) ----
+    /// Start/finish line as [lat1, lon1, lat2, lon2]. Loaded from the retained
+    /// `lhre/dash/sfGate` topic (and disk on boot). When present, the car
+    /// counts its own laps from GPS — no per-lap network dependency.
+    sf_gate: Option<[f64; 4]>,
+    /// Previous GPS fix (lat, lon), for segment-crossing detection.
+    last_gps: Option<(f64, f64)>,
+    /// Monotonic lap count — bumped by a GPS crossing or a trackside lapTrigger.
+    /// Emitted to the frontend as mqtt.lapTrigger.
+    lap_count: u64,
+    /// Last trackside lapTrigger value seen, for rising-edge detection.
+    last_offcar_trigger: Option<f32>,
+}
+
+// Path the loaded start/finish gate is cached to, so it survives a dashd or
+// car reboot even if the broker drops its retained copy. Override with
+// DASHD_SFGATE_PATH.
+const SFGATE_PATH: &str = "/tmp/BEVO_dash_sfgate.json";
+
+/// Does the car's path segment (prev->cur GPS) cross the gate line? Both car
+/// points are (lat, lon); the gate is [lat1, lon1, lat2, lon2]. Lat/lon are
+/// treated as a planar (x=lon, y=lat) frame — fine over a ~10 m gate. Returns
+/// true only on a proper crossing (segments strictly intersect).
+fn segments_cross(prev: (f64, f64), cur: (f64, f64), gate: [f64; 4]) -> bool {
+    // To (x=lon, y=lat).
+    let a = (prev.1, prev.0);
+    let b = (cur.1, cur.0);
+    let c = (gate[1], gate[0]);
+    let d = (gate[3], gate[2]);
+    // Signed area of triangle (p, q, r): >0 / <0 = r left / right of line pq.
+    let orient = |p: (f64, f64), q: (f64, f64), r: (f64, f64)| -> f64 {
+        (q.0 - p.0) * (r.1 - p.1) - (q.1 - p.1) * (r.0 - p.0)
+    };
+    let d1 = orient(c, d, a); // car-prev vs gate line
+    let d2 = orient(c, d, b); // car-cur  vs gate line
+    let d3 = orient(a, b, c); // gate-1   vs car path
+    let d4 = orient(a, b, d); // gate-2   vs car path
+    ((d1 > 0.0 && d2 < 0.0) || (d1 < 0.0 && d2 > 0.0))
+        && ((d3 > 0.0 && d4 < 0.0) || (d3 < 0.0 && d4 > 0.0))
+}
+
+fn sfgate_path() -> String {
+    env_or_default("DASHD_SFGATE_PATH", SFGATE_PATH)
+}
+
+/// Cache the gate to disk so it survives a dashd/car reboot even if the broker
+/// drops its retained copy (mosquitto without persistence).
+fn persist_sf_gate(gate: &[f64; 4]) {
+    match serde_json::to_string(gate) {
+        Ok(json) => {
+            if let Err(e) = std::fs::write(sfgate_path(), json) {
+                eprintln!("[DASHD] Failed to persist sfGate: {}", e);
+            }
+        }
+        Err(e) => eprintln!("[DASHD] Failed to serialize sfGate: {}", e),
+    }
+}
+
+/// Restore the last-known gate on boot, before the broker (re)delivers it.
+fn load_sf_gate() -> Option<[f64; 4]> {
+    let path = sfgate_path();
+    let data = std::fs::read_to_string(&path).ok()?;
+    match serde_json::from_str::<[f64; 4]>(data.trim()) {
+        Ok(gate) => {
+            println!("[DASHD] Restored start/finish gate from {}: {:?}", path, gate);
+            Some(gate)
+        }
+        Err(_) => None,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -446,10 +524,31 @@ fn ipc_reader_loop(state: Arc<Mutex<DashState>>) {
 
                     match OrionSensorData::decode(&msg_buf[..]) {
                         Ok(data) => {
+                            // GPS comes in dynamics.gps as [lat, lon] (cand NMEA).
+                            let gps = data
+                                .dynamics
+                                .as_ref()
+                                .filter(|d| d.gps.len() >= 2)
+                                .map(|d| (d.gps[0] as f64, d.gps[1] as f64))
+                                // (0,0) is the no-fix sentinel — ignore it.
+                                .filter(|&(lat, lon)| lat != 0.0 || lon != 0.0);
+
                             let mut locked = state.lock().unwrap();
                             let can_data = extract_can_data(&data, &mut locked.last_qualified_soc);
                             locked.can = can_data;
                             locked.last_can_update = Instant::now();
+
+                            // On-car lap detection: bump lap_count when the
+                            // path between consecutive fixes crosses the gate.
+                            if let Some(cur) = gps {
+                                if let (Some(gate), Some(prev)) = (locked.sf_gate, locked.last_gps) {
+                                    if segments_cross(prev, cur, gate) {
+                                        locked.lap_count += 1;
+                                        println!("[DASHD] GPS lap crossing -> lap {}", locked.lap_count);
+                                    }
+                                }
+                                locked.last_gps = Some(cur);
+                            }
                         }
                         Err(e) => eprintln!("[DASHD] Protobuf decode error: {}", e),
                     }
@@ -497,11 +596,11 @@ fn ws_server_loop(state: Arc<Mutex<DashState>>) {
                                 } else {
                                     locked.can.clone()
                                 };
-                                DashMessage {
-                                    seq,
-                                    can,
-                                    mqtt: locked.mqtt.to_mqtt_data(),
-                                }
+                                let mut mqtt = locked.mqtt.to_mqtt_data();
+                                // lap_trigger is the local monotonic lap count
+                                // (GPS- or trackside-driven). Always fresh.
+                                mqtt.lap_trigger = Some(locked.lap_count as f32);
+                                DashMessage { seq, can, mqtt }
                             };
 
                             let json = match serde_json::to_string(&message) {
@@ -594,6 +693,30 @@ fn mqtt_subscriber_loop(state: Arc<Mutex<DashState>>) {
                         Err(_) => continue,
                     };
 
+                    // sfGate carries a JSON array [lat1,lon1,lat2,lon2], not a
+                    // bare number — handle it before the numeric parse. It's
+                    // retained, so the dash re-loads the current gate on every
+                    // reconnect; we also cache it to disk for reboot survival.
+                    if field == "sfGate" {
+                        match serde_json::from_str::<[f64; 4]>(payload_str) {
+                            Ok(gate) => {
+                                {
+                                    let mut locked = state.lock().unwrap();
+                                    locked.sf_gate = Some(gate);
+                                    // Drop the last fix so swapping gates can't
+                                    // manufacture a phantom crossing.
+                                    locked.last_gps = None;
+                                }
+                                persist_sf_gate(&gate);
+                                println!("[DASHD] Loaded start/finish gate: {:?}", gate);
+                            }
+                            Err(e) => {
+                                eprintln!("[DASHD] MQTT bad sfGate payload {:?}: {}", payload_str, e)
+                            }
+                        }
+                        continue;
+                    }
+
                     let val: f32 = match payload_str.parse() {
                         Ok(v) => v,
                         Err(_) => {
@@ -625,8 +748,16 @@ fn mqtt_subscriber_loop(state: Arc<Mutex<DashState>>) {
                             locked.mqtt.last_target_power = now;
                         }
                         "lapTrigger" => {
-                            locked.mqtt.lap_trigger = Some(val);
-                            locked.mqtt.last_lap_trigger = now;
+                            // Trackside override / fallback for the on-car GPS
+                            // detector: each rising edge counts one lap. First
+                            // value just sets the baseline (no phantom lap on a
+                            // retained/stale value already on the broker).
+                            let rising = locked.last_offcar_trigger.is_some_and(|last| val > last);
+                            locked.last_offcar_trigger = Some(val);
+                            if rising {
+                                locked.lap_count += 1;
+                                println!("[DASHD] Trackside lapTrigger -> lap {}", locked.lap_count);
+                            }
                         }
                         _ => {} // ignore unknown subtopics
                     }
@@ -662,6 +793,12 @@ fn main() -> Result<()> {
         last_can_update: Instant::now() - CAN_STALE_TIMEOUT,
         last_qualified_soc: None,
         mqtt: MqttState::new(),
+        // Restore the last gate from disk; the retained MQTT topic will refresh
+        // it once the broker connects.
+        sf_gate: load_sf_gate(),
+        last_gps: None,
+        lap_count: 0,
+        last_offcar_trigger: None,
     }));
 
     let ipc_state = Arc::clone(&state);

--- a/BEVO/dashd/main.rs
+++ b/BEVO/dashd/main.rs
@@ -180,6 +180,19 @@ struct MqttData {
 
     #[serde(rename = "lapsRemaining")]
     laps_remaining: Option<f32>,
+
+    /// Live target power budget (kW) entered by the trackside team. The dash
+    /// paces per-lap energy against this: expected_Wh = targetPower * elapsed.
+    /// Trackside republishes at ~1 Hz so it doesn't go stale between changes.
+    #[serde(rename = "targetPower")]
+    target_power: Option<f32>,
+
+    /// Monotonic lap counter. Trackside bumps it each lap; the frontend fires
+    /// the full-screen lap card and resets the per-lap energy integrator when
+    /// the value increases. It's an event, not a reading, so the frontend keys
+    /// off changes rather than freshness.
+    #[serde(rename = "lapTrigger")]
+    lap_trigger: Option<f32>,
 }
 
 #[derive(Serialize, Clone)]
@@ -197,9 +210,13 @@ struct MqttState {
     lap_delta: Option<f32>,
     energy_delta: Option<f32>,
     laps_remaining: Option<f32>,
+    target_power: Option<f32>,
+    lap_trigger: Option<f32>,
     last_lap_delta: Instant,
     last_energy_delta: Instant,
     last_laps_remaining: Instant,
+    last_target_power: Instant,
+    last_lap_trigger: Instant,
 }
 
 impl MqttState {
@@ -209,9 +226,13 @@ impl MqttState {
             lap_delta: None,
             energy_delta: None,
             laps_remaining: None,
+            target_power: None,
+            lap_trigger: None,
             last_lap_delta: epoch,
             last_energy_delta: epoch,
             last_laps_remaining: epoch,
+            last_target_power: epoch,
+            last_lap_trigger: epoch,
         }
     }
 
@@ -228,6 +249,12 @@ impl MqttState {
             laps_remaining: self
                 .laps_remaining
                 .filter(|_| now.duration_since(self.last_laps_remaining) < MQTT_STALE_TIMEOUT),
+            target_power: self
+                .target_power
+                .filter(|_| now.duration_since(self.last_target_power) < MQTT_STALE_TIMEOUT),
+            lap_trigger: self
+                .lap_trigger
+                .filter(|_| now.duration_since(self.last_lap_trigger) < MQTT_STALE_TIMEOUT),
         }
     }
 }
@@ -592,6 +619,14 @@ fn mqtt_subscriber_loop(state: Arc<Mutex<DashState>>) {
                         "lapsRemaining" => {
                             locked.mqtt.laps_remaining = Some(val);
                             locked.mqtt.last_laps_remaining = now;
+                        }
+                        "targetPower" => {
+                            locked.mqtt.target_power = Some(val);
+                            locked.mqtt.last_target_power = now;
+                        }
+                        "lapTrigger" => {
+                            locked.mqtt.lap_trigger = Some(val);
+                            locked.mqtt.last_lap_trigger = now;
                         }
                         _ => {} // ignore unknown subtopics
                     }

--- a/BEVO/dashd/main.rs
+++ b/BEVO/dashd/main.rs
@@ -30,6 +30,15 @@ const MQTT_STALE_TIMEOUT: Duration = Duration::from_secs(5);
 /// the dash shows "--" instead of frozen last-known values.
 const CAN_STALE_TIMEOUT: Duration = Duration::from_secs(3);
 
+/// Largest gap between CAN frames we'll integrate energy across. A longer gap
+/// (cand stall, IPC hiccup) is treated as lost time rather than dumping a slug
+/// of phantom Wh into the lap total.
+const MAX_ENERGY_DT_S: f64 = 0.5;
+
+/// How often dashd publishes its driver-facing state to `lhre/dash/state` for
+/// the trackside mirror / link-health panel.
+const STATE_PUBLISH_HZ: u64 = 2;
+
 fn env_or_default(name: &str, default: &str) -> String {
     std::env::var(name).unwrap_or_else(|_| default.to_string())
 }
@@ -202,11 +211,49 @@ struct MqttData {
     lap_trigger: Option<f32>,
 }
 
+/// Endurance pacing, computed authoritatively on-car so the driver and the
+/// trackside mirror read identical numbers, and so the lap integrator survives
+/// a chromium reload (it lives here, not in the frontend).
+#[derive(Serialize, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+struct PacingData {
+    /// Net energy used so far this lap (drive minus regen), Wh.
+    lap_energy_wh: f32,
+    /// used - budget for this lap, Wh. Positive = over budget (red),
+    /// negative = banking margin (green). None until a targetPower is set.
+    budget_delta_wh: Option<f32>,
+    /// Wall-clock seconds since the current lap started.
+    lap_elapsed_s: f32,
+    /// 1-based lap currently in progress.
+    lap_number: u32,
+    /// Most recently completed lap (drives the full-screen lap card).
+    last_lap_number: Option<u32>,
+    last_lap_time_s: Option<f32>,
+    last_lap_energy_wh: Option<f32>,
+}
+
 #[derive(Serialize, Clone)]
 struct DashMessage {
     seq: u64,
     can: CanData,
     mqtt: MqttData,
+    pacing: PacingData,
+}
+
+/// Snapshot published to `lhre/dash/state` for the trackside link-health /
+/// dash-mirror panel — the same numbers the driver sees, plus the controls the
+/// car actually received (so trackside can confirm uplink, not just guess).
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct DashStateMsg {
+    lap_count: u64,
+    target_power: Option<f32>,
+    target_power_stale: bool,
+    speed: Option<f32>,
+    power: Option<f32>,
+    soc: Option<f32>,
+    temperature: Option<f32>,
+    pacing: PacingData,
 }
 
 // ---------------------------------------------------------------------------
@@ -290,6 +337,58 @@ struct DashState {
     lap_count: u64,
     /// Last trackside lapTrigger value seen, for rising-edge detection.
     last_offcar_trigger: Option<f32>,
+
+    // ---- On-car energy integration (authoritative) ----
+    /// Net energy used this lap (Wh), integrated from CAN power. Reset each lap.
+    lap_energy_wh: f64,
+    /// Energy budget consumed this lap at targetPower (Wh). Reset each lap.
+    lap_budget_wh: f64,
+    /// Start of the current lap, for elapsed time.
+    lap_start: Instant,
+    /// Previous integration tick, for dt. None until the first frame.
+    last_energy_update: Option<Instant>,
+    /// Snapshot of the most recently completed lap (for the lap card / mirror).
+    last_lap: Option<(u32, f32, f32)>, // (lap_number, time_s, energy_wh)
+}
+
+impl DashState {
+    /// Close the in-progress lap: snapshot its time + energy for the card,
+    /// bump the counter, and reset the per-lap integrators. Called from both
+    /// lap sources (on-car GPS crossing, trackside lapTrigger) so the energy
+    /// reset can never drift from the lap boundary.
+    fn complete_lap(&mut self, now: Instant) {
+        let completed = (self.lap_count + 1) as u32;
+        self.last_lap = Some((
+            completed,
+            now.duration_since(self.lap_start).as_secs_f32(),
+            self.lap_energy_wh as f32,
+        ));
+        self.lap_count += 1;
+        self.lap_energy_wh = 0.0;
+        self.lap_budget_wh = 0.0;
+        self.lap_start = now;
+    }
+
+    /// Build the pacing snapshot shown to the driver and mirrored to trackside.
+    fn pacing(&self, now: Instant) -> PacingData {
+        let (last_n, last_t, last_e) = match self.last_lap {
+            Some((n, t, e)) => (Some(n), Some(t), Some(e)),
+            None => (None, None, None),
+        };
+        PacingData {
+            lap_energy_wh: self.lap_energy_wh as f32,
+            // Only meaningful once a target has been set this lap.
+            budget_delta_wh: self
+                .mqtt
+                .target_power
+                .map(|_| (self.lap_energy_wh - self.lap_budget_wh) as f32),
+            lap_elapsed_s: now.duration_since(self.lap_start).as_secs_f32(),
+            lap_number: (self.lap_count + 1) as u32,
+            last_lap_number: last_n,
+            last_lap_time_s: last_t,
+            last_lap_energy_wh: last_e,
+        }
+    }
 }
 
 // Path the loaded start/finish gate is cached to, so it survives a dashd or
@@ -533,17 +632,37 @@ fn ipc_reader_loop(state: Arc<Mutex<DashState>>) {
                                 // (0,0) is the no-fix sentinel — ignore it.
                                 .filter(|&(lat, lon)| lat != 0.0 || lon != 0.0);
 
+                            let now = Instant::now();
                             let mut locked = state.lock().unwrap();
                             let can_data = extract_can_data(&data, &mut locked.last_qualified_soc);
+                            let power = can_data.power;
                             locked.can = can_data;
-                            locked.last_can_update = Instant::now();
+                            locked.last_can_update = now;
 
-                            // On-car lap detection: bump lap_count when the
-                            // path between consecutive fixes crosses the gate.
+                            // Integrate energy for this lap: Wh += kW * dt(s) / 3.6.
+                            // Regen (negative power) credits back. Budget tracks
+                            // targetPower over the same steps so the comparison is
+                            // apples-to-apples. Clamp dt so a stall can't dump a
+                            // phantom slug of energy.
+                            if let Some(prev) = locked.last_energy_update {
+                                let dt = now.duration_since(prev).as_secs_f64().min(MAX_ENERGY_DT_S);
+                                if dt > 0.0 {
+                                    if let Some(p) = power {
+                                        locked.lap_energy_wh += (p as f64) * dt / 3.6;
+                                        if let Some(tp) = locked.mqtt.target_power {
+                                            locked.lap_budget_wh += (tp as f64) * dt / 3.6;
+                                        }
+                                    }
+                                }
+                            }
+                            locked.last_energy_update = Some(now);
+
+                            // On-car lap detection: close the lap when the path
+                            // between consecutive fixes crosses the gate.
                             if let Some(cur) = gps {
                                 if let (Some(gate), Some(prev)) = (locked.sf_gate, locked.last_gps) {
                                     if segments_cross(prev, cur, gate) {
-                                        locked.lap_count += 1;
+                                        locked.complete_lap(now);
                                         println!("[DASHD] GPS lap crossing -> lap {}", locked.lap_count);
                                     }
                                 }
@@ -600,7 +719,8 @@ fn ws_server_loop(state: Arc<Mutex<DashState>>) {
                                 // lap_trigger is the local monotonic lap count
                                 // (GPS- or trackside-driven). Always fresh.
                                 mqtt.lap_trigger = Some(locked.lap_count as f32);
-                                DashMessage { seq, can, mqtt }
+                                let pacing = locked.pacing(Instant::now());
+                                DashMessage { seq, can, mqtt, pacing }
                             };
 
                             let json = match serde_json::to_string(&message) {
@@ -708,6 +828,14 @@ fn mqtt_subscriber_loop(state: Arc<Mutex<DashState>>) {
                                     locked.last_gps = None;
                                 }
                                 persist_sf_gate(&gate);
+                                // Ack receipt (retained) so trackside can confirm
+                                // the car actually got the gate.
+                                let _ = client.publish(
+                                    format!("{}ack/sfGate", MQTT_TOPIC_PREFIX),
+                                    QoS::AtMostOnce,
+                                    true,
+                                    payload_str.as_bytes().to_vec(),
+                                );
                                 println!("[DASHD] Loaded start/finish gate: {:?}", gate);
                             }
                             Err(e) => {
@@ -746,17 +874,31 @@ fn mqtt_subscriber_loop(state: Arc<Mutex<DashState>>) {
                         "targetPower" => {
                             locked.mqtt.target_power = Some(val);
                             locked.mqtt.last_target_power = now;
+                            // Echo back so trackside knows the car heard the budget.
+                            let _ = client.publish(
+                                format!("{}ack/targetPower", MQTT_TOPIC_PREFIX),
+                                QoS::AtMostOnce,
+                                true,
+                                val.to_string(),
+                            );
                         }
                         "lapTrigger" => {
                             // Trackside override / fallback for the on-car GPS
-                            // detector: each rising edge counts one lap. First
+                            // detector: each rising edge closes a lap. First
                             // value just sets the baseline (no phantom lap on a
                             // retained/stale value already on the broker).
                             let rising = locked.last_offcar_trigger.is_some_and(|last| val > last);
                             locked.last_offcar_trigger = Some(val);
                             if rising {
-                                locked.lap_count += 1;
-                                println!("[DASHD] Trackside lapTrigger -> lap {}", locked.lap_count);
+                                locked.complete_lap(now);
+                                let lap = locked.lap_count;
+                                println!("[DASHD] Trackside lapTrigger -> lap {}", lap);
+                                let _ = client.publish(
+                                    format!("{}ack/lapTrigger", MQTT_TOPIC_PREFIX),
+                                    QoS::AtMostOnce,
+                                    true,
+                                    lap.to_string(),
+                                );
                             }
                         }
                         _ => {} // ignore unknown subtopics
@@ -783,6 +925,83 @@ fn mqtt_subscriber_loop(state: Arc<Mutex<DashState>>) {
 }
 
 // ---------------------------------------------------------------------------
+// Thread 4: MQTT state publisher — pushes the driver-facing snapshot up to
+// `lhre/dash/state` so the trackside team can mirror exactly what the driver
+// sees and confirm the uplink. Separate client from the subscriber so the
+// blocking subscribe loop and the timed publish loop don't fight.
+// ---------------------------------------------------------------------------
+
+fn mqtt_state_publisher_loop(state: Arc<Mutex<DashState>>) {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    let mqtt_host = env_or_default("DASHD_MQTT_HOST", MQTT_HOST);
+    let mqtt_port: u16 = std::env::var("DASHD_MQTT_PORT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(MQTT_PORT);
+
+    let interval = Duration::from_millis(1000 / STATE_PUBLISH_HZ);
+
+    loop {
+        let client_id = format!("{}-PUB-{}", MQTT_CLIENT_ID, std::process::id());
+        let mut opts = MqttOptions::new(client_id, &mqtt_host, mqtt_port);
+        opts.set_keep_alive(Duration::from_secs(20));
+        let (client, mut connection) = Client::new(opts, 16);
+
+        // Drive the eventloop on a helper thread so outgoing publishes actually
+        // flush; it flips `alive` to false the moment the link drops.
+        let alive = Arc::new(AtomicBool::new(true));
+        let alive_driver = Arc::clone(&alive);
+        let driver = thread::spawn(move || {
+            for event in connection.iter() {
+                match event {
+                    Ok(Event::Incoming(Incoming::Disconnect)) | Err(_) => break,
+                    _ => {}
+                }
+            }
+            alive_driver.store(false, Ordering::SeqCst);
+        });
+
+        while alive.load(Ordering::SeqCst) {
+            let json = {
+                let locked = state.lock().unwrap();
+                let now = Instant::now();
+                let msg = DashStateMsg {
+                    lap_count: locked.lap_count,
+                    target_power: locked.mqtt.target_power,
+                    target_power_stale: locked
+                        .mqtt
+                        .target_power
+                        .is_some_and(|_| {
+                            now.duration_since(locked.mqtt.last_target_power) >= MQTT_STALE_TIMEOUT
+                        }),
+                    speed: locked.can.speed,
+                    power: locked.can.power,
+                    soc: locked.can.soc,
+                    temperature: locked.can.temperature,
+                    pacing: locked.pacing(now),
+                };
+                serde_json::to_string(&msg)
+            };
+
+            if let Ok(j) = json {
+                if client
+                    .publish(format!("{}state", MQTT_TOPIC_PREFIX), QoS::AtMostOnce, false, j)
+                    .is_err()
+                {
+                    break;
+                }
+            }
+            thread::sleep(interval);
+        }
+
+        let _ = client.disconnect();
+        let _ = driver.join();
+        thread::sleep(Duration::from_secs(5));
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
@@ -799,6 +1018,11 @@ fn main() -> Result<()> {
         last_gps: None,
         lap_count: 0,
         last_offcar_trigger: None,
+        lap_energy_wh: 0.0,
+        lap_budget_wh: 0.0,
+        lap_start: Instant::now(),
+        last_energy_update: None,
+        last_lap: None,
     }));
 
     let ipc_state = Arc::clone(&state);
@@ -810,7 +1034,13 @@ fn main() -> Result<()> {
     let mqtt_state = Arc::clone(&state);
     thread::spawn(move || mqtt_subscriber_loop(mqtt_state));
 
-    println!("[DASHD] Started (IPC reader + WebSocket on :{} + MQTT subscriber)", WS_PORT);
+    let pub_state = Arc::clone(&state);
+    thread::spawn(move || mqtt_state_publisher_loop(pub_state));
+
+    println!(
+        "[DASHD] Started (IPC reader + WebSocket on :{} + MQTT subscriber + state publisher)",
+        WS_PORT
+    );
 
     // Park the main thread forever (matches cand/main.rs pattern)
     loop {

--- a/telemtry/analysis/database/viewer_tool/package-lock.json
+++ b/telemtry/analysis/database/viewer_tool/package-lock.json
@@ -32,6 +32,7 @@
         "kafkajs": "^2.2.4",
         "leaflet": "^1.9.4",
         "lucide-react": "^0.544.0",
+        "mqtt": "^5.15.1",
         "nanoid": "^5.1.6",
         "next": "^15.5.7",
         "next-auth": "^4.24.11",
@@ -77,9 +78,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
-      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -2552,6 +2553,15 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/readable-stream": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.23.tgz",
+      "integrity": "sha512-wwXrtQvbMHxCbBgjHaMGEmImFTQxxpfMOR/ZoQnXxB1woqkUbdLGFDgauo00Py9IudiaqSeiBiulSV9i6XIPig==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/stats.js": {
       "version": "0.17.4",
       "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
@@ -2578,6 +2588,15 @@
       "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
       "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.44.0",
@@ -3160,6 +3179,18 @@
       "integrity": "sha512-cYrHab4d6wuVvDW5tdsfI6/o6vcLMDe6w2Citd1oS51Xxu2ycLCnVo4fqwujfKWijrZMInTJIKcXxteoy21nVA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -3528,6 +3559,18 @@
         "require-from-string": "^2.0.2"
       }
     },
+    "node_modules/bl": {
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-6.1.6.tgz",
+      "integrity": "sha512-jLsPgN/YSvPUg9UX0Kd73CXpm2Psg9FxMeCSXnk3WBO3CMT10JMwijubhGfHCnFu6TPn1ei3b975dxv7K2pWVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/readable-stream": "^4.0.0",
+        "buffer": "^6.0.3",
+        "inherits": "^2.0.4",
+        "readable-stream": "^4.2.0"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -3550,6 +3593,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/broker-factory": {
+      "version": "3.1.14",
+      "resolved": "https://registry.npmjs.org/broker-factory/-/broker-factory-3.1.14.tgz",
+      "integrity": "sha512-L45k5HMbPIrMid0nTOZ/UPXG/c0aRuQKVrSDFIb1zOkvfiyHgYmIjc3cSiN1KwQIvRDOtKE0tfb3I9EZ3CmpQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "fast-unique-numbers": "^9.0.27",
+        "tslib": "^2.8.1",
+        "worker-factory": "^7.0.49"
       }
     },
     "node_modules/buffer": {
@@ -3575,6 +3630,12 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
       }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
     },
     "node_modules/c12": {
       "version": "3.1.0",
@@ -3830,12 +3891,47 @@
         "node": ">= 10"
       }
     },
+    "node_modules/commist": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/commist/-/commist-3.2.0.tgz",
+      "integrity": "sha512-4PIMoPniho+LqXmpS5d3NuGYncG6XWlkBSVGiWycL22dd42OYdUGil2CWuzklaJoNxyxUSpO4MKIBU94viWNAw==",
+      "license": "MIT"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/concat-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/confbox": {
       "version": "0.2.2",
@@ -4343,7 +4439,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -5193,6 +5288,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/exsolve": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.7.tgz",
@@ -5273,6 +5386,19 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-unique-numbers": {
+      "version": "9.0.27",
+      "resolved": "https://registry.npmjs.org/fast-unique-numbers/-/fast-unique-numbers-9.0.27.tgz",
+      "integrity": "sha512-nDA9ADeINN8SA2u2wCtU+siWFTTDqQR37XvgPIDDmboWQeExz7X0mImxuaN+kJddliIqy2FpVRmnvRZ+j8i1/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.2.0"
+      }
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -5678,6 +5804,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/help-me": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "license": "MIT"
+    },
     "node_modules/hls.js": {
       "version": "1.6.13",
       "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.13.tgz",
@@ -5766,6 +5898,12 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -5787,6 +5925,15 @@
       "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -6265,6 +6412,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-sdsl": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
+      "integrity": "sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
       }
     },
     "node_modules/js-tokens": {
@@ -6805,7 +6962,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6850,11 +7006,59 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/mqtt": {
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-5.15.1.tgz",
+      "integrity": "sha512-V1WnkGuJh3ec9QXzy5Iylw8OOBK+Xu1WhxcQ9mMpLThG+/JZIMV1PgLNRgIiqXhZnvnVLsuyxHl5A/3bHHbcAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/readable-stream": "^4.0.21",
+        "@types/ws": "^8.18.1",
+        "commist": "^3.2.0",
+        "concat-stream": "^2.0.0",
+        "debug": "^4.4.1",
+        "help-me": "^5.0.0",
+        "lru-cache": "^10.4.3",
+        "minimist": "^1.2.8",
+        "mqtt-packet": "^9.0.2",
+        "number-allocator": "^1.0.14",
+        "readable-stream": "^4.7.0",
+        "rfdc": "^1.4.1",
+        "socks": "^2.8.6",
+        "split2": "^4.2.0",
+        "worker-timers": "^8.0.23",
+        "ws": "^8.18.3"
+      },
+      "bin": {
+        "mqtt": "build/bin/mqtt.js",
+        "mqtt_pub": "build/bin/pub.js",
+        "mqtt_sub": "build/bin/sub.js"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/mqtt-packet": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-9.0.2.tgz",
+      "integrity": "sha512-MvIY0B8/qjq7bKxdN1eD+nrljoeaai+qjLJgfRn3TiMuz0pamsIWY2bFODPZMSNmabsLANXsLl4EMoWvlaTZWA==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^6.0.8",
+        "debug": "^4.3.4",
+        "process-nextick-args": "^2.0.1"
+      }
+    },
+    "node_modules/mqtt/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -7053,6 +7257,16 @@
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/number-allocator": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/number-allocator/-/number-allocator-1.0.14.tgz",
+      "integrity": "sha512-OrL44UTVAvkKdOdRQZIJpLkAdjXGTRda052sN4sO77bKEzYYqWKMBjQvrJFzqygI99gL6Z4u2xctPW1tB8ErvA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "js-sdsl": "4.3.0"
       }
     },
     "node_modules/nypm": {
@@ -7652,6 +7866,21 @@
         }
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/promise-worker-transferable": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/promise-worker-transferable/-/promise-worker-transferable-1.0.4.tgz",
@@ -7926,6 +8155,22 @@
         }
       }
     },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -8045,6 +8290,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "license": "MIT"
+    },
     "node_modules/robust-predicates": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
@@ -8098,6 +8349,26 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
@@ -8359,6 +8630,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -8422,6 +8717,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string.prototype.includes": {
@@ -9050,6 +9354,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
@@ -9191,6 +9501,12 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/utility-types": {
       "version": "3.11.0",
@@ -9340,6 +9656,74 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/worker-factory": {
+      "version": "7.0.49",
+      "resolved": "https://registry.npmjs.org/worker-factory/-/worker-factory-7.0.49.tgz",
+      "integrity": "sha512-lW7tpgy6aUv2dFsQhv1yv+XFzdkCf/leoKRTGMPVK5/die6RrUjqgJHJf556qO+ZfytNG6wPXc17E8zzsOLUDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "fast-unique-numbers": "^9.0.27",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/worker-timers": {
+      "version": "8.0.31",
+      "resolved": "https://registry.npmjs.org/worker-timers/-/worker-timers-8.0.31.tgz",
+      "integrity": "sha512-ngkq5S6JuZyztom8tDgBzorLo9byhBMko/sXfgiUD945AuzKGg1GCgDMCC3NaYkicLpGKXutONM36wEX8UbBCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "tslib": "^2.8.1",
+        "worker-timers-broker": "^8.0.16",
+        "worker-timers-worker": "^9.0.14"
+      }
+    },
+    "node_modules/worker-timers-broker": {
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/worker-timers-broker/-/worker-timers-broker-8.0.16.tgz",
+      "integrity": "sha512-JyP3AvUGyPGbBGW7XiUewm2+0pN/aYo1QpVf5kdXAfkDZcN3p7NbWrG6XnyDEpDIvfHk/+LCnOW/NsuiU9riYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "broker-factory": "^3.1.14",
+        "fast-unique-numbers": "^9.0.27",
+        "tslib": "^2.8.1",
+        "worker-timers-worker": "^9.0.14"
+      }
+    },
+    "node_modules/worker-timers-worker": {
+      "version": "9.0.14",
+      "resolved": "https://registry.npmjs.org/worker-timers-worker/-/worker-timers-worker-9.0.14.tgz",
+      "integrity": "sha512-/qF06C60sXmSLfUl7WglvrDIbspmPOM8UrG63Dnn4bi2x4/DfqHS/+dxF5B+MdHnYO5tVuZYLHdAodrKdabTIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "tslib": "^2.8.1",
+        "worker-factory": "^7.0.49"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xtend": {

--- a/telemtry/analysis/database/viewer_tool/package.json
+++ b/telemtry/analysis/database/viewer_tool/package.json
@@ -42,6 +42,7 @@
     "kafkajs": "^2.2.4",
     "leaflet": "^1.9.4",
     "lucide-react": "^0.544.0",
+    "mqtt": "^5.15.1",
     "nanoid": "^5.1.6",
     "next": "^15.5.7",
     "next-auth": "^4.24.11",

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
@@ -4,6 +4,7 @@ import './trackside.css';
 import { useEffect, useMemo, useRef, useState, type ChangeEvent, type Dispatch, type MouseEvent, type ReactNode, type SetStateAction } from "react";
 import { Activity, ArrowDown, ArrowUp, CalendarDays, ChevronLeft, ChevronRight, Disc3, Download, FileText, Flag, Gauge, GraduationCap, HelpCircle, MapPinned, Moon, NotebookText, Plus, Radio, RefreshCcw, Save, Scissors, SlidersHorizontal, Sun, Target, Thermometer, Timer, Trash2, Upload, X, Zap } from "lucide-react";
 import { api } from "@/lib/trackside/api";
+import { useDashSignals } from "@/lib/dash/dashSignals";
 import type {
   ChannelDef,
   ChannelChartDefinition,
@@ -95,7 +96,7 @@ const METADATA_FIELDS = [
 type MetadataField = (typeof METADATA_FIELDS)[number];
 type SessionMetadata = Record<MetadataField, string>;
 type GateDrawMode = "start_finish" | "split" | null;
-type AppTab = "exporter" | "live" | "track-builder" | "race-ops";
+type AppTab = "exporter" | "live" | "track-builder" | "race-ops" | "dash";
 type LapPreviewRow = {
   id: string;
   label: string;
@@ -471,6 +472,11 @@ function App() {
   const [selectedCarPresetId, setSelectedCarPresetId] = useState(() => localStorage.getItem("motec-selected-car-preset") || "orion");
   const [carPresetDraft, setCarPresetDraft] = useState<CarPreset>(() => loadCarPresets()[0] ?? defaultCarPresets()[0]);
   const [liveState, setLiveState] = useState<LiveSessionState>(EMPTY_LIVE_STATE);
+  // Dash pacing signals (publishes targetPower + lapTrigger to the on-car dash).
+  const dashSignals = useDashSignals();
+  const [dashTargetPower, setDashTargetPower] = useState<number>(() => Number(localStorage.getItem("dash-target-power") || 30));
+  const [dashAutoLap, setDashAutoLap] = useState(() => localStorage.getItem("dash-auto-lap") === "1");
+  const dashLastLapCountRef = useRef(0);
   const liveSourceRef = useRef<EventSource | null>(null);
   const liveStateRef = useRef<LiveSessionState>(EMPTY_LIVE_STATE);
   const liveTrackRef = useRef(track);
@@ -633,6 +639,28 @@ function App() {
   useEffect(() => {
     localStorage.setItem("motec-soe-cutoff-cell-v", String(soeCutoffCellV));
   }, [soeCutoffCellV]);
+
+  // Persist + live-publish the dash power budget. Re-publishing on every change
+  // keeps the on-car dash's energy bar in sync the instant the strategist
+  // adjusts it; the hook's keepalive covers the gaps in between.
+  useEffect(() => {
+    localStorage.setItem("dash-target-power", String(dashTargetPower));
+    if (dashSignals.status === "connected") dashSignals.publishTargetPower(dashTargetPower);
+  }, [dashTargetPower, dashSignals.status, dashSignals.publishTargetPower]);
+
+  useEffect(() => {
+    localStorage.setItem("dash-auto-lap", dashAutoLap ? "1" : "0");
+  }, [dashAutoLap]);
+
+  // Auto-fire a dash lap card whenever the trackside lap detector completes a
+  // lap — optional, off by default so the thread's "manual for now" still holds.
+  useEffect(() => {
+    const count = liveState.laps.length;
+    if (count > dashLastLapCountRef.current) {
+      if (dashAutoLap && dashSignals.status === "connected") dashSignals.sendLap();
+      dashLastLapCountRef.current = count;
+    }
+  }, [liveState.laps.length, dashAutoLap, dashSignals.status, dashSignals.sendLap]);
 
   // Auto-select newly completed laps for the average (preserving manual deselections).
   useEffect(() => {
@@ -1846,6 +1874,9 @@ function App() {
         <button className={activeTab === "race-ops" ? "tab activeTab" : "tab"} onClick={() => setActiveTab("race-ops")}>
           <NotebookText size={16} /> Race Ops
         </button>
+        <button className={activeTab === "dash" ? "tab activeTab" : "tab"} onClick={() => setActiveTab("dash")}>
+          <Gauge size={16} /> Dash
+        </button>
       </nav>
 
       {activeTab === "exporter" ? <section className="grid">
@@ -2518,6 +2549,99 @@ function App() {
             </div>
             <div className="gateButtons">
               <button className="primary" onClick={saveCarPreset}><Save size={15} /> Save Preset</button>
+            </div>
+          </Panel>
+        </section>
+      ) : null}
+
+      {activeTab === "dash" ? (
+        <section className="opsGrid">
+          <Panel title="Dash Link" icon={<Radio size={18} />}>
+            <div className="opsCards">
+              <Metric
+                label="Status"
+                value={
+                  dashSignals.status === "connected" ? "Connected"
+                  : dashSignals.status === "connecting" ? "Connecting…"
+                  : dashSignals.status === "error" ? "Error"
+                  : dashSignals.status === "closed" ? "Disconnected"
+                  : "Idle"
+                }
+                tone={dashSignals.status === "connected" ? "good" : ""}
+              />
+              <Metric label="Laps Sent" value={String(dashSignals.lapsSent)} />
+            </div>
+            <div className="presetGrid">
+              <label>
+                <span>Broker (websockets)</span>
+                <input
+                  value={dashSignals.brokerUrl}
+                  onChange={(e) => dashSignals.setBrokerUrl(e.target.value)}
+                  placeholder="ws://18.191.225.118:8080"
+                />
+              </label>
+            </div>
+            <div className="gateButtons">
+              {dashSignals.status === "connected" || dashSignals.status === "connecting" ? (
+                <button className="tool dangerTool" onClick={dashSignals.disconnect}><X size={15} /> Disconnect</button>
+              ) : (
+                <button className="primary" onClick={dashSignals.connect}><Radio size={15} /> Connect to dash</button>
+              )}
+            </div>
+            {dashSignals.error ? (
+              <div className="error" role="alert"><span>{dashSignals.error}</span></div>
+            ) : null}
+          </Panel>
+
+          <Panel title="Power Budget" icon={<Zap size={18} />}>
+            <div style={{ display: "flex", alignItems: "baseline", gap: 10, marginBottom: 8 }}>
+              <strong style={{ fontSize: "3rem", lineHeight: 1 }}>{dashTargetPower.toFixed(0)}</strong>
+              <span>kW target</span>
+            </div>
+            <input
+              type="range"
+              min={0}
+              max={80}
+              step={1}
+              value={dashTargetPower}
+              onChange={(e) => setDashTargetPower(Number(e.target.value))}
+              style={{ width: "100%" }}
+            />
+            <div className="gateButtons" style={{ marginTop: 8 }}>
+              <button className="tool" onClick={() => setDashTargetPower((p) => Math.max(0, Math.round(p) - 1))}><ArrowDown size={15} /> -1</button>
+              <button className="tool" onClick={() => setDashTargetPower((p) => Math.min(120, Math.round(p) + 1))}><ArrowUp size={15} /> +1</button>
+              <input
+                type="number"
+                value={dashTargetPower}
+                min={0}
+                max={120}
+                onChange={(e) => setDashTargetPower(Number(e.target.value))}
+                style={{ width: 90 }}
+              />
+            </div>
+            <p style={{ marginTop: 10, opacity: 0.7, fontSize: "0.85rem" }}>
+              Dash energy bar runs green while the car draws under this budget, red when over.
+              Resets each lap. Sent live + republished ~1 Hz so it never goes stale.
+            </p>
+          </Panel>
+
+          <Panel title="Lap Control" icon={<Flag size={18} />}>
+            <button
+              className="primary"
+              style={{ fontSize: "1.3rem", padding: "16px 18px", width: "100%", justifyContent: "center" }}
+              disabled={dashSignals.status !== "connected"}
+              onClick={dashSignals.sendLap}
+            >
+              <Flag size={18} /> Send Lap
+            </button>
+            <label className="checkInline" style={{ marginTop: 10 }}>
+              <input type="checkbox" checked={dashAutoLap} onChange={(e) => setDashAutoLap(e.target.checked)} />
+              Auto-send on completed lap (uses the live lap detector)
+            </label>
+            <div className="opsCards" style={{ marginTop: 10 }}>
+              <Metric label="Last Lap" value={liveState.laps.at(-1) ? formatLapTime(liveState.laps.at(-1)!.durationMs) : "--"} />
+              <Metric label="Last Lap NRG" value={liveState.laps.at(-1) ? `${liveState.laps.at(-1)!.energyWh.toFixed(0)} Wh` : "--"} />
+              <Metric label="Best Lap" value={bestLap ? formatLapTime(bestLap.durationMs) : "--"} tone="purple" />
             </div>
           </Panel>
         </section>

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
@@ -477,6 +477,7 @@ function App() {
   const [dashTargetPower, setDashTargetPower] = useState<number>(() => Number(localStorage.getItem("dash-target-power") || 30));
   const [dashAutoLap, setDashAutoLap] = useState(() => localStorage.getItem("dash-auto-lap") === "1");
   const [dashGatePushed, setDashGatePushed] = useState(false);
+  const [dashNow, setDashNow] = useState(0); // 1 Hz tick for link-health "age" displays
   const dashLastLapCountRef = useRef(0);
   const liveSourceRef = useRef<EventSource | null>(null);
   const liveStateRef = useRef<LiveSessionState>(EMPTY_LIVE_STATE);
@@ -652,6 +653,15 @@ function App() {
   useEffect(() => {
     localStorage.setItem("dash-auto-lap", dashAutoLap ? "1" : "0");
   }, [dashAutoLap]);
+
+  // Tick once a second while the Dash tab is open so the link-health "Xs ago"
+  // ages and the dash-silent warning stay live without a new message.
+  useEffect(() => {
+    if (activeTab !== "dash") return;
+    setDashNow(Date.now());
+    const id = window.setInterval(() => setDashNow(Date.now()), 1000);
+    return () => window.clearInterval(id);
+  }, [activeTab]);
 
   // Auto-fire a dash lap card whenever the trackside lap detector completes a
   // lap — optional, off by default so the thread's "manual for now" still holds.
@@ -2678,6 +2688,48 @@ function App() {
                   {!sfGate ? (
                     <p style={{ marginTop: 6, opacity: 0.7, fontSize: "0.8rem" }}>
                       No start/finish gate on the loaded track yet — add one in the Track Builder tab.
+                    </p>
+                  ) : null}
+                </>
+              );
+            })()}
+          </Panel>
+
+          <Panel title="Link Health & Dash Mirror" icon={<Activity size={18} />} className="dashMirrorPanel">
+            {(() => {
+              const ds = dashSignals.dashState;
+              const at = dashSignals.lastStateAt;
+              const acks = dashSignals.acks;
+              const ago = (t: number) => `${Math.max(0, Math.round((dashNow - t) / 1000))}s ago`;
+              const linkLive = at !== null && dashNow - at < 3000;
+              const fmt = (v: number | null | undefined, d = 0, unit = "") =>
+                v === null || v === undefined ? "--" : `${v.toFixed(d)}${unit}`;
+              const delta = ds?.pacing.budgetDeltaWh ?? null;
+              return (
+                <>
+                  <div className="opsCards">
+                    <Metric label="Dash link" value={at === null ? "no data" : linkLive ? "LIVE" : `SILENT ${ago(at)}`} tone={linkLive ? "good" : ""} />
+                    <Metric label="Budget heard" value={acks.targetPower ? `${acks.targetPower.value.toFixed(0)} kW · ${ago(acks.targetPower.at)}` : "--"} tone={acks.targetPower ? "good" : ""} />
+                    <Metric label="Gate acked" value={acks.sfGate ? ago(acks.sfGate.at) : "no"} tone={acks.sfGate ? "good" : ""} />
+                  </div>
+                  <div className="opsCards" style={{ marginTop: 8 }}>
+                    <Metric label="Speed" value={fmt(ds?.speed, 0, " mph")} />
+                    <Metric label="Power" value={fmt(ds?.power, 1, " kW")} />
+                    <Metric label="SOC" value={fmt(ds?.soc, 0, " %")} />
+                  </div>
+                  <div className="opsCards" style={{ marginTop: 8 }}>
+                    <Metric label={`Lap ${ds?.pacing.lapNumber ?? "--"} NRG`} value={fmt(ds?.pacing.lapEnergyWh, 0, " Wh")} />
+                    <Metric label="Budget Δ" value={delta === null ? "--" : `${delta > 0 ? "+" : ""}${delta.toFixed(0)} Wh`} tone={delta !== null && delta < 0 ? "good" : ""} />
+                    <Metric label="Car laps" value={ds ? String(ds.lapCount) : "--"} />
+                  </div>
+                  {ds?.targetPowerStale ? (
+                    <p style={{ marginTop: 6, color: "#c47", fontSize: "0.8rem" }}>
+                      Driver&apos;s budget is showing STALE — the car hasn&apos;t heard a fresh target in 5s.
+                    </p>
+                  ) : null}
+                  {!linkLive && at !== null ? (
+                    <p style={{ marginTop: 6, color: "#c44", fontSize: "0.8rem" }}>
+                      Dash state silent — uplink may be down. The driver still has the held budget and on-car laps.
                     </p>
                   ) : null}
                 </>

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
@@ -476,6 +476,7 @@ function App() {
   const dashSignals = useDashSignals();
   const [dashTargetPower, setDashTargetPower] = useState<number>(() => Number(localStorage.getItem("dash-target-power") || 30));
   const [dashAutoLap, setDashAutoLap] = useState(() => localStorage.getItem("dash-auto-lap") === "1");
+  const [dashGatePushed, setDashGatePushed] = useState(false);
   const dashLastLapCountRef = useRef(0);
   const liveSourceRef = useRef<EventSource | null>(null);
   const liveStateRef = useRef<LiveSessionState>(EMPTY_LIVE_STATE);
@@ -2643,6 +2644,45 @@ function App() {
               <Metric label="Last Lap NRG" value={liveState.laps.at(-1) ? `${liveState.laps.at(-1)!.energyWh.toFixed(0)} Wh` : "--"} />
               <Metric label="Best Lap" value={bestLap ? formatLapTime(bestLap.durationMs) : "--"} tone="purple" />
             </div>
+          </Panel>
+
+          <Panel title="Start/Finish — on-car laps" icon={<MapPinned size={18} />}>
+            {(() => {
+              const sfGate = track.gates.find((gate) => gate.role === "start_finish");
+              return (
+                <>
+                  <div className="opsCards">
+                    <Metric label="Track" value={track.name} />
+                    <Metric label="S/F gate" value={sfGate ? "defined" : "none"} tone={sfGate ? "good" : ""} />
+                  </div>
+                  <p style={{ marginTop: 8, opacity: 0.7, fontSize: "0.85rem" }}>
+                    Push the start/finish line so the car counts laps from its own GPS — the
+                    per-lap reset then survives any cellular dropout. Send Lap stays as a manual
+                    override. Define or edit the gate in Track Builder.
+                  </p>
+                  <div className="gateButtons" style={{ marginTop: 8 }}>
+                    <button
+                      className="primary"
+                      disabled={!sfGate || dashSignals.status !== "connected"}
+                      onClick={() => {
+                        if (!sfGate) return;
+                        dashSignals.publishGate([sfGate.lat1, sfGate.lon1, sfGate.lat2, sfGate.lon2]);
+                        setDashGatePushed(true);
+                        window.setTimeout(() => setDashGatePushed(false), 2500);
+                      }}
+                    >
+                      <Upload size={15} /> Push S/F to car
+                    </button>
+                    {dashGatePushed ? <span className="goodText">Pushed ✓ (retained)</span> : null}
+                  </div>
+                  {!sfGate ? (
+                    <p style={{ marginTop: 6, opacity: 0.7, fontSize: "0.8rem" }}>
+                      No start/finish gate on the loaded track yet — add one in the Track Builder tab.
+                    </p>
+                  ) : null}
+                </>
+              );
+            })()}
           </Panel>
         </section>
       ) : null}

--- a/telemtry/analysis/database/viewer_tool/src/lib/dash/dashSignals.ts
+++ b/telemtry/analysis/database/viewer_tool/src/lib/dash/dashSignals.ts
@@ -1,0 +1,146 @@
+'use client';
+
+import mqtt, { type MqttClient } from 'mqtt';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+// Browser-side publisher for the on-car dash's pacing signals. The dash
+// (BEVO/dashd) subscribes to `lhre/dash/#` on the same broker the telemetry
+// stack uses; that broker exposes a websockets listener on :8080
+// (telemtry/stack/ingest/mosquitto.conf), so we can publish straight from the
+// strategist's browser with no extra backend. Contract: BEVO/dashd/MQTT_CONTRACT.md.
+
+const TOPIC_PREFIX = 'lhre/dash/';
+const DEFAULT_BROKER_URL = 'ws://18.191.225.118:8080';
+const BROKER_STORAGE_KEY = 'dash-signal-broker';
+
+// targetPower is a set-point, not a stream. dashd nulls any field it hasn't
+// heard from in 5 s, so we re-publish the current target on this cadence to
+// keep the dash's energy bar alive between manual changes.
+const KEEPALIVE_MS = 1000;
+
+export type DashSignalStatus = 'idle' | 'connecting' | 'connected' | 'error' | 'closed';
+
+export interface DashSignals {
+    status: DashSignalStatus;
+    error: string | null;
+    brokerUrl: string;
+    setBrokerUrl: (url: string) => void;
+    lapsSent: number;
+    connect: () => void;
+    disconnect: () => void;
+    /** Set the live power budget (kW) shown on the dash energy bar. */
+    publishTargetPower: (kw: number) => void;
+    /** Bump the lap counter — fires the dash's full-screen lap card + per-lap reset. */
+    sendLap: () => void;
+}
+
+function loadBrokerUrl(): string {
+    if (typeof window === 'undefined') return DEFAULT_BROKER_URL;
+    return localStorage.getItem(BROKER_STORAGE_KEY) || DEFAULT_BROKER_URL;
+}
+
+export function useDashSignals(): DashSignals {
+    const [status, setStatus] = useState<DashSignalStatus>('idle');
+    const [error, setError] = useState<string | null>(null);
+    const [brokerUrl, setBrokerUrlState] = useState<string>(loadBrokerUrl);
+    const [lapsSent, setLapsSent] = useState(0);
+
+    const clientRef = useRef<MqttClient | null>(null);
+    const targetPowerRef = useRef<number | null>(null);
+    const lapCounterRef = useRef(0);
+    const keepaliveRef = useRef<number | null>(null);
+
+    const publish = useCallback((field: string, value: number) => {
+        const client = clientRef.current;
+        if (!client || !client.connected) return;
+        client.publish(`${TOPIC_PREFIX}${field}`, String(value), { qos: 0 });
+    }, []);
+
+    const disconnect = useCallback(() => {
+        if (keepaliveRef.current !== null) {
+            window.clearInterval(keepaliveRef.current);
+            keepaliveRef.current = null;
+        }
+        const client = clientRef.current;
+        clientRef.current = null;
+        if (client) client.end(true);
+        setStatus('closed');
+    }, []);
+
+    const connect = useCallback(() => {
+        // Tear down any prior client before reconnecting.
+        if (clientRef.current) {
+            clientRef.current.end(true);
+            clientRef.current = null;
+        }
+        if (keepaliveRef.current !== null) {
+            window.clearInterval(keepaliveRef.current);
+            keepaliveRef.current = null;
+        }
+
+        setError(null);
+        setStatus('connecting');
+        const clientId = `dash-signal-sender-${Math.floor(Math.random() * 1e6)}`;
+        let client: MqttClient;
+        try {
+            client = mqtt.connect(brokerUrl, { clientId, reconnectPeriod: 2000, connectTimeout: 8000 });
+        } catch (e) {
+            setStatus('error');
+            setError(e instanceof Error ? e.message : String(e));
+            return;
+        }
+        clientRef.current = client;
+
+        client.on('connect', () => {
+            setStatus('connected');
+            setError(null);
+            // Push the current target straight away so a reconnect doesn't
+            // leave the dash bar blank until the next keepalive tick.
+            if (targetPowerRef.current !== null) publish('targetPower', targetPowerRef.current);
+        });
+        client.on('reconnect', () => setStatus('connecting'));
+        client.on('close', () => setStatus((s) => (s === 'error' ? s : 'closed')));
+        client.on('error', (err) => {
+            setStatus('error');
+            setError(err instanceof Error ? err.message : String(err));
+        });
+
+        keepaliveRef.current = window.setInterval(() => {
+            if (targetPowerRef.current !== null) publish('targetPower', targetPowerRef.current);
+        }, KEEPALIVE_MS);
+    }, [brokerUrl, publish]);
+
+    const publishTargetPower = useCallback((kw: number) => {
+        targetPowerRef.current = kw;
+        publish('targetPower', kw);
+    }, [publish]);
+
+    const sendLap = useCallback(() => {
+        lapCounterRef.current += 1;
+        publish('lapTrigger', lapCounterRef.current);
+        setLapsSent(lapCounterRef.current);
+    }, [publish]);
+
+    const setBrokerUrl = useCallback((url: string) => {
+        setBrokerUrlState(url);
+        if (typeof window !== 'undefined') localStorage.setItem(BROKER_STORAGE_KEY, url);
+    }, []);
+
+    // Clean up the client + keepalive when the component unmounts.
+    useEffect(() => () => {
+        if (keepaliveRef.current !== null) window.clearInterval(keepaliveRef.current);
+        clientRef.current?.end(true);
+    }, []);
+
+    return {
+        status,
+        error,
+        brokerUrl,
+        setBrokerUrl,
+        lapsSent,
+        connect,
+        disconnect,
+        publishTargetPower,
+        sendLap,
+    };
+}

--- a/telemtry/analysis/database/viewer_tool/src/lib/dash/dashSignals.ts
+++ b/telemtry/analysis/database/viewer_tool/src/lib/dash/dashSignals.ts
@@ -32,6 +32,8 @@ export interface DashSignals {
     publishTargetPower: (kw: number) => void;
     /** Bump the lap counter — fires the dash's full-screen lap card + per-lap reset. */
     sendLap: () => void;
+    /** Push the start/finish gate [lat1,lon1,lat2,lon2] so the car counts laps itself (retained). */
+    publishGate: (gate: [number, number, number, number]) => void;
 }
 
 function loadBrokerUrl(): string {
@@ -121,6 +123,14 @@ export function useDashSignals(): DashSignals {
         setLapsSent(lapCounterRef.current);
     }, [publish]);
 
+    const publishGate = useCallback((gate: [number, number, number, number]) => {
+        const client = clientRef.current;
+        if (!client || !client.connected) return;
+        // Retained + QoS 1: the car re-loads the current gate on every reconnect,
+        // and a freshly-booted dash gets it without the strategist re-sending.
+        client.publish(`${TOPIC_PREFIX}sfGate`, JSON.stringify(gate), { qos: 1, retain: true });
+    }, []);
+
     const setBrokerUrl = useCallback((url: string) => {
         setBrokerUrlState(url);
         if (typeof window !== 'undefined') localStorage.setItem(BROKER_STORAGE_KEY, url);
@@ -142,5 +152,6 @@ export function useDashSignals(): DashSignals {
         disconnect,
         publishTargetPower,
         sendLap,
+        publishGate,
     };
 }

--- a/telemtry/analysis/database/viewer_tool/src/lib/dash/dashSignals.ts
+++ b/telemtry/analysis/database/viewer_tool/src/lib/dash/dashSignals.ts
@@ -20,6 +20,35 @@ const KEEPALIVE_MS = 1000;
 
 export type DashSignalStatus = 'idle' | 'connecting' | 'connected' | 'error' | 'closed';
 
+// Mirror of dashd's DashStateMsg (lhre/dash/state) — what the driver currently
+// sees, plus the lap count, so trackside can confirm the uplink.
+export interface DashMirrorState {
+    lapCount: number;
+    targetPower: number | null;
+    targetPowerStale: boolean;
+    speed: number | null;
+    power: number | null;
+    soc: number | null;
+    temperature: number | null;
+    pacing: {
+        lapEnergyWh: number;
+        budgetDeltaWh: number | null;
+        lapElapsedS: number;
+        lapNumber: number;
+        lastLapNumber: number | null;
+        lastLapTimeS: number | null;
+        lastLapEnergyWh: number | null;
+    };
+}
+
+// Last value the car echoed back on lhre/dash/ack/*, with arrival time, so the
+// strategist knows the signal landed (not just that we sent it).
+export interface DashAcks {
+    targetPower?: { value: number; at: number };
+    lapTrigger?: { value: number; at: number };
+    sfGate?: { at: number };
+}
+
 export interface DashSignals {
     status: DashSignalStatus;
     error: string | null;
@@ -34,6 +63,12 @@ export interface DashSignals {
     sendLap: () => void;
     /** Push the start/finish gate [lat1,lon1,lat2,lon2] so the car counts laps itself (retained). */
     publishGate: (gate: [number, number, number, number]) => void;
+    /** Latest mirror of the driver's screen (null until the car publishes state). */
+    dashState: DashMirrorState | null;
+    /** Wall-clock ms of the last lhre/dash/state message — for a link-silent warning. */
+    lastStateAt: number | null;
+    /** Last echoed control values, so trackside can confirm the car heard us. */
+    acks: DashAcks;
 }
 
 function loadBrokerUrl(): string {
@@ -46,6 +81,9 @@ export function useDashSignals(): DashSignals {
     const [error, setError] = useState<string | null>(null);
     const [brokerUrl, setBrokerUrlState] = useState<string>(loadBrokerUrl);
     const [lapsSent, setLapsSent] = useState(0);
+    const [dashState, setDashState] = useState<DashMirrorState | null>(null);
+    const [lastStateAt, setLastStateAt] = useState<number | null>(null);
+    const [acks, setAcks] = useState<DashAcks>({});
 
     const clientRef = useRef<MqttClient | null>(null);
     const targetPowerRef = useRef<number | null>(null);
@@ -96,6 +134,9 @@ export function useDashSignals(): DashSignals {
         client.on('connect', () => {
             setStatus('connected');
             setError(null);
+            // Subscribe to the car's mirror + acks so trackside can see what the
+            // driver sees and confirm the uplink.
+            client.subscribe([`${TOPIC_PREFIX}state`, `${TOPIC_PREFIX}ack/#`]);
             // Push the current target straight away so a reconnect doesn't
             // leave the dash bar blank until the next keepalive tick.
             if (targetPowerRef.current !== null) publish('targetPower', targetPowerRef.current);
@@ -105,6 +146,25 @@ export function useDashSignals(): DashSignals {
         client.on('error', (err) => {
             setStatus('error');
             setError(err instanceof Error ? err.message : String(err));
+        });
+        client.on('message', (topic, payload) => {
+            const text = payload.toString();
+            if (topic === `${TOPIC_PREFIX}state`) {
+                try {
+                    setDashState(JSON.parse(text) as DashMirrorState);
+                    setLastStateAt(Date.now());
+                } catch {
+                    // ignore malformed state frame
+                }
+            } else if (topic === `${TOPIC_PREFIX}ack/targetPower`) {
+                const v = Number(text);
+                if (Number.isFinite(v)) setAcks((a) => ({ ...a, targetPower: { value: v, at: Date.now() } }));
+            } else if (topic === `${TOPIC_PREFIX}ack/lapTrigger`) {
+                const v = Number(text);
+                if (Number.isFinite(v)) setAcks((a) => ({ ...a, lapTrigger: { value: v, at: Date.now() } }));
+            } else if (topic === `${TOPIC_PREFIX}ack/sfGate`) {
+                setAcks((a) => ({ ...a, sfGate: { at: Date.now() } }));
+            }
         });
 
         keepaliveRef.current = window.setInterval(() => {
@@ -153,5 +213,8 @@ export function useDashSignals(): DashSignals {
         publishTargetPower,
         sendLap,
         publishGate,
+        dashState,
+        lastStateAt,
+        acks,
     };
 }


### PR DESCRIPTION
## What & why

From the #dashboard-requests thread: give endurance drivers a live "push or save" reference and let the trackside team feed signals to the dash. Built to be reliable on a **cellular-only** link to the AWS broker.

### Driver dash (`BEVO/dashd`)
- **Energy-budget bar** at the top of the driving screen: green while the car draws under the strategist's power budget, red while over. Resets every lap.
- **Full-screen lap card** (lap time + Wh used) on each lap crossing.
- Energy integration + lap timing are **authoritative on-car in dashd** — they survive a chromium reload and produce the exact numbers trackside mirrors.

### Trackside sender (new **Dash** tab on `/trackside-live`)
- Live **target-power (kW)** input (republished ~1 Hz keepalive).
- **Push S/F to car** — ships the Track Builder start/finish gate (retained) so the car counts its own laps.
- Manual **Send Lap** + optional auto-send on the live lap detector.
- **Link Health & Dash Mirror** panel: live mirror of the driver's screen + ack ages ("car heard 32 kW 2 s ago") + dash-silent warning.

### Reliability (cellular-only)
- **On-car GPS lap self-trigger** — once the gate is loaded, the per-lap reset depends on local GPS, not the link. A dropout can't corrupt the integrator.
- **Hold-last `targetPower`** — a blip dims the bar with a STALE badge instead of blanking it.
- **Ack/parity loop** — dashd echoes received controls (`lhre/dash/ack/*`) and publishes its state (`lhre/dash/state`), so trackside confirms the uplink and sees the driver's actual numbers.
- **Kiosk watchdog** — `launch_kiosk.sh` respawns chromium so a renderer/GPU/OOM crash can't leave a blank dash.

## MQTT topics (added)
`targetPower`, `lapTrigger`, `sfGate` (control, off→car) and `state` + `ack/*` (dash→trackside). Full spec in `BEVO/dashd/MQTT_CONTRACT.md`. Browser publishes over the broker's websockets listener (`:8080`).

## Testing
- `cargo check --bin dashd` — clean.
- `tsc --noEmit` on dash frontend and viewer_tool — clean (viewer_tool's only errors are pre-existing `prisma generate` artifacts).
- Dash demo mode (`D` key) exercises the bar + lap card; trackside Dash tab drives the live path.

## Notes / follow-ups
- Tunables: `ENERGY_DELTA_MAX_WH` (bar full-scale), `LAP_CARD_MS` (card duration), `MAX_ENERGY_DT_S`, `STATE_PUBLISH_HZ`.
- `start_telemetry.sh` has an intentional 1-hour auto-stop (disk guard) — fine for a ~25 min endurance run, flagging for awareness.
- Cellular path redundancy (dual-carrier, second broker) intentionally out of scope here.