### PR TITLE
ci: cut schema-drift job from ~7m to ~30s (prefer system protoc)

### DIFF
--- a/BEVO/nonhermetic/sync_assets.sh
+++ b/BEVO/nonhermetic/sync_assets.sh
@@ -46,18 +46,25 @@ if [[ ! -f "$PROTO_FILE" ]]; then
 fi
 
 echo "[3/4] Generating descriptor"
-if command -v bazel >/dev/null 2>&1; then
-  bazel run @protobuf//:protoc -- \
-    --descriptor_set_out="$DESC_FILE" \
-    --proto_path="$BEVO_ROOT" \
-    "$PROTO_FILE"
-elif command -v protoc >/dev/null 2>&1; then
+# Prefer the system `protoc` when present — it's instantaneous (single binary).
+# Fall back to `bazel run @protobuf//:protoc` only when there's no system
+# protoc, so hermetic bazel builds still work. Previously the order was
+# reversed: GitHub's ubuntu-latest runner has bazel preinstalled, so CI was
+# going down the bazel path and rebuilding protoc from source on a cold
+# external repo — ~6 min per schema-drift job. Override with USE_BAZEL_PROTOC=1
+# to force the bazel path explicitly.
+if [[ "${USE_BAZEL_PROTOC:-0}" != "1" ]] && command -v protoc >/dev/null 2>&1; then
   protoc \
     --descriptor_set_out="$DESC_FILE" \
     --proto_path="$BEVO_ROOT" \
     "$PROTO_FILE"
+elif command -v bazel >/dev/null 2>&1; then
+  bazel run @protobuf//:protoc -- \
+    --descriptor_set_out="$DESC_FILE" \
+    --proto_path="$BEVO_ROOT" \
+    "$PROTO_FILE"
 else
-  echo "Need either 'bazel' or 'protoc' to generate descriptor" >&2
+  echo "Need either 'protoc' or 'bazel' to generate descriptor" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

The schema-drift CI job was taking ~7 min per PR; ~6:48 of that was a single step in \`BEVO/nonhermetic/sync_assets.sh\` rebuilding protoc from source via bazel.

Diagnosis (from PR #291's schema-drift run):

\`\`\`
408.0s  Regenerate all schema artifacts from source   ← the slow step
 16.0s  Install protoc + python deps                  ← system protoc, unused
  4.0s  Checkout
\`\`\`

Inside the 408s: GitHub's \`ubuntu-latest\` runner has bazel preinstalled, so \`command -v bazel\` was true and the script went down the bazel path. Bazel then loaded the \`@protobuf\` external workspace cold and **rebuilt protoc from source** (\`687 actions, ~6 min\`). The system protoc that the workflow had just \`apt-get install\`ed (16 s) was sitting unused on PATH.

## Fix

One-line preference flip in \`sync_assets.sh\`: try system protoc first, fall back to bazel only when there's no protoc binary, with \`USE_BAZEL_PROTOC=1\` as a manual override for anyone who needs the hermetic build.

This single shell script is the only place the schema-drift workflow could hit a slow protoc path — \`update_can_proto.py\` and \`sync_schema.sh Orion\` don't shell out to protoc at all.

## Test plan

- [x] Local run of \`bash BEVO/nonhermetic/sync_assets.sh\` with system protoc on PATH ✓ (instant)
- [ ] Confirm schema-drift job on this PR runs in ~30s instead of ~7m
- [ ] Spot-check that \`sensor_data.desc\` doesn't drift vs the bazel-protoc output (likely identical or trivially-different protoc-version bytes — and the drift check already excludes \`sensor_data.desc\` for exactly that reason)