### PR TITLE
dashd: PRNDL-driven Park debug screen for pit

### DIFF
--- a/BEVO/dashd/frontend/src/LapCardRenderer.tsx
+++ b/BEVO/dashd/frontend/src/LapCardRenderer.tsx
@@ -98,7 +98,7 @@ function WidgetView({ w, data, theme, pal }: { w: Widget; data: unknown; theme: 
   if (w.type === 'delta') {
     const val = getByPath(data, w.bind);
     const color = deltaColor(val, w.goodSign ?? 'negative', w.goodColor, w.badColor, w.zeroColor ?? pal.muted);
-    const mag = formatValue(val, w.format);
+    const mag = formatValue(val, w.format, w.decimals);
     const signed = val != null && val > 0 && w.showSign !== false ? `+${mag}` : mag;
     const arrow = w.showArrow && val != null && val !== 0 ? (val > 0 ? '▲ ' : '▼ ') : '';
     return (
@@ -115,7 +115,7 @@ function WidgetView({ w, data, theme, pal }: { w: Widget; data: unknown; theme: 
   return (
     <div style={{ width: '100%', height: '100%' }}>
       <MiniRadialGauge value={val} min={w.min} max={w.max} label={w.label} color={resolveColor(w, theme, w.color ?? 'gradient')}
-        mode={w.mode} valueText={formatValue(val, w.format ?? 'int')} pal={pal} />
+        mode={w.mode} valueText={formatValue(val, w.format ?? 'int', w.decimals)} pal={pal} />
     </div>
   );
 }

--- a/BEVO/dashd/frontend/src/LapCardRenderer.tsx
+++ b/BEVO/dashd/frontend/src/LapCardRenderer.tsx
@@ -9,7 +9,7 @@
 
 import React from 'react';
 import {
-  LAP_CARD_W, LAP_CARD_H, formatValue, getByPath, deltaColor, valueColor,
+  LAP_CARD_W, LAP_CARD_H, formatValue, applyValueMap, getByPath, deltaColor, valueColor,
   resolveColor, resolveBackground, CARD_THEMES,
   type LapCardLayout, type Widget, type CardTheme, type ThemePalette,
 } from './dashLayout';
@@ -70,7 +70,7 @@ function WidgetView({ w, data, theme, pal }: { w: Widget; data: unknown; theme: 
         alignItems: w.align === 'left' ? 'flex-start' : w.align === 'right' ? 'flex-end' : 'center',
         justifyContent: 'center', lineHeight: 1, overflow: 'hidden' }}>
         {w.label && <span style={{ color: w.labelColor ?? pal.muted, fontSize: Math.max(11, w.fontSize * 0.28), letterSpacing: 3, marginBottom: 4 }}>{w.label}</span>}
-        <span style={{ color, fontSize: w.fontSize, fontWeight: w.bold ? 800 : 500 }}>{formatValue(val, w.format)}</span>
+        <span style={{ color, fontSize: w.fontSize, fontWeight: w.bold ? 800 : 500 }}>{applyValueMap(val, w.format, w.valueMap)}</span>
       </div>
     );
   }

--- a/BEVO/dashd/frontend/src/dashLayout.ts
+++ b/BEVO/dashd/frontend/src/dashLayout.ts
@@ -96,6 +96,9 @@ export interface ValueWidget extends BaseWidget {
   label?: string;           // small caption above/beside the value
   labelColor?: string;
   thresholds?: ColorRule[]; // e.g. [{cmp:'lt',value:20,color:'#ff4d4f'}] for low SoC
+  // Map a numeric value to a label (enums / bitfields, e.g. VCU event mode
+  // 4 -> "ENDUR"). Keyed by the rounded integer value as a string.
+  valueMap?: Record<string, string>;
 }
 export interface BarWidget extends BaseWidget {
   type: 'bar';
@@ -232,6 +235,16 @@ export function formatValue(v: number | null | undefined, fmt: FormatId): string
     case 'mph': return `${Math.round(v)}`;
     default: return `${v}`;
   }
+}
+
+// Value widgets with a valueMap (enums/bitfields) show the mapped label; anything
+// without a matching key falls back to the numeric format.
+export function applyValueMap(v: number | null | undefined, fmt: FormatId, valueMap?: Record<string, string>): string {
+  if (v != null && Number.isFinite(v) && valueMap) {
+    const label = valueMap[String(Math.round(v))];
+    if (label != null) return label;
+  }
+  return formatValue(v, fmt);
 }
 
 // ---- default layout (replicates today's hardcoded lap card) ---------------

--- a/BEVO/dashd/frontend/src/dashLayout.ts
+++ b/BEVO/dashd/frontend/src/dashLayout.ts
@@ -87,6 +87,7 @@ export interface ValueWidget extends BaseWidget {
   type: 'value';
   bind: string;             // dotted path into the data context (see FIELD_CATALOG)
   format: FormatId;
+  decimals?: number;        // override the format's decimal places (0–6); undefined = format default
   fontSize: number;
   color: string;            // hex, or "auto" to follow the theme foreground
   colorDark?: string;
@@ -116,6 +117,7 @@ export interface DeltaWidget extends BaseWidget {
   type: 'delta';
   bind: string;
   format: FormatId;
+  decimals?: number;        // override the format's decimal places (0–6)
   fontSize: number;
   align?: Align;
   bold?: boolean;
@@ -138,6 +140,7 @@ export interface GaugeWidget extends BaseWidget {
   colorLight?: string;
   mode?: 'standard' | 'bidirectional';
   format?: FormatId;        // center read-out format
+  decimals?: number;        // override the center read-out's decimal places (0–6)
 }
 export type Widget = TextWidget | ValueWidget | BarWidget | GaugeWidget | DeltaWidget;
 
@@ -213,8 +216,16 @@ export function valueColor(v: number | null | undefined, base: string, rules?: C
   return c;
 }
 
-export function formatValue(v: number | null | undefined, fmt: FormatId): string {
+export function formatValue(v: number | null | undefined, fmt: FormatId, decimals?: number): string {
   if (v == null || !Number.isFinite(v)) return '--';
+  // Optional per-widget precision override. Applies to the numeric formats —
+  // keeps kwh's /1000 scaling and whSigned's +/- sign; lap-time ignores it.
+  if (decimals != null && Number.isFinite(decimals) && fmt !== 'laptime') {
+    const d = Math.max(0, Math.min(6, Math.floor(decimals)));
+    if (fmt === 'kwh') return (v / 1000).toFixed(d);
+    if (fmt === 'whSigned') return `${v >= 0 ? '+' : ''}${v.toFixed(d)}`;
+    return v.toFixed(d);
+  }
   switch (fmt) {
     case 'laptime': {
       const m = Math.floor(v / 60);
@@ -239,12 +250,12 @@ export function formatValue(v: number | null | undefined, fmt: FormatId): string
 
 // Value widgets with a valueMap (enums/bitfields) show the mapped label; anything
 // without a matching key falls back to the numeric format.
-export function applyValueMap(v: number | null | undefined, fmt: FormatId, valueMap?: Record<string, string>): string {
+export function applyValueMap(v: number | null | undefined, fmt: FormatId, valueMap?: Record<string, string>, decimals?: number): string {
   if (v != null && Number.isFinite(v) && valueMap) {
     const label = valueMap[String(Math.round(v))];
     if (label != null) return label;
   }
-  return formatValue(v, fmt);
+  return formatValue(v, fmt, decimals);
 }
 
 // ---- default layout (replicates today's hardcoded lap card) ---------------

--- a/BEVO/dashd/frontend/src/hooks/useDemoData.ts
+++ b/BEVO/dashd/frontend/src/hooks/useDemoData.ts
@@ -201,6 +201,17 @@ export function useDemoData(enabled: boolean): DashMessage | null {
             const hvCurrent = 10;
             const lvVoltage = 25;
             const lvCurrent = 9.3;
+            // Cell voltages — track SoC (3.2 V empty → 4.1 V full) with a small
+            // imbalance spread that grows as the pack drains, for a plausible
+            // Park-debug demo. cellVMax/Min straddle the nominal cell V.
+            const cellVNominal = 3.2 + (a.charge / 100) * 0.9;
+            const cellVSpread = 0.02 + (1 - a.charge / 100) * 0.06;
+            const cellVMax = cellVNominal + cellVSpread / 2;
+            const cellVMin = cellVNominal - cellVSpread / 2;
+            // VCU running energy — cumulative drive + regen across the session.
+            // Roughly 180 Wh/lap drive, ~15% recovered as regen.
+            const vcuNetEnergyWh = a.lapTrigger * 180 + a.lapEnergyWh;
+            const vcuRegenEnergyWh = vcuNetEnergyWh * 0.15;
             // Wheel speeds — small per-wheel variance for visual interest.
             const wheelSpeedFL = Math.max(0, s.speed + (Math.random() - 0.5) * 0.4);
             const wheelSpeedFR = Math.max(0, s.speed + (Math.random() - 0.5) * 0.4);
@@ -253,6 +264,11 @@ export function useDemoData(enabled: boolean): DashMessage | null {
                     wheelSpeedFR,
                     wheelSpeedRL,
                     wheelSpeedRR,
+                    cellVMax,
+                    cellVMin,
+                    cellVSpread,
+                    vcuNetEnergyWh,
+                    vcuRegenEnergyWh,
                 },
                 mqtt: {
                     lapDelta,

--- a/BEVO/dashd/frontend/src/screens/Dashboard.tsx
+++ b/BEVO/dashd/frontend/src/screens/Dashboard.tsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import ScreenOne from './ScreenOne';
 import ScreenTwo from './ScreenTwo';
 import PitDiagnostic from './PitDiagnostic';
 import Settings from './Settings';
+import { useDash } from '../context/DashContext';
 
 // Add new screens by appending to this array. Enter cycles in order.
 const SCREENS: { name: string; component: React.FC }[] = [
@@ -12,8 +13,17 @@ const SCREENS: { name: string; component: React.FC }[] = [
     { name: 'Settings', component: Settings },
 ];
 
+const DRIVING_INDEX = SCREENS.findIndex(s => s.name === 'Driving');
+const PARK_INDEX = SCREENS.findIndex(s => s.name === 'PitDiagnostic');
+
 const Dashboard: React.FC = () => {
     const [screenIndex, setScreenIndex] = useState<number>(0);
+    const { data } = useDash();
+    const prndl = data?.can.prndl ?? null;
+    // Last gear we acted on, so we only snap screens on an actual P<->D
+    // transition (not on every WS frame) and the crew can still Enter-cycle
+    // freely between gear changes.
+    const lastGearRef = useRef<string | null>(null);
 
     useEffect(() => {
         const handleKeyDown = (event: KeyboardEvent) => {
@@ -24,6 +34,19 @@ const Dashboard: React.FC = () => {
         window.addEventListener('keydown', handleKeyDown);
         return () => window.removeEventListener('keydown', handleKeyDown);
     }, []);
+
+    // PRNDL-driven auto-routing: Park -> debug screen, Drive -> driving screen.
+    // The VCU only emits P or D (PRNDL.h); null/unknown frames are ignored so a
+    // dropped diag packet can't yank the screen. Fires only on a real gear
+    // change, so the moment the driver shifts to Drive the dash leaves the pit
+    // screen and shows the driving view — and shifting back to Park brings the
+    // debug screen up again. Manual Enter navigation still works between shifts.
+    useEffect(() => {
+        if (prndl !== 'P' && prndl !== 'D') return;
+        if (prndl === lastGearRef.current) return;
+        lastGearRef.current = prndl;
+        setScreenIndex(prndl === 'P' ? PARK_INDEX : DRIVING_INDEX);
+    }, [prndl]);
 
     const ActiveScreen = SCREENS[screenIndex].component;
 

--- a/BEVO/dashd/frontend/src/screens/PitDiagnostic.css
+++ b/BEVO/dashd/frontend/src/screens/PitDiagnostic.css
@@ -54,6 +54,24 @@
     color: var(--fg-secondary);
 }
 
+/* SoE headline (top-right of the tray) — the number the crew reads first. */
+.pit-soe {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+}
+
+.pit-soe .label-small {
+    margin-bottom: 0;
+}
+
+.pit-soe-val {
+    font-size: 2.2rem;
+    font-weight: bold;
+    line-height: 1;
+    font-variant-numeric: tabular-nums;
+}
+
 .fault-light {
     width: 10px;
     height: 10px;
@@ -115,15 +133,17 @@
     left: 12px;
     right: 12px;
     display: grid;
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: repeat(3, 1fr);
+    grid-template-rows: repeat(2, 1fr);
     gap: 10px;
 }
 
 .pit-section {
     display: flex;
     flex-direction: column;
-    padding: 10px 14px;
+    padding: 8px 14px;
     overflow: hidden;
+    min-height: 0;   /* let cards shrink within the grid row instead of overflowing */
 }
 
 .pit-section-title {
@@ -139,7 +159,7 @@
     display: flex;
     justify-content: space-between;
     align-items: baseline;
-    padding: 5px 0;
+    padding: 3px 0;
     min-width: 0;
 }
 
@@ -149,12 +169,13 @@
 }
 
 .diag-value {
-    font-size: 1.2rem;
+    font-size: 1.15rem;
     font-weight: bold;
     text-align: right;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    font-variant-numeric: tabular-nums;
 }
 
 .diag-value.warn {
@@ -163,6 +184,10 @@
 
 .diag-value.bad {
     color: #FF3333;
+}
+
+.diag-value.good {
+    color: #00FF66;
 }
 
 .diag-fault-row {

--- a/BEVO/dashd/frontend/src/screens/PitDiagnostic.tsx
+++ b/BEVO/dashd/frontend/src/screens/PitDiagnostic.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { useDash } from '../context/DashContext';
 import { SHUTDOWN_NAMES } from '../types/DashData';
 import ConnectivityIndicator from '../components/ConnectivityIndicator';
+import { LapCardRenderer } from '../LapCardRenderer';
+import { validateLapCardLayout } from '../dashLayout';
 import './ScreenOne.css';
 import './PitDiagnostic.css';
 
@@ -13,7 +15,12 @@ import './PitDiagnostic.css';
 // inputs + brake bias, running VCU energy usage, pack/LV rails, and active faults.
 // Resolution: 800 x 480.
 //
-// All fields read from the same OrionSensorData snapshot dashd forwards over the
+// Two render paths:
+//   1. If trackside has published a custom park layout (retained
+//      lhre/dash/parkLayout, forwarded as data.parkLayout), render it with the
+//      shared LapCardRenderer — same authoring loop as the lap card.
+//   2. Otherwise the built-in grid below (so the screen never blanks).
+// All fields read from the OrionSensorData snapshot dashd forwards over the
 // WebSocket (BEVO/dashd/main.rs::extract_can_data). A field shows "--" until
 // cand has decoded the matching CAN packet.
 
@@ -32,7 +39,23 @@ const energyUnit = (wh: number | null | undefined): string =>
 
 const PitDiagnostic: React.FC = () => {
     const { data } = useDash();
+    // Follow the dash's current light/dark theme (body.theme-light is toggled by
+    // the car's settings / auto sunrise-sunset), same mechanism ScreenOne uses.
+    const cardTheme: 'dark' | 'light' =
+        (typeof document !== 'undefined' && document.body.classList.contains('theme-light')) ? 'light' : 'dark';
     const can = data?.can;
+
+    // Custom park layout authored on the website (validated; falls back to the
+    // built-in grid below when absent/malformed so the screen never blanks).
+    const customLayout = validateLapCardLayout(data?.parkLayout);
+    if (customLayout && customLayout.widgets.length) {
+        const ctx = { can: data?.can, pacing: data?.pacing, mqtt: data?.mqtt };
+        return (
+            <div style={{ position: 'absolute', inset: 0, zIndex: 1 }}>
+                <LapCardRenderer layout={customLayout} data={ctx} scale={1} theme={cardTheme} />
+            </div>
+        );
+    }
 
     // ----- Energy / charge -----
     const soe = can?.soc ?? null;                       // state of energy %

--- a/BEVO/dashd/frontend/src/screens/PitDiagnostic.tsx
+++ b/BEVO/dashd/frontend/src/screens/PitDiagnostic.tsx
@@ -5,86 +5,89 @@ import ConnectivityIndicator from '../components/ConnectivityIndicator';
 import './ScreenOne.css';
 import './PitDiagnostic.css';
 
-// Pit / Diagnostic Screen
-// Static-state info to inspect before/after driving — driver inputs, powertrain
-// temps, battery V/I, wheel speeds, active faults.
-// Resolution: 800 x 480
+// Pit / Diagnostic Screen — the PARK debug view.
+// Shown automatically whenever the VCU reports PRNDL = Park (see Dashboard.tsx),
+// and replaced by the driving screen the instant the car shifts to Drive. It
+// surfaces the things the crew checks between runs at an FSAE event: state of
+// energy, cell-voltage health (min/max/spread), cell + powertrain temps, driver
+// inputs + brake bias, running VCU energy usage, pack/LV rails, and active faults.
+// Resolution: 800 x 480.
 //
-// =====================================================================
-// BACKEND STATUS — most fields on this screen are NOT WIRED YET.
-// =====================================================================
-// Today, dashd (BEVO/dashd/main.rs) only forwards: speed (single wheel),
-// power (derived = dc_bus_v * dc_bus_current / 1000), soc, temperature
-// (cell_top_temp), signalStrength (always null), shutdown (always null),
-// and lap/energy/laps from MQTT.
-//
-// To make this screen useful, both ends need extending in lockstep:
-//   1. Add fields to CanData in BEVO/dashd/main.rs and populate them in
-//      extract_can_data() from the matching protobuf messages.
-//   2. Mirror those additions in src/types/DashData.ts so the frontend
-//      can read them.
-//
-// Per-field TODOs are flagged at the data-binding site below.
-// =====================================================================
+// All fields read from the same OrionSensorData snapshot dashd forwards over the
+// WebSocket (BEVO/dashd/main.rs::extract_can_data). A field shows "--" until
+// cand has decoded the matching CAN packet.
 
 const fmt = (val: number | null | undefined, decimals = 0): string => {
     if (val === null || val === undefined) return '--';
     return decimals > 0 ? val.toFixed(decimals) : Math.round(val).toString();
 };
 
+// Energy: Wh below 1 kWh, kWh above, so a multi-kWh session total stays readable.
+const fmtEnergy = (wh: number | null | undefined): string => {
+    if (wh === null || wh === undefined) return '--';
+    return Math.abs(wh) >= 1000 ? `${(wh / 1000).toFixed(2)}` : `${Math.round(wh)}`;
+};
+const energyUnit = (wh: number | null | undefined): string =>
+    wh !== null && wh !== undefined && Math.abs(wh) >= 1000 ? 'kWh' : 'Wh';
+
 const PitDiagnostic: React.FC = () => {
     const { data } = useDash();
+    const can = data?.can;
 
-    // ----- Wired fields -----
-    const cellTopTemp = data?.can.temperature ?? null;
-    const shutdown = data?.can.shutdown ?? null;
-    // BACKEND: odometer field exists in CanData but dashd always sets it
-    // to null today (no integrated wheel-speed-over-time logic, and unit
-    // unverified). Will read whatever the backend eventually provides.
-    const odometer = data?.can.odometer ?? null;
+    // ----- Energy / charge -----
+    const soe = can?.soc ?? null;                       // state of energy %
+    const vcuNet = can?.vcuNetEnergyWh ?? null;         // running net (drive - regen) Wh
+    const vcuRegen = can?.vcuRegenEnergyWh ?? null;     // running regen Wh
+    // Drive (gross out of the pack) = net + regen returned.
+    const vcuDrive = vcuNet !== null && vcuRegen !== null ? vcuNet + vcuRegen : null;
 
-    // ----- Optional fields — wired in demo mode via useDemoData; live mode
-    //       returns null until dashd publishes them. See per-field BACKEND
-    //       TODOs in the type definition (src/types/DashData.ts). -----
+    // ----- Driver inputs -----
+    const apps = can?.apps ?? null;
+    const bpps = can?.bpps ?? null;
+    const brakeBias = can?.brakeBias ?? null;
+    const brakePressureFront = can?.brakePressureFront ?? null;
+    const brakePressureRear = can?.brakePressureRear ?? null;
 
-    const apps = data?.can.apps ?? null;
-    const bpps = data?.can.bpps ?? null;
-    const brakePressureFront = data?.can.brakePressureFront ?? null;
-    const brakePressureRear = data?.can.brakePressureRear ?? null;
+    // ----- Cell voltages (pack health) -----
+    const cellVMax = can?.cellVMax ?? null;
+    const cellVMin = can?.cellVMin ?? null;
+    const cellVSpread = can?.cellVSpread ?? null;       // V; shown as mV
+    const cellVSpreadMv = cellVSpread !== null ? cellVSpread * 1000 : null;
 
-    const motorTemp = data?.can.motorTemp ?? null;
-    const inverterTemp = data?.can.inverterTemp ?? null;
-    const coolantTemp = data?.can.coolantTemp ?? null;
-    // Prefer dashd's pack-wide max (aggregate of pack.cells_temps[]) when
-    // present; fall back to the single cell_top_temp the main TEMP gauge uses.
-    const cellTempMax = data?.can.cellTempMax ?? cellTopTemp;
-    const cellTempAvg = data?.can.cellTempAvg ?? null;
-    const cellTempMin = data?.can.cellTempMin ?? null;
+    // ----- Cell + powertrain temps -----
+    const cellTempMax = can?.cellTempMax ?? can?.temperature ?? null;
+    const cellTempAvg = can?.cellTempAvg ?? null;
+    const cellTempMin = can?.cellTempMin ?? null;
+    const motorTemp = can?.motorTemp ?? null;
+    const inverterTemp = can?.inverterTemp ?? null;
+    const coolantTemp = can?.coolantTemp ?? null;
 
-    const hvVoltage = data?.can.hvVoltage ?? null;
-    const hvCurrent = data?.can.hvCurrent ?? null;
-    const lvVoltage = data?.can.lvVoltage ?? null;
-    const lvCurrent = data?.can.lvCurrent ?? null;
+    // ----- Rails -----
+    const hvVoltage = can?.hvVoltage ?? null;
+    const hvCurrent = can?.hvCurrent ?? null;
+    const lvVoltage = can?.lvVoltage ?? null;
+    const lvCurrent = can?.lvCurrent ?? null;
+    const power = can?.power ?? null;
 
-    const wheelSpeedFL = data?.can.wheelSpeedFL ?? null;
-    const wheelSpeedFR = data?.can.wheelSpeedFR ?? null;
-    const wheelSpeedRL = data?.can.wheelSpeedRL ?? null;
-    const wheelSpeedRR = data?.can.wheelSpeedRR ?? null;
-
-    // Derived faults — dashd emits four legs from diagnostics_low.shutdown_legX.
-    // SHUTDOWN_NAMES holds the placeholder leg labels until electrical clarifies
-    // which physical sub-system each leg represents.
+    // ----- Faults -----
+    const shutdown = can?.shutdown ?? null;
     const faultIndices = shutdown
         ? shutdown.map((ok, i) => (ok ? -1 : i)).filter(i => i >= 0)
         : null;
     const faultCount = faultIndices ? faultIndices.length : null;
 
     // ----- Render helpers -----
-
     const tempClass = (t: number | null): string => {
         if (t === null) return '';
         if (t > 80) return 'bad';
         if (t > 60) return 'warn';
+        return '';
+    };
+    // Cell imbalance: >100 mV is a real concern, >50 mV worth watching.
+    const spreadClass = (mv: number | null): string => {
+        if (mv === null) return '';
+        if (mv > 100) return 'bad';
+        if (mv > 50) return 'warn';
         return '';
     };
 
@@ -106,9 +109,8 @@ const PitDiagnostic: React.FC = () => {
 
     return (
         <div className="modern-dash-container pit-container">
-            {/* ===== TOP TRAY: connectivity + fault summary ===== */}
+            {/* ===== TOP TRAY: connectivity + fault summary + SoE hero ===== */}
             <div className="dash-card pit-tray pit-tray-top">
-                {/* Left: shared connectivity indicator (mirrors ScreenOne) */}
                 <div className="pit-tray-left">
                     <ConnectivityIndicator />
                 </div>
@@ -125,18 +127,70 @@ const PitDiagnostic: React.FC = () => {
                     )}
                 </div>
 
-                <div className="pit-tray-right">DIAG</div>
+                {/* SoE is the headline pit number — big, top-right. */}
+                <div className="pit-soe">
+                    <span className="label-small">SoE</span>
+                    <span className="pit-soe-val">
+                        {fmt(soe, 0)}<span className="unit-label">%</span>
+                    </span>
+                </div>
             </div>
 
-            {/* ===== MIDDLE: 4 section cards ===== */}
+            {/* ===== MIDDLE: 3 x 2 section cards ===== */}
             <div className="pit-middle">
-                {/* Driver inputs */}
+                {/* Driver inputs + brake bias */}
                 <div className="dash-card pit-section">
                     <div className="pit-section-title">DRIVER INPUTS</div>
                     {renderRow('APPS', apps, '%', 1)}
                     {renderRow('BPPS', bpps, '%', 1)}
-                    {renderRow('Brk F', brakePressureFront, 'psi', 0)}
-                    {renderRow('Brk R', brakePressureRear, 'psi', 0)}
+                    {renderRow('Bias F', brakeBias, '%', 0)}
+                    {/* Front / rear brake pressure on one row to keep the card to 4 rows. */}
+                    <div className="diag-row">
+                        <span className="label-small">Brk F/R</span>
+                        <span className="value-display diag-value">
+                            {fmt(brakePressureFront, 0)} / {fmt(brakePressureRear, 0)}
+                            <span className="unit-label">psi</span>
+                        </span>
+                    </div>
+                </div>
+
+                {/* Cell voltage health */}
+                <div className="dash-card pit-section">
+                    <div className="pit-section-title">CELL VOLTAGE</div>
+                    {renderRow('Max', cellVMax, 'V', 3)}
+                    {renderRow('Min', cellVMin, 'V', 3)}
+                    {renderRow('Δ Spread', cellVSpreadMv, 'mV', 0, spreadClass(cellVSpreadMv))}
+                </div>
+
+                {/* Running VCU energy */}
+                <div className="dash-card pit-section">
+                    <div className="pit-section-title">ENERGY · VCU</div>
+                    <div className="diag-row">
+                        <span className="label-small">Net</span>
+                        <span className="value-display diag-value">
+                            {fmtEnergy(vcuNet)}<span className="unit-label">{energyUnit(vcuNet)}</span>
+                        </span>
+                    </div>
+                    <div className="diag-row">
+                        <span className="label-small">Drive</span>
+                        <span className="value-display diag-value">
+                            {fmtEnergy(vcuDrive)}<span className="unit-label">{energyUnit(vcuDrive)}</span>
+                        </span>
+                    </div>
+                    <div className="diag-row">
+                        <span className="label-small">Regen</span>
+                        <span className="value-display diag-value good">
+                            {fmtEnergy(vcuRegen)}<span className="unit-label">{energyUnit(vcuRegen)}</span>
+                        </span>
+                    </div>
+                </div>
+
+                {/* Cell temps */}
+                <div className="dash-card pit-section">
+                    <div className="pit-section-title">CELL TEMP</div>
+                    {renderRow('Max', cellTempMax, '°C', 0, tempClass(cellTempMax))}
+                    {renderRow('Avg', cellTempAvg, '°C', 0, tempClass(cellTempAvg))}
+                    {renderRow('Min', cellTempMin, '°C', 0)}
                 </div>
 
                 {/* Powertrain temps */}
@@ -145,18 +199,6 @@ const PitDiagnostic: React.FC = () => {
                     {renderRow('Motor', motorTemp, '°C', 0, tempClass(motorTemp))}
                     {renderRow('Inv', inverterTemp, '°C', 0, tempClass(inverterTemp))}
                     {renderRow('Cool', coolantTemp, '°C', 0, tempClass(coolantTemp))}
-                    {renderRow('Cell↑', cellTempMax, '°C', 0, tempClass(cellTempMax))}
-                    {renderRow('Cell μ', cellTempAvg, '°C', 0, tempClass(cellTempAvg))}
-                    {renderRow('Cell↓', cellTempMin, '°C', 0)}
-                </div>
-
-                {/* Wheels */}
-                <div className="dash-card pit-section">
-                    <div className="pit-section-title">WHEELS</div>
-                    {renderRow('FL', wheelSpeedFL, '', 0)}
-                    {renderRow('FR', wheelSpeedFR, '', 0)}
-                    {renderRow('RL', wheelSpeedRL, '', 0)}
-                    {renderRow('RR', wheelSpeedRR, '', 0)}
                 </div>
 
                 {/* Active faults */}
@@ -168,57 +210,52 @@ const PitDiagnostic: React.FC = () => {
                         <div className="diag-fault-row empty">NONE</div>
                     ) : (
                         faultIndices
-                            .slice(0, 6)
+                            .slice(0, 4)
                             .map(i => (
                                 <div key={i} className="diag-fault-row">
                                     {SHUTDOWN_NAMES[i]}
                                 </div>
                             ))
                     )}
-                    {faultIndices && faultIndices.length > 6 && (
+                    {faultIndices && faultIndices.length > 4 && (
                         <div className="diag-fault-row empty">
-                            +{faultIndices.length - 6} more
+                            +{faultIndices.length - 4} more
                         </div>
                     )}
                 </div>
             </div>
 
-            {/* ===== BOTTOM TRAY: HV V | HV A | LV V | Odometer ===== */}
+            {/* ===== BOTTOM TRAY: HV V | HV A | LV V | LV A | Pack kW ===== */}
             <div className="dash-card pit-tray pit-tray-bottom">
                 <div className="pit-batt-grid">
                     <div className="pit-batt-cell">
                         <div className="label-small">HV V</div>
                         <div className="value-display pit-batt-val">
-                            {fmt(hvVoltage, 1)}
-                            <span className="unit-label">V</span>
+                            {fmt(hvVoltage, 1)}<span className="unit-label">V</span>
                         </div>
                     </div>
                     <div className="pit-batt-cell">
                         <div className="label-small">HV A</div>
                         <div className="value-display pit-batt-val">
-                            {fmt(hvCurrent, 1)}
-                            <span className="unit-label">A</span>
+                            {fmt(hvCurrent, 1)}<span className="unit-label">A</span>
                         </div>
                     </div>
                     <div className="pit-batt-cell">
                         <div className="label-small">LV V</div>
                         <div className="value-display pit-batt-val">
-                            {fmt(lvVoltage, 1)}
-                            <span className="unit-label">V</span>
+                            {fmt(lvVoltage, 1)}<span className="unit-label">V</span>
                         </div>
                     </div>
                     <div className="pit-batt-cell">
                         <div className="label-small">LV A</div>
                         <div className="value-display pit-batt-val">
-                            {fmt(lvCurrent, 1)}
-                            <span className="unit-label">A</span>
+                            {fmt(lvCurrent, 1)}<span className="unit-label">A</span>
                         </div>
                     </div>
                     <div className="pit-batt-cell">
-                        <div className="label-small">Odo</div>
+                        <div className="label-small">Pack</div>
                         <div className="value-display pit-batt-val">
-                            {fmt(odometer, 1)}
-                            <span className="unit-label">mi</span>
+                            {fmt(power, 1)}<span className="unit-label">kW</span>
                         </div>
                     </div>
                 </div>

--- a/BEVO/dashd/frontend/src/types/DashData.ts
+++ b/BEVO/dashd/frontend/src/types/DashData.ts
@@ -124,6 +124,9 @@ export interface DashMessage {
     // Website-authored lap-card layout (retained lhre/dash/layout), forwarded by
     // dashd. Validated at render; absent → the built-in lap card is used.
     layout?: unknown;
+    // Website-authored park/pit-screen layout (retained lhre/dash/parkLayout).
+    // Validated at render; absent → the built-in park screen is used.
+    parkLayout?: unknown;
 }
 
 // VCU event mode enum (matches firmware VCU_DEFAULT_PARAMS + per-event override

--- a/BEVO/dashd/frontend/src/types/DashData.ts
+++ b/BEVO/dashd/frontend/src/types/DashData.ts
@@ -66,6 +66,17 @@ export interface CanData {
     wheelSpeedFR?: number | null;
     wheelSpeedRL?: number | null;
     wheelSpeedRR?: number | null;
+
+    // Pack cell-voltage aggregates from pack.cells_v[]. cellVSpread (max-min)
+    // is the pack-imbalance health metric watched in the pit.
+    cellVMax?: number | null;         // V, highest cell
+    cellVMin?: number | null;         // V, lowest cell
+    cellVSpread?: number | null;      // V, max - min
+
+    // Running cumulative energy from the VCU's 0x1C9 Energy Estimate (Wh).
+    // VCU is the source of truth for energy — no client-side integration.
+    vcuNetEnergyWh?: number | null;     // net = drive - regen returned
+    vcuRegenEnergyWh?: number | null;   // cumulative regen returned
 }
 
 export interface MqttData {

--- a/BEVO/dashd/main.rs
+++ b/BEVO/dashd/main.rs
@@ -183,6 +183,27 @@ struct CanData {
     /// Lives on Controls.event_mode (byte 6 of 0x1C7 VCU State).
     #[serde(rename = "eventMode")]
     event_mode: Option<u8>,
+
+    /// Pack cell-voltage aggregates from pack.cells_v[] (V). None until cand
+    /// has received a cell-voltage packet (empty vec). `spread` (max - min) is
+    /// the pit crew's pack-imbalance health check — a widening spread flags a
+    /// weak/failing cell before it becomes a DNF.
+    #[serde(rename = "cellVMax")]
+    cell_v_max: Option<f32>,
+    #[serde(rename = "cellVMin")]
+    cell_v_min: Option<f32>,
+    #[serde(rename = "cellVSpread")]
+    cell_v_spread: Option<f32>,
+
+    /// Running cumulative energy from the VCU's 0x1C9 Energy Estimate
+    /// (Controls.net_energy / regen_energy, Wh). `net` is drive-minus-regen
+    /// returned; `regen` is cumulative regen. The VCU is the source of truth
+    /// for energy (no client-side integration) — these are what the pit crew
+    /// watches in Park to read session usage.
+    #[serde(rename = "vcuNetEnergyWh")]
+    vcu_net_energy_wh: Option<f32>,
+    #[serde(rename = "vcuRegenEnergyWh")]
+    vcu_regen_energy_wh: Option<f32>,
 }
 
 #[derive(Serialize, Clone, Default)]
@@ -544,16 +565,42 @@ fn extract_can_data(data: &OrionSensorData, last_qualified_soc: &mut Option<f32>
     // NOTE: soc_estimate lives on the Pack message (not DiagnosticsHigh).
     let soc = pack.map(|p| p.soc_estimate);
 
-    // Per-cell temp aggregates — None when cand has not received cell-temp
-    // packets yet (empty vec).
+    // Per-cell temp aggregates. Like cells_v[], cand fills cells_temps[] as
+    // packets arrive, so not-yet-received slots sit at exactly 0.0 — exclude
+    // those so min/avg aren't dragged toward 0 by unpopulated cells (max was
+    // already correct, which is why the driving screen's TEMP gauge looked
+    // fine). We filter *exactly* 0.0 rather than `> 0.0` because a real cell
+    // can read sub-zero. None until at least one populated cell is seen.
     let (cell_temp_max, cell_temp_avg, cell_temp_min) = pack
-        .map(|p| p.cells_temps.as_slice())
-        .filter(|t| !t.is_empty())
-        .map(|t| {
-            let max = t.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
-            let min = t.iter().cloned().fold(f32::INFINITY, f32::min);
-            let avg = t.iter().sum::<f32>() / t.len() as f32;
-            (Some(max), Some(avg), Some(min))
+        .map(|p| {
+            let vals: Vec<f32> = p.cells_temps.iter().cloned().filter(|&t| t != 0.0).collect();
+            if vals.is_empty() {
+                (None, None, None)
+            } else {
+                let max = vals.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+                let min = vals.iter().cloned().fold(f32::INFINITY, f32::min);
+                let avg = vals.iter().sum::<f32>() / vals.len() as f32;
+                (Some(max), Some(avg), Some(min))
+            }
+        })
+        .unwrap_or((None, None, None));
+
+    // Per-cell voltage aggregates from pack.cells_v[]. spread = max - min, the
+    // pack-imbalance metric. cand fills cells_v[] as per-cell packets arrive, so
+    // not-yet-received slots sit at exactly 0.0 — exclude those (a connected
+    // cell is never 0 V) or a half-populated array drags min/spread to garbage.
+    // None until at least one real (>0 V) cell has been seen. NB: cell *temps*
+    // are NOT filtered this way — 0 °C is a plausible real reading.
+    let (cell_v_max, cell_v_min, cell_v_spread) = pack
+        .map(|p| {
+            let vals: Vec<f32> = p.cells_v.iter().cloned().filter(|&v| v > 0.0).collect();
+            if vals.is_empty() {
+                (None, None, None)
+            } else {
+                let max = vals.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+                let min = vals.iter().cloned().fold(f32::INFINITY, f32::min);
+                (Some(max), Some(min), Some(max - min))
+            }
         })
         .unwrap_or((None, None, None));
 
@@ -656,6 +703,15 @@ fn extract_can_data(data: &OrionSensorData, last_qualified_soc: &mut Option<f32>
         // Wire value is uint8 but the proto declares the field as float
         // (matches prndl/soc convention); cast back for the frontend enum.
         event_mode: controls.map(|c| c.event_mode as u8),
+
+        cell_v_max,
+        cell_v_min,
+        cell_v_spread,
+
+        // Running cumulative energy from the VCU (Controls.net_energy /
+        // regen_energy, 0x1C9). Shown on the Park debug screen.
+        vcu_net_energy_wh: controls.map(|c| c.net_energy),
+        vcu_regen_energy_wh: controls.map(|c| c.regen_energy),
     }
 }
 

--- a/BEVO/dashd/main.rs
+++ b/BEVO/dashd/main.rs
@@ -276,6 +276,10 @@ struct DashMessage {
     /// built-in lap card.
     #[serde(skip_serializing_if = "Option::is_none")]
     layout: Option<serde_json::Value>,
+    /// Website-authored park/pit-screen layout (retained `lhre/dash/parkLayout`).
+    /// None until one is sent → frontend uses its built-in park screen.
+    #[serde(rename = "parkLayout", skip_serializing_if = "Option::is_none")]
+    park_layout: Option<serde_json::Value>,
 }
 
 /// Snapshot published to `lhre/dash/state` for the trackside link-health /
@@ -395,6 +399,9 @@ struct DashState {
     /// Website-authored lap-card layout (retained `lhre/dash/layout`), held as
     /// raw JSON and forwarded to the frontend. None → frontend's built-in card.
     layout: Option<serde_json::Value>,
+    /// Website-authored park/pit-screen layout (retained `lhre/dash/parkLayout`).
+    /// None → frontend's built-in park screen.
+    park_layout: Option<serde_json::Value>,
 }
 
 impl DashState {
@@ -523,6 +530,32 @@ fn load_layout() -> Option<serde_json::Value> {
     match serde_json::from_str::<serde_json::Value>(data.trim()) {
         Ok(v) => {
             println!("[DASHD] Restored lap-card layout from {}", path);
+            Some(v)
+        }
+        Err(_) => None,
+    }
+}
+
+// Park/pit-screen layout — same disk-cache pattern as the lap-card layout, own
+// file + env override so the two survive a reboot independently.
+const PARK_LAYOUT_PATH: &str = "/tmp/BEVO_dash_parklayout.json";
+
+fn park_layout_path() -> String {
+    env_or_default("DASHD_PARK_LAYOUT_PATH", PARK_LAYOUT_PATH)
+}
+
+fn persist_park_layout(raw: &str) {
+    if let Err(e) = std::fs::write(park_layout_path(), raw) {
+        eprintln!("[DASHD] Failed to persist park layout: {}", e);
+    }
+}
+
+fn load_park_layout() -> Option<serde_json::Value> {
+    let path = park_layout_path();
+    let data = std::fs::read_to_string(&path).ok()?;
+    match serde_json::from_str::<serde_json::Value>(data.trim()) {
+        Ok(v) => {
+            println!("[DASHD] Restored park layout from {}", path);
             Some(v)
         }
         Err(_) => None,
@@ -841,7 +874,8 @@ fn ws_server_loop(state: Arc<Mutex<DashState>>) {
                                 mqtt.lap_trigger = Some(locked.lap_count as f32);
                                 let pacing = locked.pacing(Instant::now());
                                 let layout = locked.layout.clone();
-                                DashMessage { seq, can, mqtt, pacing, layout }
+                                let park_layout = locked.park_layout.clone();
+                                DashMessage { seq, can, mqtt, pacing, layout, park_layout }
                             };
 
                             let json = match serde_json::to_string(&message) {
@@ -987,6 +1021,31 @@ fn mqtt_subscriber_loop(state: Arc<Mutex<DashState>>) {
                             }
                             Err(e) => {
                                 eprintln!("[DASHD] MQTT bad layout payload: {}", e)
+                            }
+                        }
+                        continue;
+                    }
+
+                    // parkLayout: the park/pit-screen layout. Same handling as
+                    // `layout` — retained, cached to disk, forwarded verbatim.
+                    if field == "parkLayout" {
+                        match serde_json::from_str::<serde_json::Value>(payload_str) {
+                            Ok(v) => {
+                                {
+                                    let mut locked = state.lock().unwrap();
+                                    locked.park_layout = Some(v);
+                                }
+                                persist_park_layout(payload_str);
+                                let _ = client.publish(
+                                    format!("{}ack/parkLayout", MQTT_TOPIC_PREFIX),
+                                    QoS::AtMostOnce,
+                                    true,
+                                    payload_str.as_bytes().to_vec(),
+                                );
+                                println!("[DASHD] Loaded park layout ({} bytes)", payload_str.len());
+                            }
+                            Err(e) => {
+                                eprintln!("[DASHD] MQTT bad parkLayout payload: {}", e)
                             }
                         }
                         continue;
@@ -1222,6 +1281,7 @@ fn main() -> Result<()> {
         last_lap: None,
         // Restore the last layout from disk; the retained MQTT topic refreshes it.
         layout: load_layout(),
+        park_layout: load_park_layout(),
     }));
 
     let ipc_state = Arc::clone(&state);

--- a/BEVO/dashd/main.rs
+++ b/BEVO/dashd/main.rs
@@ -296,6 +296,14 @@ struct DashStateMsg {
     soc: Option<f32>,
     temperature: Option<f32>,
     pacing: PacingData,
+    /// Free + total space on `/` (MB). The car's storage kill switch
+    /// (start_telemetry.sh) stops telemetry when free < 1024 MB, so trackside
+    /// can warn before that. None until the first disk poll.
+    disk_free_mb: Option<f64>,
+    disk_total_mb: Option<f64>,
+    /// Seconds the telemetry stack has been running. The same kill switch stops
+    /// at 3600 s (1 h); surfaced so trackside can watch the runtime cap too.
+    runtime_s: Option<f32>,
 }
 
 // ---------------------------------------------------------------------------
@@ -362,6 +370,12 @@ impl MqttState {
 
 struct DashState {
     can: CanData,
+    /// When this dashd (i.e. the telemetry stack) started — for the runtime
+    /// readout vs the 1-hour storage kill switch.
+    boot: Instant,
+    /// Latest free / total space on `/` (MB), refreshed by disk_monitor_loop.
+    disk_free_mb: Option<f64>,
+    disk_total_mb: Option<f64>,
     /// Wall-clock time of the most recent successful IPC decode. Used by the
     /// WS sender to null out CanData once cand has stopped publishing.
     last_can_update: Instant,
@@ -1236,6 +1250,9 @@ fn mqtt_state_publisher_loop(state: Arc<Mutex<DashState>>) {
                     soc: locked.can.soc,
                     temperature: locked.can.temperature,
                     pacing: locked.pacing(now),
+                    disk_free_mb: locked.disk_free_mb,
+                    disk_total_mb: locked.disk_total_mb,
+                    runtime_s: Some(locked.boot.elapsed().as_secs_f32()),
                 };
                 serde_json::to_string(&msg)
             };
@@ -1261,9 +1278,43 @@ fn mqtt_state_publisher_loop(state: Arc<Mutex<DashState>>) {
 // Main
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Thread 5: disk monitor — polls free space on `/` so trackside can watch the
+// storage kill switch (start_telemetry.sh stops telemetry when free < 1024 MB).
+// ---------------------------------------------------------------------------
+
+/// (free_mb, total_mb) on `/` via `df -k` — the same filesystem + metric the
+/// kill switch reads (`df / | awk 'NR==2 {print $4/1024}'`). None on parse fail.
+fn read_disk_mb() -> Option<(f64, f64)> {
+    let out = std::process::Command::new("df").arg("-k").arg("/").output().ok()?;
+    let text = String::from_utf8_lossy(&out.stdout);
+    // Header line, then the root filesystem row:
+    //   Filesystem  1K-blocks  Used  Available  Use%  Mounted-on
+    let cols: Vec<&str> = text.lines().nth(1)?.split_whitespace().collect();
+    let total_kb: f64 = cols.get(1)?.parse().ok()?;
+    let avail_kb: f64 = cols.get(3)?.parse().ok()?;
+    Some((avail_kb / 1024.0, total_kb / 1024.0))
+}
+
+fn disk_monitor_loop(state: Arc<Mutex<DashState>>) {
+    loop {
+        if let Some((free_mb, total_mb)) = read_disk_mb() {
+            let mut locked = state.lock().unwrap();
+            locked.disk_free_mb = Some(free_mb);
+            locked.disk_total_mb = Some(total_mb);
+        }
+        // The kill switch checks every 60 s; 15 s here gives trackside a little
+        // more lead time without being chatty.
+        thread::sleep(Duration::from_secs(15));
+    }
+}
+
 fn main() -> Result<()> {
     let state = Arc::new(Mutex::new(DashState {
         can: CanData::default(),
+        boot: Instant::now(),
+        disk_free_mb: None,
+        disk_total_mb: None,
         // Start stale so the dash shows "--" until cand actually connects.
         last_can_update: Instant::now() - CAN_STALE_TIMEOUT,
         last_qualified_soc: None,
@@ -1295,6 +1346,9 @@ fn main() -> Result<()> {
 
     let pub_state = Arc::clone(&state);
     thread::spawn(move || mqtt_state_publisher_loop(pub_state));
+
+    let disk_state = Arc::clone(&state);
+    thread::spawn(move || disk_monitor_loop(disk_state));
 
     println!(
         "[DASHD] Started (IPC reader + WebSocket on :{} + MQTT subscriber + state publisher)",

--- a/telemtry/analysis/database/viewer_tool/src/app/api/dash/layouts/route.ts
+++ b/telemtry/analysis/database/viewer_tool/src/app/api/dash/layouts/route.ts
@@ -9,16 +9,21 @@ import { NextRequest, NextResponse } from "next/server";
 import { promises as fs } from "fs";
 import path from "path";
 
-function libPath(): string {
+// Per-screen library file. `lapCard` keeps the original library.json (so saved
+// lap cards survive this change); any other screen gets library.<screen>.json.
+// `screen` is sanitized to a safe slug so the query param can't escape the dir.
+function libPath(screen: string): string {
   const dir = process.env.CACHE_DIR
     ? path.join(process.env.CACHE_DIR, "dash_layouts")
     : path.join(process.cwd(), ".cache", "dash_layouts");
-  return path.join(dir, "library.json");
+  const slug = (screen || "lapCard").replace(/[^a-zA-Z0-9_-]/g, "").slice(0, 40) || "lapCard";
+  return path.join(dir, slug === "lapCard" ? "library.json" : `library.${slug}.json`);
 }
 
-export async function GET() {
+export async function GET(req: NextRequest) {
+  const screen = req.nextUrl.searchParams.get("screen") ?? "lapCard";
   try {
-    const raw = await fs.readFile(libPath(), "utf-8");
+    const raw = await fs.readFile(libPath(screen), "utf-8");
     return NextResponse.json(JSON.parse(raw));
   } catch {
     return NextResponse.json({ items: [], savedAt: 0 });
@@ -26,9 +31,10 @@ export async function GET() {
 }
 
 export async function PUT(req: NextRequest) {
+  const screen = req.nextUrl.searchParams.get("screen") ?? "lapCard";
   const body = (await req.json().catch(() => ({}))) as { items?: unknown };
   const items = Array.isArray(body.items) ? body.items : [];
-  const p = libPath();
+  const p = libPath(screen);
   await fs.mkdir(path.dirname(p), { recursive: true });
   const tmp = `${p}.tmp`;
   await fs.writeFile(tmp, JSON.stringify({ items, savedAt: Date.now() }));

--- a/telemtry/analysis/database/viewer_tool/src/app/api/dash/layouts/route.ts
+++ b/telemtry/analysis/database/viewer_tool/src/app/api/dash/layouts/route.ts
@@ -32,12 +32,29 @@ export async function GET(req: NextRequest) {
 
 export async function PUT(req: NextRequest) {
   const screen = req.nextUrl.searchParams.get("screen") ?? "lapCard";
-  const body = (await req.json().catch(() => ({}))) as { items?: unknown };
+  const body = (await req.json().catch(() => ({}))) as { items?: unknown; baseSavedAt?: unknown };
   const items = Array.isArray(body.items) ? body.items : [];
+  const baseSavedAt = typeof body.baseSavedAt === "number" ? body.baseSavedAt : null;
   const p = libPath(screen);
+
+  // Optimistic concurrency: if the caller passed the savedAt it loaded and the
+  // file has since moved on (another editor saved), reject so the client can
+  // merge instead of silently clobbering. First write (no file) always allowed;
+  // callers that don't pass baseSavedAt keep the old overwrite behavior.
+  let current: { items?: unknown; savedAt?: unknown } | null = null;
+  try { current = JSON.parse(await fs.readFile(p, "utf-8")); } catch { /* no file yet */ }
+  const currentSavedAt = typeof current?.savedAt === "number" ? current.savedAt : null;
+  if (baseSavedAt != null && currentSavedAt != null && baseSavedAt !== currentSavedAt) {
+    return NextResponse.json(
+      { conflict: true, items: Array.isArray(current?.items) ? current!.items : [], savedAt: currentSavedAt },
+      { status: 409 },
+    );
+  }
+
+  const savedAt = Date.now();
   await fs.mkdir(path.dirname(p), { recursive: true });
   const tmp = `${p}.tmp`;
-  await fs.writeFile(tmp, JSON.stringify({ items, savedAt: Date.now() }));
+  await fs.writeFile(tmp, JSON.stringify({ items, savedAt }));
   await fs.rename(tmp, p); // atomic
-  return NextResponse.json({ ok: true, count: items.length });
+  return NextResponse.json({ ok: true, count: items.length, savedAt });
 }

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
@@ -1794,11 +1794,13 @@ function App() {
 
   // Publish the lap-card layout to the car (retained: used until replaced). Only
   // the session leader commands the car; the dash link must be connected.
-  function sendLapLayout(layout: LapCardLayout) {
+  function sendDashLayout(screenId: string, layout: LapCardLayout) {
     if (isMirrorRef.current) { setLayoutSendStatus("Read-only mirror — only the session leader can push to the car."); return; }
     if (dashSignals.status !== "connected") { setLayoutSendStatus("Connect to the dash first (Dash tab → Connect to dash)."); return; }
-    const ok = dashSignals.publishLayout(layout);
-    setLayoutSendStatus(ok ? `Sent “${layout.name}” to the car ✓ (retained — used until replaced)` : "Publish failed — check the dash link.");
+    // Route to the screen's retained topic: park → parkLayout, else the lap card.
+    const ok = screenId === "park" ? dashSignals.publishParkLayout(layout) : dashSignals.publishLayout(layout);
+    const where = screenId === "park" ? "park screen" : "lap card";
+    setLayoutSendStatus(ok ? `Sent “${layout.name}” to the ${where} ✓ (retained — used until replaced)` : "Publish failed — check the dash link.");
     window.setTimeout(() => setLayoutSendStatus(""), 5000);
   }
 
@@ -2718,7 +2720,7 @@ function App() {
         />
       ) : null}
       {lapDesignerOpen ? (
-        <DashLayoutEditor onClose={() => setLapDesignerOpen(false)} onSend={sendLapLayout} sendStatus={layoutSendStatus} />
+        <DashLayoutEditor onClose={() => setLapDesignerOpen(false)} onSend={sendDashLayout} sendStatus={layoutSendStatus} />
       ) : null}
       {confirmStopOpen ? (
         <div className="modalOverlay" onMouseDown={() => setConfirmStopOpen(false)}>
@@ -3959,7 +3961,7 @@ function App() {
             </div>
             <div className="gateButtons" style={{ marginTop: 10 }}>
               <button className="tool" disabled={isMirror} onClick={() => setLapDesignerOpen(true)}>
-                <SlidersHorizontal size={15} /> Design lap screen
+                <SlidersHorizontal size={15} /> Design dash screens
               </button>
             </div>
             <label style={{ marginTop: 10 }}>

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
@@ -11,7 +11,7 @@ import { useSession } from "next-auth/react";
 import { DashLayoutEditor } from "@/components/dashlayout/DashLayoutEditor";
 import { DashMessageEditor } from "@/components/dashlayout/DashMessageEditor";
 import type { LapCardLayout } from "@/lib/dash/dashLayout";
-import { useDashSignals } from "@/lib/dash/dashSignals";
+import { useDashSignals, type DashMirrorState } from "@/lib/dash/dashSignals";
 import { useMessageLibrary } from "@/lib/dash/useMessageLibrary";
 import { activeMessages, MESSAGE_ICON_GLYPH, type DashMessage } from "@/lib/dash/dashMessages";
 import { useRacePlan } from "@/lib/dash/useRacePlan";
@@ -2694,6 +2694,7 @@ function App() {
 
   return (
     <main className="shell">
+      {activeTab === "live" ? <CarStorageBar dash={dashSignals.dashState} /> : null}
       {showTour ? (
         <TracksideTour
           onNavigate={(tab) => setActiveTab(tab)}
@@ -4328,6 +4329,46 @@ function CarStatusPanel({
         )}
       </div>
     </Panel>
+  );
+}
+
+// Thin top-edge bar that mirrors the car's on-board storage kill switch
+// (start_telemetry.sh stops telemetry when free space on / < 1 GB, or after 1 h
+// runtime). Renders nothing until the car's dashd reports the fields, so it's
+// invisible pre-deploy / when the car isn't publishing. Tracks the SAME metric
+// + thresholds the kill switch uses, so "approaching red" = "about to be cut".
+function CarStorageBar({ dash }: { dash: DashMirrorState | null }) {
+  const freeMb = dash?.diskFreeMb ?? null;
+  const totalMb = dash?.diskTotalMb ?? null;
+  const runtimeS = dash?.runtimeS ?? null;
+  if (freeMb == null && runtimeS == null) return null; // car not reporting yet
+
+  const KILL_FREE = 1024, WARN_FREE = 2048;     // MB
+  const KILL_RUN = 3600, WARN_RUN = 3000;       // s (1 h kill, 50 min warn)
+  const freeGb = freeMb == null ? null : freeMb / 1024;
+  const usedFrac = freeMb != null && totalMb ? Math.max(0, Math.min(1, 1 - freeMb / totalMb)) : 0;
+  const diskTone = freeMb == null ? "" : freeMb < KILL_FREE ? "crit" : freeMb < WARN_FREE ? "warn" : "ok";
+  const runFrac = runtimeS == null ? 0 : Math.max(0, Math.min(1, runtimeS / KILL_RUN));
+  const runTone = runtimeS == null ? "" : runtimeS > KILL_RUN ? "crit" : runtimeS > WARN_RUN ? "warn" : "ok";
+  const mmss = (s: number) => `${Math.floor(s / 60)}:${String(Math.floor(s % 60)).padStart(2, "0")}`;
+
+  return (
+    <div className="carStorageBar" role="status" aria-label="Car storage and runtime">
+      <span className="csbTag">BEVO</span>
+      <div className={`csbSeg ${diskTone}`} title={`Free space on / — telemetry stops below 1 GB${totalMb ? ` (disk ${(totalMb / 1024).toFixed(0)} GB)` : ""}`}>
+        <span className="csbCap">DISK</span>
+        <div className="csbTrack">
+          <span className="csbFill" style={{ width: `${usedFrac * 100}%` }} />
+          {totalMb ? <span className="csbKill" style={{ left: `${Math.max(0, Math.min(100, (1 - KILL_FREE / totalMb) * 100))}%` }} /> : null}
+        </div>
+        <b className="csbVal">{freeGb == null ? "--" : `${freeGb.toFixed(1)} GB free`}</b>
+      </div>
+      <div className={`csbSeg ${runTone}`} title="Telemetry stops after 1 h of runtime">
+        <span className="csbCap">RUN</span>
+        <div className="csbTrack"><span className="csbFill" style={{ width: `${runFrac * 100}%` }} /></div>
+        <b className="csbVal">{runtimeS == null ? "--" : `${mmss(runtimeS)} / 60:00`}</b>
+      </div>
+    </div>
   );
 }
 

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/trackside.css
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/trackside.css
@@ -841,10 +841,10 @@ textarea:focus-visible,
   box-shadow: 0 24px 70px rgba(0, 0, 0, 0.5);
   overflow: hidden;
 }
-.dashEditorHead { display: flex; align-items: center; justify-content: space-between; gap: var(--s-3); padding: var(--s-3) var(--s-4); border-bottom: 1px solid var(--border); }
-.dashEditorTitle { display: flex; align-items: center; gap: var(--s-3); min-width: 0; }
-.dashEditorTitle input { background: var(--surface-alt); border: 1px solid var(--border); border-radius: var(--radius); padding: 4px 8px; color: var(--text); font-size: var(--fs-sm); }
-.dashEditorActions { display: flex; align-items: center; gap: var(--s-2); }
+.dashEditorHead { display: flex; align-items: center; justify-content: space-between; gap: var(--s-3); row-gap: var(--s-2); flex-wrap: wrap; padding: var(--s-3) var(--s-4); border-bottom: 1px solid var(--border); }
+.dashEditorTitle { display: flex; align-items: center; gap: var(--s-2); row-gap: var(--s-2); flex-wrap: wrap; min-width: 0; flex: 1 1 auto; }
+.dashEditorTitle input { background: var(--surface-alt); border: 1px solid var(--border); border-radius: var(--radius); padding: 4px 8px; color: var(--text); font-size: var(--fs-sm); max-width: 160px; }
+.dashEditorActions { display: flex; align-items: center; gap: var(--s-2); row-gap: var(--s-2); flex-wrap: wrap; justify-content: flex-end; flex: 0 1 auto; }
 .dashEditorStatus { padding: 6px var(--s-4); font-size: var(--fs-sm); color: var(--fresh); background: color-mix(in srgb, var(--fresh) 10%, transparent); border-bottom: 1px solid var(--border); }
 .dashEditorBody { flex: 1; display: grid; grid-template-columns: 190px 1fr 270px; min-height: 0; }
 .dashEditorRail { border-right: 1px solid var(--border); display: flex; flex-direction: column; min-height: 0; }

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/trackside.css
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/trackside.css
@@ -830,6 +830,34 @@ textarea:focus-visible,
 .syncBanner.leader { border-color: color-mix(in srgb, var(--fresh) 45%, var(--border)); background: color-mix(in srgb, var(--fresh) 8%, transparent); }
 
 /* ---- Lap-screen designer (dash layout editor) ---- */
+/* Thin car-storage / runtime bar pinned at the top edge of the live view.
+   Mirrors the on-car kill switch (free < 1 GB or runtime > 1 h stops telemetry). */
+.carStorageBar {
+  display: flex;
+  align-items: center;
+  gap: var(--s-3);
+  padding: 3px 12px;
+  font-size: 0.72rem;
+  background: var(--surface-alt, var(--surface));
+  border-bottom: 1px solid var(--border);
+  min-height: 22px;
+}
+.carStorageBar .csbTag { font-weight: 700; letter-spacing: 1px; color: var(--muted-text); flex-shrink: 0; }
+.csbSeg { display: flex; align-items: center; gap: 6px; min-width: 0; flex: 1 1 0; max-width: 360px; }
+.csbSeg .csbCap { color: var(--muted-text); letter-spacing: 1px; flex-shrink: 0; }
+.csbTrack {
+  position: relative; flex: 1 1 auto; height: 8px; min-width: 60px;
+  background: var(--bar-track, rgba(255,255,255,0.1)); border-radius: 4px; overflow: hidden;
+}
+.csbFill { position: absolute; left: 0; top: 0; bottom: 0; border-radius: 4px; background: #2ee06a; transition: width 0.4s ease; }
+.csbSeg.warn .csbFill { background: #FFD700; }
+.csbSeg.crit .csbFill { background: #FF3333; }
+/* kill marker: where free space hits the 1 GB cutoff */
+.csbKill { position: absolute; top: -1px; bottom: -1px; width: 2px; background: #FF3333; opacity: 0.85; }
+.csbVal { flex-shrink: 0; font-variant-numeric: tabular-nums; white-space: nowrap; }
+.csbSeg.warn .csbVal { color: #FFD700; }
+.csbSeg.crit .csbVal { color: #FF3333; }
+
 .dashEditor {
   width: min(1180px, 96vw);
   height: min(760px, 92vh);

--- a/telemtry/analysis/database/viewer_tool/src/components/dashlayout/DashLayoutEditor.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/components/dashlayout/DashLayoutEditor.tsx
@@ -380,6 +380,9 @@ function PropertyPanel({ w, fields, onChange, onDelete }: { w: Widget; fields: F
                 if (fd.bidirectional != null) (p as { bidirectional?: boolean }).bidirectional = fd.bidirectional;
               }
               if ((w.type === 'delta' || w.type === 'bar') && fd.goodSign) (p as { goodSign?: GoodSign }).goodSign = fd.goodSign;
+              // Enum/bitfield fields (e.g. VCU event mode) pre-fill the value→label
+              // map so the widget shows "ENDUR" not 4; clears it for plain numbers.
+              if (w.type === 'value') (p as { valueMap?: Record<string, string> }).valueMap = fd.enumMap;
             }
             onChange(p);
           }}>
@@ -451,6 +454,9 @@ function PropertyPanel({ w, fields, onChange, onDelete }: { w: Widget; fields: F
       {w.type === 'value' && (
         <ThresholdRules rules={w.thresholds ?? []} onChange={(r) => onChange({ thresholds: r })} />
       )}
+      {w.type === 'value' && (
+        <ValueLabels map={w.valueMap} onChange={(m) => onChange({ valueMap: m })} />
+      )}
       <div className="propGrid">
         <Row label="X"><input type="number" value={w.x} onChange={(e) => onChange({ x: Number(e.target.value) })} /></Row>
         <Row label="Y"><input type="number" value={w.y} onChange={(e) => onChange({ y: Number(e.target.value) })} /></Row>
@@ -479,6 +485,35 @@ function ThresholdRules({ rules, onChange }: { rules: ColorRule[]; onChange: (r:
         </div>
       ))}
       {!rules.length && <p className="muted" style={{ fontSize: '0.78rem', margin: '2px 0 0' }}>e.g. &lt; 20 → red for low SoC. Last matching rule wins.</p>}
+    </div>
+  );
+}
+
+// Value→label map editor for value widgets — turns an enum/bitfield number into
+// its meaning (e.g. 4 → ENDUR). Binding an enum field (VCU event mode) pre-fills
+// this; it's editable for any field. A value with no matching key shows numerically.
+function ValueLabels({ map, onChange }: { map?: Record<string, string>; onChange: (m: Record<string, string> | undefined) => void }) {
+  const entries = Object.entries(map ?? {});
+  const rebuild = (next: [string, string][]) => {
+    const obj: Record<string, string> = {};
+    for (const [k, v] of next) if (k.trim() !== '') obj[k.trim()] = v;
+    onChange(Object.keys(obj).length ? obj : undefined);
+  };
+  return (
+    <div className="thresholdRules">
+      <div className="propHead"><span className="muted" style={{ fontSize: '0.78rem', textTransform: 'uppercase', letterSpacing: 1 }}>Value labels</span>
+        <button className="tool" onClick={() => rebuild([...entries, [String(entries.length), '']])}>+ Label</button>
+      </div>
+      {entries.map(([k, v], i) => (
+        <div key={i} className="thresholdRule">
+          <input type="number" value={k} style={{ width: 56 }} aria-label="value"
+            onChange={(e) => rebuild(entries.map((en, idx) => (idx === i ? [e.target.value, en[1]] : en)))} />
+          <input type="text" value={v} placeholder="label" aria-label="label"
+            onChange={(e) => rebuild(entries.map((en, idx) => (idx === i ? [en[0], e.target.value] : en)))} />
+          <button className="tool iconOnly" aria-label="Remove label" onClick={() => rebuild(entries.filter((_, idx) => idx !== i))}><Trash2 size={12} /></button>
+        </div>
+      ))}
+      {!entries.length && <p className="muted" style={{ fontSize: '0.78rem', margin: '2px 0 0' }}>Map a number to text, e.g. 4 → ENDUR (enums / bitfields).</p>}
     </div>
   );
 }

--- a/telemtry/analysis/database/viewer_tool/src/components/dashlayout/DashLayoutEditor.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/components/dashlayout/DashLayoutEditor.tsx
@@ -345,7 +345,7 @@ export function DashLayoutEditor({ onClose, onSend, sendStatus, initialScreenId 
           {/* property panel */}
           <aside className="dashEditorProps">
             {!selected ? <p className="muted" style={{ padding: 8 }}>Select a widget to edit its data &amp; style.</p> : (
-              <PropertyPanel w={selected} fields={fields} onChange={(p) => patch(selected.id, p)} onDelete={removeSelected} />
+              <PropertyPanel key={selected.id} w={selected} fields={fields} onChange={(p) => patch(selected.id, p)} onDelete={removeSelected} />
             )}
           </aside>
         </div>
@@ -455,7 +455,7 @@ function PropertyPanel({ w, fields, onChange, onDelete }: { w: Widget; fields: F
         <ThresholdRules rules={w.thresholds ?? []} onChange={(r) => onChange({ thresholds: r })} />
       )}
       {w.type === 'value' && (
-        <ValueLabels map={w.valueMap} onChange={(m) => onChange({ valueMap: m })} />
+        <ValueLabels key={w.bind} map={w.valueMap} onChange={(m) => onChange({ valueMap: m })} />
       )}
       <div className="propGrid">
         <Row label="X"><input type="number" value={w.x} onChange={(e) => onChange({ x: Number(e.target.value) })} /></Row>
@@ -492,28 +492,35 @@ function ThresholdRules({ rules, onChange }: { rules: ColorRule[]; onChange: (r:
 // Value→label map editor for value widgets — turns an enum/bitfield number into
 // its meaning (e.g. 4 → ENDUR). Binding an enum field (VCU event mode) pre-fills
 // this; it's editable for any field. A value with no matching key shows numerically.
+//
+// Edits an ordered ROW LIST internally (not the value→label object directly) so
+// "+ Label" always appends a fresh blank row, blank/half-typed rows persist while
+// you fill them, and typing a key never reorders or overwrites another row. The
+// object is rebuilt (deduped, blank keys dropped) only when emitting. Remounted
+// per field via key={w.bind} at the call site, so an external prefill flows in.
 function ValueLabels({ map, onChange }: { map?: Record<string, string>; onChange: (m: Record<string, string> | undefined) => void }) {
-  const entries = Object.entries(map ?? {});
-  const rebuild = (next: [string, string][]) => {
+  const [rows, setRows] = useState<[string, string][]>(() => Object.entries(map ?? {}));
+  const emit = (next: [string, string][]) => {
+    setRows(next);
     const obj: Record<string, string> = {};
-    for (const [k, v] of next) if (k.trim() !== '') obj[k.trim()] = v;
+    for (const [k, v] of next) { const kk = k.trim(); if (kk !== '') obj[kk] = v; } // last wins on dup key
     onChange(Object.keys(obj).length ? obj : undefined);
   };
   return (
     <div className="thresholdRules">
       <div className="propHead"><span className="muted" style={{ fontSize: '0.78rem', textTransform: 'uppercase', letterSpacing: 1 }}>Value labels</span>
-        <button className="tool" onClick={() => rebuild([...entries, [String(entries.length), '']])}>+ Label</button>
+        <button className="tool" onClick={() => emit([...rows, ['', '']])}>+ Label</button>
       </div>
-      {entries.map(([k, v], i) => (
+      {rows.map(([k, v], i) => (
         <div key={i} className="thresholdRule">
-          <input type="number" value={k} style={{ width: 56 }} aria-label="value"
-            onChange={(e) => rebuild(entries.map((en, idx) => (idx === i ? [e.target.value, en[1]] : en)))} />
+          <input type="number" value={k} placeholder="#" style={{ width: 56 }} aria-label="value"
+            onChange={(e) => emit(rows.map((r, idx) => (idx === i ? [e.target.value, r[1]] : r)))} />
           <input type="text" value={v} placeholder="label" aria-label="label"
-            onChange={(e) => rebuild(entries.map((en, idx) => (idx === i ? [en[0], e.target.value] : en)))} />
-          <button className="tool iconOnly" aria-label="Remove label" onClick={() => rebuild(entries.filter((_, idx) => idx !== i))}><Trash2 size={12} /></button>
+            onChange={(e) => emit(rows.map((r, idx) => (idx === i ? [r[0], e.target.value] : r)))} />
+          <button className="tool iconOnly" aria-label="Remove label" onClick={() => emit(rows.filter((_, idx) => idx !== i))}><Trash2 size={12} /></button>
         </div>
       ))}
-      {!entries.length && <p className="muted" style={{ fontSize: '0.78rem', margin: '2px 0 0' }}>Map a number to text, e.g. 4 → ENDUR (enums / bitfields).</p>}
+      {!rows.length && <p className="muted" style={{ fontSize: '0.78rem', margin: '2px 0 0' }}>Map a number to text, e.g. 4 → ENDUR (enums / bitfields).</p>}
     </div>
   );
 }

--- a/telemtry/analysis/database/viewer_tool/src/components/dashlayout/DashLayoutEditor.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/components/dashlayout/DashLayoutEditor.tsx
@@ -139,34 +139,61 @@ export function DashLayoutEditor({ onClose, onSend, sendStatus, initialScreenId 
   snapRef.current = snap;
   const drag = useRef<null | { mode: 'move' | 'resize'; id: string; sx: number; sy: number; ox: number; oy: number; ow: number; oh: number }>(null);
 
+  const [syncMsg, setSyncMsg] = useState('Syncing…');
+  // The server library version we last loaded — sent with each save so the
+  // server can reject (409) if another editor saved in between, rather than us
+  // silently clobbering their work. null = unknown (first save / offline).
+  const serverSavedAtRef = useRef<number | null>(null);
+
+  // Push the library to the shared server with optimistic concurrency. On a
+  // conflict the server returns its current copy; we MERGE (server as the base,
+  // our actively-edited layout wins, plus any layouts only we have) and re-save
+  // on the fresh version — so concurrent edits to *different* layouts both
+  // survive, and only simultaneous edits to the *same* layout are last-wins.
+  const pushToServer = useCallback(async (screen: string, items: LapCardLayout[], activeId: string) => {
+    const r = await saveServerLayouts(screen, items, serverSavedAtRef.current);
+    if (r.ok) { serverSavedAtRef.current = r.savedAt ?? serverSavedAtRef.current; setSyncMsg('Synced'); return; }
+    if (r.conflict && r.items) {
+      const byId = new Map<string, LapCardLayout>(r.items.map(withId).map((l) => [l.id!, l]));
+      for (const l of items) if (l.id === activeId || !byId.has(l.id!)) byId.set(l.id!, withId(l));
+      const merged = Array.from(byId.values());
+      serverSavedAtRef.current = r.savedAt ?? null; // adopt the server's new base
+      setSyncMsg('Merged changes from another editor');
+      // setLib re-triggers the debounced effect, which re-saves on the fresh base.
+      setLib((prev) => ({ items: merged, activeId: merged.some((i) => i.id === prev.activeId) ? prev.activeId : (merged[0]?.id ?? prev.activeId) }));
+    }
+  }, []);
+
   // Persist locally on every change; debounce a push to the shared server copy
   // so every client sees the same saved layouts.
   const serverSaveTimer = useRef<number | null>(null);
   useEffect(() => {
     const key = screenDef(libScreenRef.current).libraryKey;
     const screen = libScreenRef.current;
-    try { localStorage.setItem(key, JSON.stringify(lib)); } catch { /* quota */ }
+    const snapshot = lib;
+    try { localStorage.setItem(key, JSON.stringify(snapshot)); } catch { /* quota */ }
     if (serverSaveTimer.current) window.clearTimeout(serverSaveTimer.current);
-    serverSaveTimer.current = window.setTimeout(() => { void saveServerLayouts(screen, lib.items); }, 800);
+    serverSaveTimer.current = window.setTimeout(() => { void pushToServer(screen, snapshot.items, snapshot.activeId); }, 800);
     return () => { if (serverSaveTimer.current) window.clearTimeout(serverSaveTimer.current); };
-  }, [lib]);
+  }, [lib, pushToServer]);
 
   // Pull a screen's shared library. Server is the source of truth if it has
   // anything; if it's empty but we have local layouts, seed it from local.
-  const [syncMsg, setSyncMsg] = useState('Syncing…');
   const pullFromServer = useCallback(async (screen: string, localItems: LapCardLayout[], announce = true) => {
     if (announce) setSyncMsg('Syncing…');
     const server = await fetchServerLayouts(screen);
     if (server === null) { setSyncMsg('Offline — local only'); return; }
-    if (server.length) {
-      const items = server.map(withId);
+    serverSavedAtRef.current = server.savedAt; // remember the base we loaded
+    if (server.items.length) {
+      const items = server.items.map(withId);
       libScreenRef.current = screen;
       setLib((prev) => ({ items, activeId: items.some((i) => i.id === prev.activeId) ? prev.activeId : items[0].id! }));
       setSyncMsg('Synced');
     } else {
       // server empty — seed it from whatever we have locally
       setSyncMsg('Synced');
-      void saveServerLayouts(screen, localItems);
+      const r = await saveServerLayouts(screen, localItems, server.savedAt);
+      if (r.ok) serverSavedAtRef.current = r.savedAt ?? serverSavedAtRef.current;
     }
   }, []);
   useEffect(() => { void pullFromServer(screenId, lib.items); /* on open only */ // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/telemtry/analysis/database/viewer_tool/src/components/dashlayout/DashLayoutEditor.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/components/dashlayout/DashLayoutEditor.tsx
@@ -401,6 +401,19 @@ function PropertyPanel({ w, fields, onChange, onDelete }: { w: Widget; fields: F
           </select>
         </Row>
       )}
+      {(w.type === 'value' || w.type === 'gauge' || w.type === 'delta') && (
+        <Row label="Decimals">
+          <select value={(w as { decimals?: number }).decimals ?? ''}
+            onChange={(e) => onChange({ decimals: e.target.value === '' ? undefined : Number(e.target.value) } as Partial<Widget>)}>
+            <option value="">Auto</option>
+            <option value="0">0</option>
+            <option value="1">1</option>
+            <option value="2">2</option>
+            <option value="3">3</option>
+            <option value="4">4</option>
+          </select>
+        </Row>
+      )}
       {(w.type === 'value' || w.type === 'bar' || w.type === 'gauge' || w.type === 'delta') && (
         <Row label="Label"><input value={(w as { label?: string }).label ?? ''} onChange={(e) => onChange({ label: e.target.value } as Partial<Widget>)} /></Row>
       )}

--- a/telemtry/analysis/database/viewer_tool/src/components/dashlayout/DashLayoutEditor.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/components/dashlayout/DashLayoutEditor.tsx
@@ -9,13 +9,13 @@ import { X, Send, Plus, Copy, RotateCcw, Trash2, Type, Hash, BarChart3, Gauge as
 import LapCardRenderer from './LapCardRenderer';
 import { fetchServerLayouts, saveServerLayouts } from '@/lib/dash/layoutStore';
 import {
-  LAP_CARD_W, LAP_CARD_H, FIELD_CATALOG, fieldDef, defaultLapCardLayout, validateLapCardLayout,
-  sampleLapCardData, LAYOUT_TEMPLATES, type LapCardLayout, type Widget, type WidgetType,
+  LAP_CARD_W, LAP_CARD_H, fieldDef, validateLapCardLayout,
+  sampleLapCardData, LAYOUT_TEMPLATES, DASH_SCREENS, screenDef, fieldsForScreen,
+  type LapCardLayout, type Widget, type WidgetType, type FieldDef,
   type FormatId, type Align, type GoodSign, type ColorRule,
 } from '@/lib/dash/dashLayout';
 
 const STORAGE_KEY = 'dash-lap-layout';   // legacy single-layout key (migrated on load)
-const LIBRARY_KEY = 'dash-lap-layouts';  // { items: LapCardLayout[], activeId }
 const SCALE = 0.82; // 800 -> 656 on the editor stage
 const GRID = 10;        // snap-to-grid step (layout px)
 const SNAP_THRESH = 7;  // alignment-guide snap distance (layout px)
@@ -55,11 +55,14 @@ function withId(l: LapCardLayout): LapCardLayout { return l.id ? l : { ...l, id:
 
 interface Library { items: LapCardLayout[]; activeId: string; }
 
-// Load the saved layout library, migrating the legacy single-layout key.
-function loadLibrary(): Library {
+// Load a screen's saved layout library from its localStorage namespace. The lap
+// card also migrates the legacy single-layout key; other screens start from
+// their built-in default.
+function loadLibrary(screenId: string): Library {
+  const sd = screenDef(screenId);
   if (typeof window !== 'undefined') {
     try {
-      const raw = localStorage.getItem(LIBRARY_KEY);
+      const raw = localStorage.getItem(sd.libraryKey);
       if (raw) {
         const parsed = JSON.parse(raw) as { items?: unknown[]; activeId?: string };
         const items = (parsed.items ?? [])
@@ -70,11 +73,13 @@ function loadLibrary(): Library {
           return { items, activeId };
         }
       }
-      const old = localStorage.getItem(STORAGE_KEY); // migrate legacy single layout
-      if (old) { const v = validateLapCardLayout(JSON.parse(old)); if (v) { const w = withId(v); return { items: [w], activeId: w.id! }; } }
+      if (screenId === 'lapCard') {
+        const old = localStorage.getItem(STORAGE_KEY); // migrate legacy single layout
+        if (old) { const v = validateLapCardLayout(JSON.parse(old)); if (v) { const w = withId(v); return { items: [w], activeId: w.id! }; } }
+      }
     } catch { /* fall through to default */ }
   }
-  const d = withId(defaultLapCardLayout());
+  const d = withId(sd.build());
   return { items: [d], activeId: d.id! };
 }
 
@@ -89,22 +94,38 @@ function newWidget(type: WidgetType): Widget {
   return { ...base, type: 'gauge', w: 180, h: 180, bind: 'can.soc', min: 0, max: 100, label: 'SOC', color: 'gradient', mode: 'standard', format: 'pct' };
 }
 
-export function DashLayoutEditor({ onClose, onSend, sendStatus }: {
+export function DashLayoutEditor({ onClose, onSend, sendStatus, initialScreenId }: {
   onClose: () => void;
-  onSend: (layout: LapCardLayout) => void;
+  onSend: (screenId: string, layout: LapCardLayout) => void;
   sendStatus?: string;
+  initialScreenId?: string;
 }) {
-  const [lib, setLib] = useState<Library>(loadLibrary);
+  // Which dash screen is being authored (lap card / park / …). Each has its own
+  // layout library + publish topic; switching reloads that screen's library.
+  const [screenId, setScreenId] = useState<string>(initialScreenId ?? 'lapCard');
+  const [lib, setLib] = useState<Library>(() => loadLibrary(initialScreenId ?? 'lapCard'));
+  // The screen `lib` currently holds — so the persist effect writes to the right
+  // namespace even on the render where screenId has changed but lib hasn't yet.
+  const libScreenRef = useRef<string>(initialScreenId ?? 'lapCard');
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [snap, setSnap] = useState(true);
   const [guides, setGuides] = useState<Guide[]>([]);
   const [previewTheme, setPreviewTheme] = useState<'dark' | 'light'>('dark');
   const data = useMemo(() => sampleLapCardData(), []);
   const stageRef = useRef<HTMLDivElement>(null);
+  const fields = useMemo(() => fieldsForScreen(screenId), [screenId]);
+  // Templates offered for the active screen. The lap card has its curated set;
+  // other screens just offer their built-in default as a starting point.
+  const screenTemplates = useMemo(
+    () => (screenId === 'lapCard'
+      ? LAYOUT_TEMPLATES
+      : [{ id: 'default', name: `Default ${screenDef(screenId).name}`, build: screenDef(screenId).build }]),
+    [screenId],
+  );
 
   // The active layout being edited. setLayout updates just that library entry,
   // so all the existing widget handlers keep working unchanged.
-  const layout = lib.items.find((l) => l.id === lib.activeId) ?? lib.items[0] ?? withId(defaultLapCardLayout());
+  const layout = lib.items.find((l) => l.id === lib.activeId) ?? lib.items[0] ?? withId(screenDef(screenId).build());
   const setLayout = useCallback((upd: LapCardLayout | ((p: LapCardLayout) => LapCardLayout)) => {
     setLib((prev) => ({
       ...prev,
@@ -122,31 +143,46 @@ export function DashLayoutEditor({ onClose, onSend, sendStatus }: {
   // so every client sees the same saved layouts.
   const serverSaveTimer = useRef<number | null>(null);
   useEffect(() => {
-    try { localStorage.setItem(LIBRARY_KEY, JSON.stringify(lib)); } catch { /* quota */ }
+    const key = screenDef(libScreenRef.current).libraryKey;
+    const screen = libScreenRef.current;
+    try { localStorage.setItem(key, JSON.stringify(lib)); } catch { /* quota */ }
     if (serverSaveTimer.current) window.clearTimeout(serverSaveTimer.current);
-    serverSaveTimer.current = window.setTimeout(() => { void saveServerLayouts(lib.items); }, 800);
+    serverSaveTimer.current = window.setTimeout(() => { void saveServerLayouts(screen, lib.items); }, 800);
     return () => { if (serverSaveTimer.current) window.clearTimeout(serverSaveTimer.current); };
   }, [lib]);
 
-  // Pull the shared library on open. Server is the source of truth if it has
+  // Pull a screen's shared library. Server is the source of truth if it has
   // anything; if it's empty but we have local layouts, seed it from local.
   const [syncMsg, setSyncMsg] = useState('Syncing…');
-  const pullFromServer = useCallback(async (announce = true) => {
+  const pullFromServer = useCallback(async (screen: string, localItems: LapCardLayout[], announce = true) => {
     if (announce) setSyncMsg('Syncing…');
-    const server = await fetchServerLayouts();
+    const server = await fetchServerLayouts(screen);
     if (server === null) { setSyncMsg('Offline — local only'); return; }
     if (server.length) {
       const items = server.map(withId);
+      libScreenRef.current = screen;
       setLib((prev) => ({ items, activeId: items.some((i) => i.id === prev.activeId) ? prev.activeId : items[0].id! }));
       setSyncMsg('Synced');
     } else {
       // server empty — seed it from whatever we have locally
       setSyncMsg('Synced');
-      void saveServerLayouts(lib.items);
+      void saveServerLayouts(screen, localItems);
     }
-  }, [lib.items]);
-  useEffect(() => { void pullFromServer(); /* on open only */ // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+  useEffect(() => { void pullFromServer(screenId, lib.items); /* on open only */ // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Switch the screen being authored: load that screen's library + pull its
+  // shared copy. Persisting the outgoing screen already happened via the effect.
+  const switchScreen = useCallback((id: string) => {
+    if (id === screenId) return;
+    const next = loadLibrary(id);
+    libScreenRef.current = id;
+    setScreenId(id);
+    setLib(next);
+    setSelectedId(null);
+    void pullFromServer(id, next.items);
+  }, [screenId, pullFromServer]);
 
   const uniqueName = (base: string): string => {
     const names = new Set(lib.items.map((l) => l.name));
@@ -154,7 +190,7 @@ export function DashLayoutEditor({ onClose, onSend, sendStatus }: {
     let n = 2; while (names.has(`${base} ${n}`)) n++; return `${base} ${n}`;
   };
   const addLayout = (l: LapCardLayout) => {
-    const w = withId({ ...l, id: undefined, name: uniqueName(l.name || 'Lap card') });
+    const w = withId({ ...l, id: undefined, name: uniqueName(l.name || screenDef(screenId).name) });
     setLib((p) => ({ items: [...p.items, w], activeId: w.id! }));
     setSelectedId(null);
   };
@@ -162,7 +198,7 @@ export function DashLayoutEditor({ onClose, onSend, sendStatus }: {
     if (!window.confirm(`Delete layout “${layout.name}”?`)) return;
     setLib((p) => {
       const items = p.items.filter((l) => l.id !== p.activeId);
-      if (!items.length) { const d = withId(defaultLapCardLayout()); return { items: [d], activeId: d.id! }; }
+      if (!items.length) { const d = withId(screenDef(screenId).build()); return { items: [d], activeId: d.id! }; }
       return { items, activeId: items[0].id! };
     });
     setSelectedId(null);
@@ -213,40 +249,44 @@ export function DashLayoutEditor({ onClose, onSend, sendStatus }: {
 
   const addWidget = (t: WidgetType) => { const w = newWidget(t); setLayout((l) => ({ ...l, widgets: [...l.widgets, w] })); setSelectedId(w.id); };
   const removeSelected = () => { if (!selected) return; setLayout((l) => ({ ...l, widgets: l.widgets.filter((w) => w.id !== selected.id) })); setSelectedId(null); };
-  const resetDefault = () => { if (window.confirm('Reset this layout to the default lap card?')) { setLayout((l) => ({ ...defaultLapCardLayout(), id: l.id, name: l.name })); setSelectedId(null); } };
+  const resetDefault = () => { if (window.confirm(`Reset this layout to the default ${screenDef(screenId).name}?`)) { setLayout((l) => ({ ...screenDef(screenId).build(), id: l.id, name: l.name })); setSelectedId(null); } };
 
   return (
     <div className="modalOverlay" onMouseDown={onClose}>
       <div className="dashEditor" onMouseDown={(e) => e.stopPropagation()}>
         <div className="dashEditorHead">
           <div className="dashEditorTitle">
-            <strong>Lap-screen designer</strong>
+            <strong>Dash designer</strong>
+            <select className="tmplSelect" value={screenId} aria-label="Screen"
+              title="Which dash screen to design" onChange={(e) => switchScreen(e.target.value)}>
+              {DASH_SCREENS.map((s) => <option key={s.id} value={s.id}>{s.name}</option>)}
+            </select>
             <select className="tmplSelect" value={lib.activeId} aria-label="Saved layout"
               onChange={(e) => { setLib((p) => ({ ...p, activeId: e.target.value })); setSelectedId(null); }}>
               {lib.items.map((l) => <option key={l.id} value={l.id}>{l.name}</option>)}
             </select>
             <input value={layout.name} onChange={(e) => setLayout((l) => ({ ...l, name: e.target.value }))} aria-label="Layout name" title="Rename this layout" />
-            <button className="tool" onClick={() => addLayout(defaultLapCardLayout())} title="New layout"><Plus size={14} /> New</button>
+            <button className="tool" onClick={() => addLayout(screenDef(screenId).build())} title="New layout"><Plus size={14} /> New</button>
             <button className="tool" onClick={() => addLayout({ ...layout, name: `${layout.name} copy` })} title="Duplicate"><Copy size={14} /></button>
             <button className="tool dangerTool" disabled={lib.items.length <= 1} onClick={deleteActive} title="Delete layout"><Trash2 size={14} /></button>
           </div>
           <div className="dashEditorActions">
             <span className="syncChip" title="Saved layouts are shared with all clients"><Cloud size={13} /> {syncMsg}</span>
-            <button className="tool iconOnly" title="Refresh from server" onClick={() => pullFromServer()}><RefreshCw size={14} /></button>
+            <button className="tool iconOnly" title="Refresh from server" onClick={() => pullFromServer(screenId, lib.items)}><RefreshCw size={14} /></button>
             <select className="tmplSelect" value="" aria-label="New from template"
               onChange={(e) => {
-                const t = LAYOUT_TEMPLATES.find((x) => x.id === e.target.value);
+                const t = screenTemplates.find((x) => x.id === e.target.value);
                 if (t) addLayout(t.build());
                 e.target.value = '';
               }}>
               <option value="">New from template…</option>
-              {LAYOUT_TEMPLATES.map((t) => <option key={t.id} value={t.id}>{t.name}</option>)}
+              {screenTemplates.map((t) => <option key={t.id} value={t.id}>{t.name}</option>)}
             </select>
             <label className="checkInline" style={{ whiteSpace: 'nowrap' }}>
               <input type="checkbox" checked={snap} onChange={(e) => setSnap(e.target.checked)} /> Snap
             </label>
             <button className="tool" onClick={resetDefault}><RotateCcw size={14} /> Reset</button>
-            <button className="primary" onClick={() => onSend(layout)}><Send size={14} /> Send to car</button>
+            <button className="primary" onClick={() => onSend(screenId, layout)}><Send size={14} /> Send to car</button>
             <button className="tool iconOnly" onClick={onClose} aria-label="Close"><X size={16} /></button>
           </div>
         </div>
@@ -305,7 +345,7 @@ export function DashLayoutEditor({ onClose, onSend, sendStatus }: {
           {/* property panel */}
           <aside className="dashEditorProps">
             {!selected ? <p className="muted" style={{ padding: 8 }}>Select a widget to edit its data &amp; style.</p> : (
-              <PropertyPanel w={selected} onChange={(p) => patch(selected.id, p)} onDelete={removeSelected} />
+              <PropertyPanel w={selected} fields={fields} onChange={(p) => patch(selected.id, p)} onDelete={removeSelected} />
             )}
           </aside>
         </div>
@@ -318,7 +358,7 @@ function Row({ label, children }: { label: string; children: React.ReactNode }) 
   return <label className="propRow"><span>{label}</span>{children}</label>;
 }
 
-function PropertyPanel({ w, onChange, onDelete }: { w: Widget; onChange: (p: Partial<Widget>) => void; onDelete: () => void }) {
+function PropertyPanel({ w, fields, onChange, onDelete }: { w: Widget; fields: FieldDef[]; onChange: (p: Partial<Widget>) => void; onDelete: () => void }) {
   const hasBind = w.type !== 'text';
   return (
     <div className="propPanel">
@@ -343,9 +383,9 @@ function PropertyPanel({ w, onChange, onDelete }: { w: Widget; onChange: (p: Par
             }
             onChange(p);
           }}>
-            {Array.from(new Set(FIELD_CATALOG.map((f) => f.group))).map((g) => (
+            {Array.from(new Set(fields.map((f) => f.group))).map((g) => (
               <optgroup key={g} label={g}>
-                {FIELD_CATALOG.filter((f) => f.group === g).map((f) => <option key={f.bind} value={f.bind}>{f.label}{f.unit ? ` (${f.unit})` : ''}</option>)}
+                {fields.filter((f) => f.group === g).map((f) => <option key={f.bind} value={f.bind}>{f.label}{f.unit ? ` (${f.unit})` : ''}</option>)}
               </optgroup>
             ))}
           </select>

--- a/telemtry/analysis/database/viewer_tool/src/components/dashlayout/LapCardRenderer.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/components/dashlayout/LapCardRenderer.tsx
@@ -8,7 +8,7 @@
 
 import React from 'react';
 import {
-  LAP_CARD_W, LAP_CARD_H, formatValue, getByPath, deltaColor, valueColor,
+  LAP_CARD_W, LAP_CARD_H, formatValue, applyValueMap, getByPath, deltaColor, valueColor,
   resolveColor, resolveBackground, CARD_THEMES,
   type LapCardLayout, type Widget, type CardTheme, type ThemePalette,
 } from '@/lib/dash/dashLayout';
@@ -69,7 +69,7 @@ function WidgetView({ w, data, theme, pal }: { w: Widget; data: unknown; theme: 
         alignItems: w.align === 'left' ? 'flex-start' : w.align === 'right' ? 'flex-end' : 'center',
         justifyContent: 'center', lineHeight: 1, overflow: 'hidden' }}>
         {w.label && <span style={{ color: w.labelColor ?? pal.muted, fontSize: Math.max(11, w.fontSize * 0.28), letterSpacing: 3, marginBottom: 4 }}>{w.label}</span>}
-        <span style={{ color, fontSize: w.fontSize, fontWeight: w.bold ? 800 : 500 }}>{formatValue(val, w.format)}</span>
+        <span style={{ color, fontSize: w.fontSize, fontWeight: w.bold ? 800 : 500 }}>{applyValueMap(val, w.format, w.valueMap)}</span>
       </div>
     );
   }

--- a/telemtry/analysis/database/viewer_tool/src/components/dashlayout/LapCardRenderer.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/components/dashlayout/LapCardRenderer.tsx
@@ -69,7 +69,7 @@ function WidgetView({ w, data, theme, pal }: { w: Widget; data: unknown; theme: 
         alignItems: w.align === 'left' ? 'flex-start' : w.align === 'right' ? 'flex-end' : 'center',
         justifyContent: 'center', lineHeight: 1, overflow: 'hidden' }}>
         {w.label && <span style={{ color: w.labelColor ?? pal.muted, fontSize: Math.max(11, w.fontSize * 0.28), letterSpacing: 3, marginBottom: 4 }}>{w.label}</span>}
-        <span style={{ color, fontSize: w.fontSize, fontWeight: w.bold ? 800 : 500 }}>{applyValueMap(val, w.format, w.valueMap)}</span>
+        <span style={{ color, fontSize: w.fontSize, fontWeight: w.bold ? 800 : 500 }}>{applyValueMap(val, w.format, w.valueMap, w.decimals)}</span>
       </div>
     );
   }
@@ -97,7 +97,7 @@ function WidgetView({ w, data, theme, pal }: { w: Widget; data: unknown; theme: 
   if (w.type === 'delta') {
     const val = getByPath(data, w.bind);
     const color = deltaColor(val, w.goodSign ?? 'negative', w.goodColor, w.badColor, w.zeroColor ?? pal.muted);
-    const mag = formatValue(val, w.format);
+    const mag = formatValue(val, w.format, w.decimals);
     const signed = val != null && val > 0 && w.showSign !== false ? `+${mag}` : mag;
     const arrow = w.showArrow && val != null && val !== 0 ? (val > 0 ? '▲ ' : '▼ ') : '';
     return (
@@ -114,7 +114,7 @@ function WidgetView({ w, data, theme, pal }: { w: Widget; data: unknown; theme: 
   return (
     <div style={{ width: '100%', height: '100%' }}>
       <MiniRadialGauge value={val} min={w.min} max={w.max} label={w.label} color={resolveColor(w, theme, w.color ?? 'gradient')}
-        mode={w.mode} valueText={formatValue(val, w.format ?? 'int')} pal={pal} />
+        mode={w.mode} valueText={formatValue(val, w.format ?? 'int', w.decimals)} pal={pal} />
     </div>
   );
 }

--- a/telemtry/analysis/database/viewer_tool/src/lib/dash/dashLayout.ts
+++ b/telemtry/analysis/database/viewer_tool/src/lib/dash/dashLayout.ts
@@ -145,7 +145,12 @@ export interface LapCardLayout {
 }
 
 // ---- bindable fields (the "pick a data point" catalog) ---------------------
-// Paths resolve against the lap-card data context: { lapCard, pacing, can, mqtt }.
+// Paths resolve against the dash data context. The lap card binds against
+// { lapCard, pacing, can, mqtt }; the park screen against { can, pacing, mqtt }.
+// This catalog is intentionally COMPREHENSIVE — every numeric channel dashd
+// forwards is exposed so any of them can be bound in the editor ("auto-expose
+// all upstream, refine labels/formats later"). `root` (derived from the bind
+// path) lets a screen filter to only the contexts it actually receives.
 export interface FieldDef {
   bind: string;
   label: string;
@@ -162,30 +167,72 @@ export interface FieldDef {
 }
 
 export const FIELD_CATALOG: FieldDef[] = [
-  // The just-finished lap (what the card is fundamentally about)
+  // The just-finished lap (lap card only — lapCard.* is null on other screens)
   { bind: 'lapCard.lapNumber', label: 'Lap number', group: 'Lap', defaultFormat: 'int', min: 0, max: 30 },
   { bind: 'lapCard.timeS', label: 'Lap time', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120 },
   { bind: 'lapCard.energyWh', label: 'Lap energy', group: 'Lap', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 400 },
   { bind: 'mqtt.bestLapTime', label: 'Best lap', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120 },
   { bind: 'mqtt.lastLapTime', label: 'Last lap', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120 },
-  // Pacing / strategy
+  { bind: 'mqtt.currentLapTime', label: 'Current lap time', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120 },
+  { bind: 'mqtt.lapTrigger', label: 'Lap count', group: 'Lap', defaultFormat: 'int', min: 0, max: 30 },
+  // Pacing / strategy (on-car authoritative pacing snapshot)
   { bind: 'pacing.lapEnergyWh', label: 'Energy (this lap)', group: 'Pacing', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 400 },
+  { bind: 'pacing.lapBudgetWh', label: 'Per-lap budget', group: 'Pacing', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 400 },
+  { bind: 'pacing.lapElapsedS', label: 'Lap elapsed', group: 'Pacing', unit: 's', defaultFormat: 'laptime', min: 0, max: 120 },
+  { bind: 'pacing.lapNumber', label: 'Lap (in progress)', group: 'Pacing', defaultFormat: 'int', min: 0, max: 30 },
   { bind: 'mqtt.lapsRemaining', label: 'Laps remaining', group: 'Pacing', defaultFormat: 'int', min: 0, max: 30 },
+  { bind: 'mqtt.lapsRemainingEnergy', label: 'Laps left (energy)', group: 'Pacing', defaultFormat: 'int', min: 0, max: 30 },
   { bind: 'mqtt.targetPower', label: 'Target power', group: 'Pacing', unit: 'kW', defaultFormat: 'kw', min: 0, max: 80 },
   // Deltas (signed — green/red by sign; lower/negative is "good" by default)
   { bind: 'mqtt.lapDelta', label: 'Lap Δ vs ref', group: 'Deltas', unit: 's', defaultFormat: 'float2', min: -5, max: 5, bidirectional: true, isDelta: true, goodSign: 'negative' },
   { bind: 'pacing.budgetDeltaWh', label: 'Energy budget Δ', group: 'Deltas', unit: 'Wh', defaultFormat: 'whSigned', min: -100, max: 100, bidirectional: true, isDelta: true, goodSign: 'negative' },
   { bind: 'mqtt.energyDelta', label: 'Energy Δ vs target', group: 'Deltas', unit: 'Wh', defaultFormat: 'whSigned', min: -100, max: 100, bidirectional: true, isDelta: true, goodSign: 'negative' },
   { bind: 'mqtt.lapDeltaRate', label: 'Lap Δ rate', group: 'Deltas', unit: 's/s', defaultFormat: 'float2', min: -2, max: 2, bidirectional: true, isDelta: true, goodSign: 'negative' },
-  // Live car
-  { bind: 'can.soc', label: 'State of charge', group: 'Battery', unit: '%', defaultFormat: 'pct', min: 0, max: 100 },
-  { bind: 'can.temperature', label: 'Battery temp', group: 'Battery', unit: '°C', defaultFormat: 'temp', min: 0, max: 80 },
-  { bind: 'can.power', label: 'Power', group: 'Dynamics', unit: 'kW', defaultFormat: 'kw', min: -80, max: 80, bidirectional: true },
+  // Energy / charge (VCU is the source of truth for running energy)
+  { bind: 'can.soc', label: 'State of energy', group: 'Energy', unit: '%', defaultFormat: 'pct', min: 0, max: 100 },
+  { bind: 'can.vcuNetEnergyWh', label: 'VCU net energy', group: 'Energy', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 8000 },
+  { bind: 'can.vcuRegenEnergyWh', label: 'VCU regen energy', group: 'Energy', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 2000 },
+  { bind: 'can.power', label: 'Pack power', group: 'Energy', unit: 'kW', defaultFormat: 'kw', min: -80, max: 80, bidirectional: true },
+  // Cell voltages (pack health)
+  { bind: 'can.cellVMax', label: 'Cell V max', group: 'Cells', unit: 'V', defaultFormat: 'volt', min: 2.5, max: 4.3 },
+  { bind: 'can.cellVMin', label: 'Cell V min', group: 'Cells', unit: 'V', defaultFormat: 'volt', min: 2.5, max: 4.3 },
+  { bind: 'can.cellVSpread', label: 'Cell V spread', group: 'Cells', unit: 'V', defaultFormat: 'float2', min: 0, max: 0.5 },
+  // Cell + pack temps
+  { bind: 'can.cellTempMax', label: 'Cell T max', group: 'Temps', unit: '°C', defaultFormat: 'temp', min: 0, max: 80 },
+  { bind: 'can.cellTempAvg', label: 'Cell T avg', group: 'Temps', unit: '°C', defaultFormat: 'temp', min: 0, max: 80 },
+  { bind: 'can.cellTempMin', label: 'Cell T min', group: 'Temps', unit: '°C', defaultFormat: 'temp', min: 0, max: 80 },
+  { bind: 'can.temperature', label: 'Battery temp', group: 'Temps', unit: '°C', defaultFormat: 'temp', min: 0, max: 80 },
+  // Powertrain temps
+  { bind: 'can.motorTemp', label: 'Motor temp', group: 'Temps', unit: '°C', defaultFormat: 'temp', min: 0, max: 120 },
+  { bind: 'can.inverterTemp', label: 'Inverter temp', group: 'Temps', unit: '°C', defaultFormat: 'temp', min: 0, max: 100 },
+  { bind: 'can.coolantTemp', label: 'Coolant temp', group: 'Temps', unit: '°C', defaultFormat: 'temp', min: 0, max: 80 },
+  // Driver inputs
+  { bind: 'can.apps', label: 'APPS (accel)', group: 'Driver', unit: '%', defaultFormat: 'pct', min: 0, max: 100 },
+  { bind: 'can.bpps', label: 'BPPS (brake)', group: 'Driver', unit: '%', defaultFormat: 'pct', min: 0, max: 100 },
+  { bind: 'can.brakeBias', label: 'Brake bias (front)', group: 'Driver', unit: '%', defaultFormat: 'pct', min: 0, max: 100 },
+  { bind: 'can.brakePressureFront', label: 'Brake pressure F', group: 'Driver', unit: 'psi', defaultFormat: 'int', min: 0, max: 1000 },
+  { bind: 'can.brakePressureRear', label: 'Brake pressure R', group: 'Driver', unit: 'psi', defaultFormat: 'int', min: 0, max: 1000 },
+  // Rails
+  { bind: 'can.hvVoltage', label: 'HV voltage', group: 'Rails', unit: 'V', defaultFormat: 'volt', min: 0, max: 600 },
+  { bind: 'can.hvCurrent', label: 'HV current', group: 'Rails', unit: 'A', defaultFormat: 'amp', min: -400, max: 400, bidirectional: true },
+  { bind: 'can.lvVoltage', label: 'LV voltage', group: 'Rails', unit: 'V', defaultFormat: 'volt', min: 0, max: 30 },
+  { bind: 'can.lvCurrent', label: 'LV current', group: 'Rails', unit: 'A', defaultFormat: 'amp', min: 0, max: 30 },
+  // Dynamics + wheels
   { bind: 'can.speed', label: 'Speed', group: 'Dynamics', unit: 'mph', defaultFormat: 'mph', min: 0, max: 100 },
+  { bind: 'can.eventMode', label: 'VCU event mode', group: 'Dynamics', defaultFormat: 'int', min: 0, max: 4 },
+  { bind: 'can.wheelSpeedFL', label: 'Wheel FL', group: 'Wheels', defaultFormat: 'float1', min: 0, max: 100 },
+  { bind: 'can.wheelSpeedFR', label: 'Wheel FR', group: 'Wheels', defaultFormat: 'float1', min: 0, max: 100 },
+  { bind: 'can.wheelSpeedRL', label: 'Wheel RL', group: 'Wheels', defaultFormat: 'float1', min: 0, max: 100 },
+  { bind: 'can.wheelSpeedRR', label: 'Wheel RR', group: 'Wheels', defaultFormat: 'float1', min: 0, max: 100 },
 ];
 
 export function fieldDef(bind: string): FieldDef | undefined {
   return FIELD_CATALOG.find((f) => f.bind === bind);
+}
+
+// The top-level context object a bind path reads from (e.g. 'can.cellVMax' -> 'can').
+export function bindRoot(bind: string): string {
+  return bind.split('.')[0];
 }
 
 // ---- value access + formatting --------------------------------------------
@@ -249,6 +296,77 @@ export function defaultLapCardLayout(): LapCardLayout {
   };
 }
 
+// ---- screens ---------------------------------------------------------------
+// Each editable dash screen authors independently: its own retained MQTT topic
+// (lhre/dash/<topic>), library namespace, default layout, and the set of data
+// contexts available to bind. Add a screen here + a render site that reads the
+// matching DashMessage field, and the unified editor picks it up automatically.
+export interface ScreenDef {
+  id: string;
+  name: string;
+  topic: string;            // lhre/dash/<topic> (retained)
+  libraryKey: string;       // localStorage key + server library namespace
+  contextRoots: string[];   // top-level ctx objects the screen receives
+  build: () => LapCardLayout;
+}
+
+// Default starter for the Park / pit-debug screen — SoE, cell-voltage health,
+// running VCU energy, key temps, brake bias. All can.* (no lapCard.* — that
+// only exists on the lap card).
+export function defaultParkLayout(): LapCardLayout {
+  return {
+    version: DASH_LAYOUT_VERSION,
+    name: 'Default park screen',
+    background: 'auto',
+    widgets: [
+      { id: 'soe', type: 'value', bind: 'can.soc', format: 'pct', label: 'SoE %',
+        x: 30, y: 24, w: 320, h: 150, fontSize: 110, color: 'auto', align: 'center', bold: true },
+      { id: 'vmax', type: 'value', bind: 'can.cellVMax', format: 'volt', label: 'CELL V MAX',
+        x: 380, y: 30, w: 180, h: 96, fontSize: 46, color: 'auto', align: 'center', bold: true },
+      { id: 'vmin', type: 'value', bind: 'can.cellVMin', format: 'volt', label: 'CELL V MIN',
+        x: 580, y: 30, w: 180, h: 96, fontSize: 46, color: 'auto', align: 'center', bold: true },
+      { id: 'vspread', type: 'value', bind: 'can.cellVSpread', format: 'float2', label: 'SPREAD V',
+        x: 380, y: 140, w: 180, h: 96, fontSize: 46, color: 'auto', align: 'center', bold: true,
+        thresholds: [{ cmp: 'gt', value: 0.05, color: '#FFD700' }, { cmp: 'gt', value: 0.1, color: '#FF3333' }] },
+      { id: 'net', type: 'value', bind: 'can.vcuNetEnergyWh', format: 'wh', label: 'NET Wh',
+        x: 580, y: 140, w: 180, h: 96, fontSize: 46, color: 'auto', align: 'center', bold: true },
+      { id: 'tmax', type: 'value', bind: 'can.cellTempMax', format: 'temp', label: 'CELL T MAX',
+        x: 30, y: 260, w: 180, h: 90, fontSize: 42, color: 'auto', align: 'center', bold: true,
+        thresholds: [{ cmp: 'gt', value: 50, color: '#FFD700' }, { cmp: 'gt', value: 60, color: '#FF3333' }] },
+      { id: 'motor', type: 'value', bind: 'can.motorTemp', format: 'temp', label: 'MOTOR °C',
+        x: 230, y: 260, w: 180, h: 90, fontSize: 42, color: 'auto', align: 'center', bold: true },
+      { id: 'inv', type: 'value', bind: 'can.inverterTemp', format: 'temp', label: 'INV °C',
+        x: 430, y: 260, w: 160, h: 90, fontSize: 42, color: 'auto', align: 'center', bold: true },
+      { id: 'hv', type: 'value', bind: 'can.hvVoltage', format: 'volt', label: 'HV V',
+        x: 610, y: 260, w: 150, h: 90, fontSize: 42, color: 'auto', align: 'center', bold: true },
+      { id: 'bias', type: 'value', bind: 'can.brakeBias', format: 'pct', label: 'BIAS F %',
+        x: 30, y: 372, w: 180, h: 84, fontSize: 40, color: 'auto', align: 'center', bold: true },
+      { id: 'pwr', type: 'value', bind: 'can.power', format: 'kw', label: 'PACK kW',
+        x: 230, y: 372, w: 180, h: 84, fontSize: 40, color: 'auto', align: 'center', bold: true },
+      { id: 'regen', type: 'value', bind: 'can.vcuRegenEnergyWh', format: 'wh', label: 'REGEN Wh',
+        x: 430, y: 372, w: 330, h: 84, fontSize: 40, color: 'auto', align: 'center', bold: true },
+    ],
+  };
+}
+
+export const DASH_SCREENS: ScreenDef[] = [
+  { id: 'lapCard', name: 'Lap Card', topic: 'layout', libraryKey: 'dash-lap-layouts',
+    contextRoots: ['lapCard', 'pacing', 'can', 'mqtt'], build: defaultLapCardLayout },
+  { id: 'park', name: 'Park / Pit', topic: 'parkLayout', libraryKey: 'dash-park-layouts',
+    contextRoots: ['can', 'pacing', 'mqtt'], build: defaultParkLayout },
+];
+
+export function screenDef(id: string): ScreenDef {
+  return DASH_SCREENS.find((s) => s.id === id) ?? DASH_SCREENS[0];
+}
+
+// Catalog fields a screen can bind — only those whose context it actually
+// receives (so the park picker doesn't offer lapCard.* which is always null).
+export function fieldsForScreen(screenId: string): FieldDef[] {
+  const roots = screenDef(screenId).contextRoots;
+  return FIELD_CATALOG.filter((f) => roots.includes(bindRoot(f.bind)));
+}
+
 // Starter presets the strategist can load and then tweak.
 export const LAYOUT_TEMPLATES: { id: string; name: string; build: () => LapCardLayout }[] = [
   { id: 'default', name: 'Default lap card', build: defaultLapCardLayout },
@@ -308,14 +426,26 @@ export function validateLapCardLayout(raw: unknown): LapCardLayout | null {
   };
 }
 
-// Synthetic data so the editor preview is realistic with the car off.
+// Synthetic data so the editor preview is realistic with the car off. Covers
+// every catalog field across all contexts so any bound widget renders a value
+// (both the lap card and the park screen preview from this).
 export function sampleLapCardData() {
   return {
     lapCard: { lapNumber: 7, timeS: 84.36, energyWh: 213 },
-    pacing: { lapEnergyWh: 213, budgetDeltaWh: -12, lapElapsedS: 84.36, lapNumber: 7,
-      lastLapNumber: 7, lastLapTimeS: 84.36, lastLapEnergyWh: 213 },
-    can: { soc: 62, temperature: 41.5, power: 47, speed: 38 },
-    mqtt: { lapDelta: -0.42, energyDelta: -12, lapsRemaining: 15, targetPower: 30,
-      bestLapTime: 83.1, lastLapTime: 84.36, lapDeltaRate: 0.08 },
+    pacing: { lapEnergyWh: 213, budgetDeltaWh: -12, lapBudgetWh: 225, lapElapsedS: 84.36,
+      lapNumber: 7, lastLapNumber: 7, lastLapTimeS: 84.36, lastLapEnergyWh: 213 },
+    can: {
+      soc: 62, temperature: 41.5, power: 47, speed: 38, eventMode: 4,
+      vcuNetEnergyWh: 4120, vcuRegenEnergyWh: 615,
+      cellVMax: 4.02, cellVMin: 3.91, cellVSpread: 0.11,
+      cellTempMax: 46.2, cellTempAvg: 42.8, cellTempMin: 38.4,
+      motorTemp: 64, inverterTemp: 52, coolantTemp: 38,
+      apps: 0, bpps: 0, brakeBias: 54, brakePressureFront: 0, brakePressureRear: 0,
+      hvVoltage: 449.3, hvCurrent: 10, lvVoltage: 25, lvCurrent: 9.3,
+      wheelSpeedFL: 38, wheelSpeedFR: 38, wheelSpeedRL: 38, wheelSpeedRR: 38,
+    },
+    mqtt: { lapDelta: -0.42, energyDelta: -12, lapsRemaining: 15, lapsRemainingEnergy: 14,
+      targetPower: 30, bestLapTime: 83.1, lastLapTime: 84.36, currentLapTime: 84.36,
+      lapDeltaRate: 0.08, lapTrigger: 7 },
   };
 }

--- a/telemtry/analysis/database/viewer_tool/src/lib/dash/dashLayout.ts
+++ b/telemtry/analysis/database/viewer_tool/src/lib/dash/dashLayout.ts
@@ -94,6 +94,10 @@ export interface ValueWidget extends BaseWidget {
   label?: string;           // small caption above/beside the value
   labelColor?: string;
   thresholds?: ColorRule[]; // e.g. [{cmp:'lt',value:20,color:'#ff4d4f'}] for low SoC
+  // Map a numeric value to a label (enums / bitfields, e.g. VCU event mode
+  // 4 -> "ENDUR"). Keyed by the rounded integer value as a string. When a key
+  // matches, its label is shown instead of the numeric format.
+  valueMap?: Record<string, string>;
 }
 export interface BarWidget extends BaseWidget {
   type: 'bar';
@@ -164,6 +168,9 @@ export interface FieldDef {
   // delta hint: this field is a signed delta, and which sign is "good" (green)
   isDelta?: boolean;
   goodSign?: GoodSign;
+  // enum/bitfield fields: value -> label map. When bound, the editor pre-fills a
+  // value widget's valueMap with this so it renders labels instead of raw ints.
+  enumMap?: Record<string, string>;
 }
 
 export const FIELD_CATALOG: FieldDef[] = [
@@ -219,7 +226,8 @@ export const FIELD_CATALOG: FieldDef[] = [
   { bind: 'can.lvCurrent', label: 'LV current', group: 'Rails', unit: 'A', defaultFormat: 'amp', min: 0, max: 30 },
   // Dynamics + wheels
   { bind: 'can.speed', label: 'Speed', group: 'Dynamics', unit: 'mph', defaultFormat: 'mph', min: 0, max: 100 },
-  { bind: 'can.eventMode', label: 'VCU event mode', group: 'Dynamics', defaultFormat: 'int', min: 0, max: 4 },
+  { bind: 'can.eventMode', label: 'VCU event mode', group: 'Dynamics', defaultFormat: 'int', min: 0, max: 4,
+    enumMap: { '0': '—', '1': 'ACCEL', '2': 'SKID', '3': 'AUTOX', '4': 'ENDUR' } },
   { bind: 'can.wheelSpeedFL', label: 'Wheel FL', group: 'Wheels', defaultFormat: 'float1', min: 0, max: 100 },
   { bind: 'can.wheelSpeedFR', label: 'Wheel FR', group: 'Wheels', defaultFormat: 'float1', min: 0, max: 100 },
   { bind: 'can.wheelSpeedRL', label: 'Wheel RL', group: 'Wheels', defaultFormat: 'float1', min: 0, max: 100 },
@@ -277,6 +285,16 @@ export function formatValue(v: number | null | undefined, fmt: FormatId): string
     case 'mph': return `${Math.round(v)}`;
     default: return `${v}`;
   }
+}
+
+// Value widgets with a valueMap (enums/bitfields) show the mapped label; anything
+// without a matching key falls back to the numeric format.
+export function applyValueMap(v: number | null | undefined, fmt: FormatId, valueMap?: Record<string, string>): string {
+  if (v != null && Number.isFinite(v) && valueMap) {
+    const label = valueMap[String(Math.round(v))];
+    if (label != null) return label;
+  }
+  return formatValue(v, fmt);
 }
 
 // ---- default layout (replicates today's hardcoded lap card) ---------------

--- a/telemtry/analysis/database/viewer_tool/src/lib/dash/dashLayout.ts
+++ b/telemtry/analysis/database/viewer_tool/src/lib/dash/dashLayout.ts
@@ -85,6 +85,7 @@ export interface ValueWidget extends BaseWidget {
   type: 'value';
   bind: string;             // dotted path into the data context (see FIELD_CATALOG)
   format: FormatId;
+  decimals?: number;        // override the format's decimal places (0–6); undefined = format default
   fontSize: number;
   color: string;            // hex, or "auto" to follow the theme foreground
   colorDark?: string;
@@ -115,6 +116,7 @@ export interface DeltaWidget extends BaseWidget {
   type: 'delta';
   bind: string;
   format: FormatId;
+  decimals?: number;        // override the format's decimal places (0–6)
   fontSize: number;
   align?: Align;
   bold?: boolean;
@@ -137,6 +139,7 @@ export interface GaugeWidget extends BaseWidget {
   colorLight?: string;
   mode?: 'standard' | 'bidirectional';
   format?: FormatId;        // center read-out format
+  decimals?: number;        // override the center read-out's decimal places (0–6)
 }
 export type Widget = TextWidget | ValueWidget | BarWidget | GaugeWidget | DeltaWidget;
 
@@ -263,8 +266,16 @@ export function valueColor(v: number | null | undefined, base: string, rules?: C
   return c;
 }
 
-export function formatValue(v: number | null | undefined, fmt: FormatId): string {
+export function formatValue(v: number | null | undefined, fmt: FormatId, decimals?: number): string {
   if (v == null || !Number.isFinite(v)) return '--';
+  // Optional per-widget precision override. Applies to the numeric formats —
+  // keeps kwh's /1000 scaling and whSigned's +/- sign; lap-time ignores it.
+  if (decimals != null && Number.isFinite(decimals) && fmt !== 'laptime') {
+    const d = Math.max(0, Math.min(6, Math.floor(decimals)));
+    if (fmt === 'kwh') return (v / 1000).toFixed(d);
+    if (fmt === 'whSigned') return `${v >= 0 ? '+' : ''}${v.toFixed(d)}`;
+    return v.toFixed(d);
+  }
   switch (fmt) {
     case 'laptime': {
       const m = Math.floor(v / 60);
@@ -289,12 +300,12 @@ export function formatValue(v: number | null | undefined, fmt: FormatId): string
 
 // Value widgets with a valueMap (enums/bitfields) show the mapped label; anything
 // without a matching key falls back to the numeric format.
-export function applyValueMap(v: number | null | undefined, fmt: FormatId, valueMap?: Record<string, string>): string {
+export function applyValueMap(v: number | null | undefined, fmt: FormatId, valueMap?: Record<string, string>, decimals?: number): string {
   if (v != null && Number.isFinite(v) && valueMap) {
     const label = valueMap[String(Math.round(v))];
     if (label != null) return label;
   }
-  return formatValue(v, fmt);
+  return formatValue(v, fmt, decimals);
 }
 
 // ---- default layout (replicates today's hardcoded lap card) ---------------

--- a/telemtry/analysis/database/viewer_tool/src/lib/dash/dashSignals.ts
+++ b/telemtry/analysis/database/viewer_tool/src/lib/dash/dashSignals.ts
@@ -83,6 +83,8 @@ export interface DashSignals {
     publishGate: (gate: [number, number, number, number]) => void;
     /** Push the lap-card layout the dash renders (retained: sent once, used until replaced). */
     publishLayout: (layout: unknown) => boolean;
+    /** Push the park/pit-screen layout (retained, separate topic from the lap card). */
+    publishParkLayout: (layout: unknown) => boolean;
     /** Push the live dynamic per-lap energy budget (Wh) the dash shows (retained). */
     publishLapBudget: (wh: number) => boolean;
     publishLapCardMs: (ms: number) => boolean;
@@ -287,6 +289,15 @@ export function useDashSignals(): DashSignals {
         return true;
     }, []);
 
+    // Park / pit-screen layout — same retained pattern, separate topic so the
+    // two screens are authored independently.
+    const publishParkLayout = useCallback((layout: unknown): boolean => {
+        const client = clientRef.current;
+        if (!client || !client.connected) return false;
+        client.publish(`${TOPIC_PREFIX}parkLayout`, JSON.stringify(layout), { qos: 1, retain: true });
+        return true;
+    }, []);
+
     // Retained: the live per-lap Wh budget (remaining energy / remaining laps),
     // republished by trackside whenever it changes. The dash holds it and shows
     // the driver the current Wh/lap target.
@@ -359,6 +370,7 @@ export function useDashSignals(): DashSignals {
         resetLapCounter,
         publishGate,
         publishLayout,
+        publishParkLayout,
         publishLapBudget,
         publishLapCardMs,
         publishMessages,

--- a/telemtry/analysis/database/viewer_tool/src/lib/dash/dashSignals.ts
+++ b/telemtry/analysis/database/viewer_tool/src/lib/dash/dashSignals.ts
@@ -43,6 +43,11 @@ export interface DashMirrorState {
     power: number | null;
     soc: number | null;
     temperature: number | null;
+    // Car storage + runtime vs the on-car kill switch (free < 1 GB or > 1 h
+    // stops telemetry). null until the car's dashd reports them.
+    diskFreeMb?: number | null;
+    diskTotalMb?: number | null;
+    runtimeS?: number | null;
     pacing: {
         lapEnergyWh: number;
         budgetDeltaWh: number | null;

--- a/telemtry/analysis/database/viewer_tool/src/lib/dash/layoutStore.ts
+++ b/telemtry/analysis/database/viewer_tool/src/lib/dash/layoutStore.ts
@@ -8,27 +8,41 @@
 
 import { validateLapCardLayout, type LapCardLayout } from './dashLayout';
 
-export async function fetchServerLayouts(screen = 'lapCard'): Promise<LapCardLayout[] | null> {
+export interface ServerLayouts { items: LapCardLayout[]; savedAt: number | null; }
+// Result of a save: ok = written (savedAt is the new version); conflict = the
+// server moved on since `baseSavedAt` (its current items/savedAt are returned so
+// the caller can merge); neither = offline/unreachable.
+export interface SaveResult { ok: boolean; conflict?: boolean; items?: LapCardLayout[]; savedAt?: number | null; }
+
+export async function fetchServerLayouts(screen = 'lapCard'): Promise<ServerLayouts | null> {
   if (typeof fetch === 'undefined') return null;
   try {
     const res = await fetch(`/api/dash/layouts?screen=${encodeURIComponent(screen)}`);
     if (!res.ok) return null;
-    const body = (await res.json()) as { items?: unknown[] };
-    return (body.items ?? []).map((i) => validateLapCardLayout(i)).filter(Boolean) as LapCardLayout[];
+    const body = (await res.json()) as { items?: unknown[]; savedAt?: number };
+    const items = (body.items ?? []).map((i) => validateLapCardLayout(i)).filter(Boolean) as LapCardLayout[];
+    return { items, savedAt: typeof body.savedAt === 'number' ? body.savedAt : null };
   } catch {
     return null; // offline / unreachable — caller keeps localStorage copy
   }
 }
 
-export async function saveServerLayouts(screen: string, items: LapCardLayout[]): Promise<void> {
-  if (typeof fetch === 'undefined') return;
+export async function saveServerLayouts(screen: string, items: LapCardLayout[], baseSavedAt?: number | null): Promise<SaveResult> {
+  if (typeof fetch === 'undefined') return { ok: false };
   try {
-    await fetch(`/api/dash/layouts?screen=${encodeURIComponent(screen)}`, {
+    const res = await fetch(`/api/dash/layouts?screen=${encodeURIComponent(screen)}`, {
       method: 'PUT',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ items }),
+      body: JSON.stringify({ items, baseSavedAt }),
     });
+    const body = (await res.json().catch(() => ({}))) as { ok?: boolean; conflict?: boolean; items?: unknown[]; savedAt?: number };
+    const savedAt = typeof body.savedAt === 'number' ? body.savedAt : null;
+    if (res.status === 409 || body.conflict) {
+      const remote = (body.items ?? []).map((i) => validateLapCardLayout(i)).filter(Boolean) as LapCardLayout[];
+      return { ok: false, conflict: true, items: remote, savedAt };
+    }
+    return { ok: res.ok && body.ok !== false, savedAt };
   } catch {
-    // offline — the localStorage copy still holds the work
+    return { ok: false }; // offline — the localStorage copy still holds the work
   }
 }

--- a/telemtry/analysis/database/viewer_tool/src/lib/dash/layoutStore.ts
+++ b/telemtry/analysis/database/viewer_tool/src/lib/dash/layoutStore.ts
@@ -1,13 +1,17 @@
 // Server bridge for the shared dash-layout library (/api/dash/layouts). Lets
 // every client see the same saved layouts. localStorage stays as an offline
 // cache + instant initial render; the server copy is the shared source.
+//
+// Layouts are namespaced per screen via `?screen=`. The default (`lapCard`)
+// maps to the original library.json so existing saved lap cards are untouched;
+// other screens (e.g. `park`) get their own file server-side.
 
 import { validateLapCardLayout, type LapCardLayout } from './dashLayout';
 
-export async function fetchServerLayouts(): Promise<LapCardLayout[] | null> {
+export async function fetchServerLayouts(screen = 'lapCard'): Promise<LapCardLayout[] | null> {
   if (typeof fetch === 'undefined') return null;
   try {
-    const res = await fetch('/api/dash/layouts');
+    const res = await fetch(`/api/dash/layouts?screen=${encodeURIComponent(screen)}`);
     if (!res.ok) return null;
     const body = (await res.json()) as { items?: unknown[] };
     return (body.items ?? []).map((i) => validateLapCardLayout(i)).filter(Boolean) as LapCardLayout[];
@@ -16,10 +20,10 @@ export async function fetchServerLayouts(): Promise<LapCardLayout[] | null> {
   }
 }
 
-export async function saveServerLayouts(items: LapCardLayout[]): Promise<void> {
+export async function saveServerLayouts(screen: string, items: LapCardLayout[]): Promise<void> {
   if (typeof fetch === 'undefined') return;
   try {
-    await fetch('/api/dash/layouts', {
+    await fetch(`/api/dash/layouts?screen=${encodeURIComponent(screen)}`, {
       method: 'PUT',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ items }),


### PR DESCRIPTION
Two stacked changes, now consolidated onto this branch (the screen-designer PR #296 was merged in):

## 1. PRNDL-driven Park debug screen

When the VCU reports **Park**, the dash auto-shows a pit/debug screen; the instant it shifts to **Drive** it returns to the driving screen. Manual Enter-cycling still works between gear changes (only a real P↔D transition snaps the view; null/unknown frames ignored). Live-verified on the car: `prndl` flipped `P → D` between reads and the routing followed.

Built-in Park view surfaces what the crew checks between runs: SoE; cell-voltage health (max/min/Δ-spread, color-graded for imbalance); running VCU energy (Net/Drive/Regen from 0x1C9); cell + powertrain temps; driver inputs + brake bias; HV/LV rails; active faults.

dashd `CanData` gains `cellVMax/Min/Spread` (reduced from `pack.cells_v[]`) and `vcuNetEnergyWh/RegenEnergyWh` (`Controls.net_energy`/`regen_energy`). Everything else was already populated. **Cell-aggregate zero-slot fix**: cand fills `cells_v[]`/`cells_temps[]` as packets arrive, so unfilled slots sit at `0.0` and dragged min/avg/spread to garbage; the reductions now exclude them (voltages drop `<=0`; temps drop exactly `0.0`). `max`/`temperature` (driving-screen TEMP gauge) unchanged. Verified: cellVMin 4.07 V / spread 106 mV, cellTempMin 38.4 °C / avg 42.8 °C, VCU net accumulating.

## 2. Customizable dash screens (unified designer)

Makes the Park screen editable like the lap card — full widget drag/resize/bind, control over which telemetry field each item reads — by generalizing the existing lap-card layout system into a multi-screen designer (renderer + editor were already generic).

- **Unified editor** with a screen picker (Lap Card / Park). Each screen authors independently: own layout library (localStorage + server, namespaced via `?screen=`), own retained MQTT topic, field picker scoped to the contexts it receives. Driven by a `DASH_SCREENS` registry — add a screen + a render site and it appears.
- **Auto-exposed catalog**: every numeric channel dashd forwards (`can.*`, `pacing.*`, `mqtt.*`) is bindable; labels/formats are a first pass to refine.
- **Transport**: `publishParkLayout` → retained `lhre/dash/parkLayout`; dashd mirrors the lap-card layout plumbing (persist/ack/forward/restore). `PitDiagnostic` renders the website-authored layout via the shared `LapCardRenderer`, else the built-in grid (never blanks).
- Park-screen faults left off the editable layout for now (fault reporting isn't trustworthy yet); the fallback grid still shows them.

## Test / status

- viewer_tool `tsc` clean; CI green. Part 1 verified live on the car; the designer is **not yet deployed** (deploy gated on this merge + the usual surgical car-side dashd patch).
- Pure dashd + website change; no CAN-schema/proto changes.
- `PitDiagnostic` derives its theme from the DOM class (matching the car's ScreenOne), so it doesn't depend on the repo-only `SettingsContext` — deployable to the car without dragging in that divergence.