### PR TITLE
dash: unified screen designer — make the Park screen customizable

### DIFF
--- a/BEVO/dashd/frontend/src/screens/PitDiagnostic.tsx
+++ b/BEVO/dashd/frontend/src/screens/PitDiagnostic.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { useDash } from '../context/DashContext';
 import { SHUTDOWN_NAMES } from '../types/DashData';
 import ConnectivityIndicator from '../components/ConnectivityIndicator';
+import { LapCardRenderer } from '../LapCardRenderer';
+import { validateLapCardLayout } from '../dashLayout';
 import './ScreenOne.css';
 import './PitDiagnostic.css';
 
@@ -13,7 +15,12 @@ import './PitDiagnostic.css';
 // inputs + brake bias, running VCU energy usage, pack/LV rails, and active faults.
 // Resolution: 800 x 480.
 //
-// All fields read from the same OrionSensorData snapshot dashd forwards over the
+// Two render paths:
+//   1. If trackside has published a custom park layout (retained
+//      lhre/dash/parkLayout, forwarded as data.parkLayout), render it with the
+//      shared LapCardRenderer — same authoring loop as the lap card.
+//   2. Otherwise the built-in grid below (so the screen never blanks).
+// All fields read from the OrionSensorData snapshot dashd forwards over the
 // WebSocket (BEVO/dashd/main.rs::extract_can_data). A field shows "--" until
 // cand has decoded the matching CAN packet.
 
@@ -32,7 +39,23 @@ const energyUnit = (wh: number | null | undefined): string =>
 
 const PitDiagnostic: React.FC = () => {
     const { data } = useDash();
+    // Follow the dash's current light/dark theme (body.theme-light is toggled by
+    // the car's settings / auto sunrise-sunset), same mechanism ScreenOne uses.
+    const cardTheme: 'dark' | 'light' =
+        (typeof document !== 'undefined' && document.body.classList.contains('theme-light')) ? 'light' : 'dark';
     const can = data?.can;
+
+    // Custom park layout authored on the website (validated; falls back to the
+    // built-in grid below when absent/malformed so the screen never blanks).
+    const customLayout = validateLapCardLayout(data?.parkLayout);
+    if (customLayout && customLayout.widgets.length) {
+        const ctx = { can: data?.can, pacing: data?.pacing, mqtt: data?.mqtt };
+        return (
+            <div style={{ position: 'absolute', inset: 0, zIndex: 1 }}>
+                <LapCardRenderer layout={customLayout} data={ctx} scale={1} theme={cardTheme} />
+            </div>
+        );
+    }
 
     // ----- Energy / charge -----
     const soe = can?.soc ?? null;                       // state of energy %

--- a/BEVO/dashd/frontend/src/types/DashData.ts
+++ b/BEVO/dashd/frontend/src/types/DashData.ts
@@ -124,6 +124,9 @@ export interface DashMessage {
     // Website-authored lap-card layout (retained lhre/dash/layout), forwarded by
     // dashd. Validated at render; absent → the built-in lap card is used.
     layout?: unknown;
+    // Website-authored park/pit-screen layout (retained lhre/dash/parkLayout).
+    // Validated at render; absent → the built-in park screen is used.
+    parkLayout?: unknown;
 }
 
 // VCU event mode enum (matches firmware VCU_DEFAULT_PARAMS + per-event override

--- a/BEVO/dashd/main.rs
+++ b/BEVO/dashd/main.rs
@@ -276,6 +276,10 @@ struct DashMessage {
     /// built-in lap card.
     #[serde(skip_serializing_if = "Option::is_none")]
     layout: Option<serde_json::Value>,
+    /// Website-authored park/pit-screen layout (retained `lhre/dash/parkLayout`).
+    /// None until one is sent → frontend uses its built-in park screen.
+    #[serde(rename = "parkLayout", skip_serializing_if = "Option::is_none")]
+    park_layout: Option<serde_json::Value>,
 }
 
 /// Snapshot published to `lhre/dash/state` for the trackside link-health /
@@ -395,6 +399,9 @@ struct DashState {
     /// Website-authored lap-card layout (retained `lhre/dash/layout`), held as
     /// raw JSON and forwarded to the frontend. None → frontend's built-in card.
     layout: Option<serde_json::Value>,
+    /// Website-authored park/pit-screen layout (retained `lhre/dash/parkLayout`).
+    /// None → frontend's built-in park screen.
+    park_layout: Option<serde_json::Value>,
 }
 
 impl DashState {
@@ -523,6 +530,32 @@ fn load_layout() -> Option<serde_json::Value> {
     match serde_json::from_str::<serde_json::Value>(data.trim()) {
         Ok(v) => {
             println!("[DASHD] Restored lap-card layout from {}", path);
+            Some(v)
+        }
+        Err(_) => None,
+    }
+}
+
+// Park/pit-screen layout — same disk-cache pattern as the lap-card layout, own
+// file + env override so the two survive a reboot independently.
+const PARK_LAYOUT_PATH: &str = "/tmp/BEVO_dash_parklayout.json";
+
+fn park_layout_path() -> String {
+    env_or_default("DASHD_PARK_LAYOUT_PATH", PARK_LAYOUT_PATH)
+}
+
+fn persist_park_layout(raw: &str) {
+    if let Err(e) = std::fs::write(park_layout_path(), raw) {
+        eprintln!("[DASHD] Failed to persist park layout: {}", e);
+    }
+}
+
+fn load_park_layout() -> Option<serde_json::Value> {
+    let path = park_layout_path();
+    let data = std::fs::read_to_string(&path).ok()?;
+    match serde_json::from_str::<serde_json::Value>(data.trim()) {
+        Ok(v) => {
+            println!("[DASHD] Restored park layout from {}", path);
             Some(v)
         }
         Err(_) => None,
@@ -841,7 +874,8 @@ fn ws_server_loop(state: Arc<Mutex<DashState>>) {
                                 mqtt.lap_trigger = Some(locked.lap_count as f32);
                                 let pacing = locked.pacing(Instant::now());
                                 let layout = locked.layout.clone();
-                                DashMessage { seq, can, mqtt, pacing, layout }
+                                let park_layout = locked.park_layout.clone();
+                                DashMessage { seq, can, mqtt, pacing, layout, park_layout }
                             };
 
                             let json = match serde_json::to_string(&message) {
@@ -987,6 +1021,31 @@ fn mqtt_subscriber_loop(state: Arc<Mutex<DashState>>) {
                             }
                             Err(e) => {
                                 eprintln!("[DASHD] MQTT bad layout payload: {}", e)
+                            }
+                        }
+                        continue;
+                    }
+
+                    // parkLayout: the park/pit-screen layout. Same handling as
+                    // `layout` — retained, cached to disk, forwarded verbatim.
+                    if field == "parkLayout" {
+                        match serde_json::from_str::<serde_json::Value>(payload_str) {
+                            Ok(v) => {
+                                {
+                                    let mut locked = state.lock().unwrap();
+                                    locked.park_layout = Some(v);
+                                }
+                                persist_park_layout(payload_str);
+                                let _ = client.publish(
+                                    format!("{}ack/parkLayout", MQTT_TOPIC_PREFIX),
+                                    QoS::AtMostOnce,
+                                    true,
+                                    payload_str.as_bytes().to_vec(),
+                                );
+                                println!("[DASHD] Loaded park layout ({} bytes)", payload_str.len());
+                            }
+                            Err(e) => {
+                                eprintln!("[DASHD] MQTT bad parkLayout payload: {}", e)
                             }
                         }
                         continue;
@@ -1222,6 +1281,7 @@ fn main() -> Result<()> {
         last_lap: None,
         // Restore the last layout from disk; the retained MQTT topic refreshes it.
         layout: load_layout(),
+        park_layout: load_park_layout(),
     }));
 
     let ipc_state = Arc::clone(&state);

--- a/telemtry/analysis/database/viewer_tool/src/app/api/dash/layouts/route.ts
+++ b/telemtry/analysis/database/viewer_tool/src/app/api/dash/layouts/route.ts
@@ -9,16 +9,21 @@ import { NextRequest, NextResponse } from "next/server";
 import { promises as fs } from "fs";
 import path from "path";
 
-function libPath(): string {
+// Per-screen library file. `lapCard` keeps the original library.json (so saved
+// lap cards survive this change); any other screen gets library.<screen>.json.
+// `screen` is sanitized to a safe slug so the query param can't escape the dir.
+function libPath(screen: string): string {
   const dir = process.env.CACHE_DIR
     ? path.join(process.env.CACHE_DIR, "dash_layouts")
     : path.join(process.cwd(), ".cache", "dash_layouts");
-  return path.join(dir, "library.json");
+  const slug = (screen || "lapCard").replace(/[^a-zA-Z0-9_-]/g, "").slice(0, 40) || "lapCard";
+  return path.join(dir, slug === "lapCard" ? "library.json" : `library.${slug}.json`);
 }
 
-export async function GET() {
+export async function GET(req: NextRequest) {
+  const screen = req.nextUrl.searchParams.get("screen") ?? "lapCard";
   try {
-    const raw = await fs.readFile(libPath(), "utf-8");
+    const raw = await fs.readFile(libPath(screen), "utf-8");
     return NextResponse.json(JSON.parse(raw));
   } catch {
     return NextResponse.json({ items: [], savedAt: 0 });
@@ -26,9 +31,10 @@ export async function GET() {
 }
 
 export async function PUT(req: NextRequest) {
+  const screen = req.nextUrl.searchParams.get("screen") ?? "lapCard";
   const body = (await req.json().catch(() => ({}))) as { items?: unknown };
   const items = Array.isArray(body.items) ? body.items : [];
-  const p = libPath();
+  const p = libPath(screen);
   await fs.mkdir(path.dirname(p), { recursive: true });
   const tmp = `${p}.tmp`;
   await fs.writeFile(tmp, JSON.stringify({ items, savedAt: Date.now() }));

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
@@ -1794,11 +1794,13 @@ function App() {
 
   // Publish the lap-card layout to the car (retained: used until replaced). Only
   // the session leader commands the car; the dash link must be connected.
-  function sendLapLayout(layout: LapCardLayout) {
+  function sendDashLayout(screenId: string, layout: LapCardLayout) {
     if (isMirrorRef.current) { setLayoutSendStatus("Read-only mirror — only the session leader can push to the car."); return; }
     if (dashSignals.status !== "connected") { setLayoutSendStatus("Connect to the dash first (Dash tab → Connect to dash)."); return; }
-    const ok = dashSignals.publishLayout(layout);
-    setLayoutSendStatus(ok ? `Sent “${layout.name}” to the car ✓ (retained — used until replaced)` : "Publish failed — check the dash link.");
+    // Route to the screen's retained topic: park → parkLayout, else the lap card.
+    const ok = screenId === "park" ? dashSignals.publishParkLayout(layout) : dashSignals.publishLayout(layout);
+    const where = screenId === "park" ? "park screen" : "lap card";
+    setLayoutSendStatus(ok ? `Sent “${layout.name}” to the ${where} ✓ (retained — used until replaced)` : "Publish failed — check the dash link.");
     window.setTimeout(() => setLayoutSendStatus(""), 5000);
   }
 
@@ -2718,7 +2720,7 @@ function App() {
         />
       ) : null}
       {lapDesignerOpen ? (
-        <DashLayoutEditor onClose={() => setLapDesignerOpen(false)} onSend={sendLapLayout} sendStatus={layoutSendStatus} />
+        <DashLayoutEditor onClose={() => setLapDesignerOpen(false)} onSend={sendDashLayout} sendStatus={layoutSendStatus} />
       ) : null}
       {confirmStopOpen ? (
         <div className="modalOverlay" onMouseDown={() => setConfirmStopOpen(false)}>
@@ -3959,7 +3961,7 @@ function App() {
             </div>
             <div className="gateButtons" style={{ marginTop: 10 }}>
               <button className="tool" disabled={isMirror} onClick={() => setLapDesignerOpen(true)}>
-                <SlidersHorizontal size={15} /> Design lap screen
+                <SlidersHorizontal size={15} /> Design dash screens
               </button>
             </div>
             <label style={{ marginTop: 10 }}>

--- a/telemtry/analysis/database/viewer_tool/src/components/dashlayout/DashLayoutEditor.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/components/dashlayout/DashLayoutEditor.tsx
@@ -9,13 +9,13 @@ import { X, Send, Plus, Copy, RotateCcw, Trash2, Type, Hash, BarChart3, Gauge as
 import LapCardRenderer from './LapCardRenderer';
 import { fetchServerLayouts, saveServerLayouts } from '@/lib/dash/layoutStore';
 import {
-  LAP_CARD_W, LAP_CARD_H, FIELD_CATALOG, fieldDef, defaultLapCardLayout, validateLapCardLayout,
-  sampleLapCardData, LAYOUT_TEMPLATES, type LapCardLayout, type Widget, type WidgetType,
+  LAP_CARD_W, LAP_CARD_H, fieldDef, validateLapCardLayout,
+  sampleLapCardData, LAYOUT_TEMPLATES, DASH_SCREENS, screenDef, fieldsForScreen,
+  type LapCardLayout, type Widget, type WidgetType, type FieldDef,
   type FormatId, type Align, type GoodSign, type ColorRule,
 } from '@/lib/dash/dashLayout';
 
 const STORAGE_KEY = 'dash-lap-layout';   // legacy single-layout key (migrated on load)
-const LIBRARY_KEY = 'dash-lap-layouts';  // { items: LapCardLayout[], activeId }
 const SCALE = 0.82; // 800 -> 656 on the editor stage
 const GRID = 10;        // snap-to-grid step (layout px)
 const SNAP_THRESH = 7;  // alignment-guide snap distance (layout px)
@@ -55,11 +55,14 @@ function withId(l: LapCardLayout): LapCardLayout { return l.id ? l : { ...l, id:
 
 interface Library { items: LapCardLayout[]; activeId: string; }
 
-// Load the saved layout library, migrating the legacy single-layout key.
-function loadLibrary(): Library {
+// Load a screen's saved layout library from its localStorage namespace. The lap
+// card also migrates the legacy single-layout key; other screens start from
+// their built-in default.
+function loadLibrary(screenId: string): Library {
+  const sd = screenDef(screenId);
   if (typeof window !== 'undefined') {
     try {
-      const raw = localStorage.getItem(LIBRARY_KEY);
+      const raw = localStorage.getItem(sd.libraryKey);
       if (raw) {
         const parsed = JSON.parse(raw) as { items?: unknown[]; activeId?: string };
         const items = (parsed.items ?? [])
@@ -70,11 +73,13 @@ function loadLibrary(): Library {
           return { items, activeId };
         }
       }
-      const old = localStorage.getItem(STORAGE_KEY); // migrate legacy single layout
-      if (old) { const v = validateLapCardLayout(JSON.parse(old)); if (v) { const w = withId(v); return { items: [w], activeId: w.id! }; } }
+      if (screenId === 'lapCard') {
+        const old = localStorage.getItem(STORAGE_KEY); // migrate legacy single layout
+        if (old) { const v = validateLapCardLayout(JSON.parse(old)); if (v) { const w = withId(v); return { items: [w], activeId: w.id! }; } }
+      }
     } catch { /* fall through to default */ }
   }
-  const d = withId(defaultLapCardLayout());
+  const d = withId(sd.build());
   return { items: [d], activeId: d.id! };
 }
 
@@ -89,22 +94,38 @@ function newWidget(type: WidgetType): Widget {
   return { ...base, type: 'gauge', w: 180, h: 180, bind: 'can.soc', min: 0, max: 100, label: 'SOC', color: 'gradient', mode: 'standard', format: 'pct' };
 }
 
-export function DashLayoutEditor({ onClose, onSend, sendStatus }: {
+export function DashLayoutEditor({ onClose, onSend, sendStatus, initialScreenId }: {
   onClose: () => void;
-  onSend: (layout: LapCardLayout) => void;
+  onSend: (screenId: string, layout: LapCardLayout) => void;
   sendStatus?: string;
+  initialScreenId?: string;
 }) {
-  const [lib, setLib] = useState<Library>(loadLibrary);
+  // Which dash screen is being authored (lap card / park / …). Each has its own
+  // layout library + publish topic; switching reloads that screen's library.
+  const [screenId, setScreenId] = useState<string>(initialScreenId ?? 'lapCard');
+  const [lib, setLib] = useState<Library>(() => loadLibrary(initialScreenId ?? 'lapCard'));
+  // The screen `lib` currently holds — so the persist effect writes to the right
+  // namespace even on the render where screenId has changed but lib hasn't yet.
+  const libScreenRef = useRef<string>(initialScreenId ?? 'lapCard');
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [snap, setSnap] = useState(true);
   const [guides, setGuides] = useState<Guide[]>([]);
   const [previewTheme, setPreviewTheme] = useState<'dark' | 'light'>('dark');
   const data = useMemo(() => sampleLapCardData(), []);
   const stageRef = useRef<HTMLDivElement>(null);
+  const fields = useMemo(() => fieldsForScreen(screenId), [screenId]);
+  // Templates offered for the active screen. The lap card has its curated set;
+  // other screens just offer their built-in default as a starting point.
+  const screenTemplates = useMemo(
+    () => (screenId === 'lapCard'
+      ? LAYOUT_TEMPLATES
+      : [{ id: 'default', name: `Default ${screenDef(screenId).name}`, build: screenDef(screenId).build }]),
+    [screenId],
+  );
 
   // The active layout being edited. setLayout updates just that library entry,
   // so all the existing widget handlers keep working unchanged.
-  const layout = lib.items.find((l) => l.id === lib.activeId) ?? lib.items[0] ?? withId(defaultLapCardLayout());
+  const layout = lib.items.find((l) => l.id === lib.activeId) ?? lib.items[0] ?? withId(screenDef(screenId).build());
   const setLayout = useCallback((upd: LapCardLayout | ((p: LapCardLayout) => LapCardLayout)) => {
     setLib((prev) => ({
       ...prev,
@@ -122,31 +143,46 @@ export function DashLayoutEditor({ onClose, onSend, sendStatus }: {
   // so every client sees the same saved layouts.
   const serverSaveTimer = useRef<number | null>(null);
   useEffect(() => {
-    try { localStorage.setItem(LIBRARY_KEY, JSON.stringify(lib)); } catch { /* quota */ }
+    const key = screenDef(libScreenRef.current).libraryKey;
+    const screen = libScreenRef.current;
+    try { localStorage.setItem(key, JSON.stringify(lib)); } catch { /* quota */ }
     if (serverSaveTimer.current) window.clearTimeout(serverSaveTimer.current);
-    serverSaveTimer.current = window.setTimeout(() => { void saveServerLayouts(lib.items); }, 800);
+    serverSaveTimer.current = window.setTimeout(() => { void saveServerLayouts(screen, lib.items); }, 800);
     return () => { if (serverSaveTimer.current) window.clearTimeout(serverSaveTimer.current); };
   }, [lib]);
 
-  // Pull the shared library on open. Server is the source of truth if it has
+  // Pull a screen's shared library. Server is the source of truth if it has
   // anything; if it's empty but we have local layouts, seed it from local.
   const [syncMsg, setSyncMsg] = useState('Syncing…');
-  const pullFromServer = useCallback(async (announce = true) => {
+  const pullFromServer = useCallback(async (screen: string, localItems: LapCardLayout[], announce = true) => {
     if (announce) setSyncMsg('Syncing…');
-    const server = await fetchServerLayouts();
+    const server = await fetchServerLayouts(screen);
     if (server === null) { setSyncMsg('Offline — local only'); return; }
     if (server.length) {
       const items = server.map(withId);
+      libScreenRef.current = screen;
       setLib((prev) => ({ items, activeId: items.some((i) => i.id === prev.activeId) ? prev.activeId : items[0].id! }));
       setSyncMsg('Synced');
     } else {
       // server empty — seed it from whatever we have locally
       setSyncMsg('Synced');
-      void saveServerLayouts(lib.items);
+      void saveServerLayouts(screen, localItems);
     }
-  }, [lib.items]);
-  useEffect(() => { void pullFromServer(); /* on open only */ // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+  useEffect(() => { void pullFromServer(screenId, lib.items); /* on open only */ // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Switch the screen being authored: load that screen's library + pull its
+  // shared copy. Persisting the outgoing screen already happened via the effect.
+  const switchScreen = useCallback((id: string) => {
+    if (id === screenId) return;
+    const next = loadLibrary(id);
+    libScreenRef.current = id;
+    setScreenId(id);
+    setLib(next);
+    setSelectedId(null);
+    void pullFromServer(id, next.items);
+  }, [screenId, pullFromServer]);
 
   const uniqueName = (base: string): string => {
     const names = new Set(lib.items.map((l) => l.name));
@@ -154,7 +190,7 @@ export function DashLayoutEditor({ onClose, onSend, sendStatus }: {
     let n = 2; while (names.has(`${base} ${n}`)) n++; return `${base} ${n}`;
   };
   const addLayout = (l: LapCardLayout) => {
-    const w = withId({ ...l, id: undefined, name: uniqueName(l.name || 'Lap card') });
+    const w = withId({ ...l, id: undefined, name: uniqueName(l.name || screenDef(screenId).name) });
     setLib((p) => ({ items: [...p.items, w], activeId: w.id! }));
     setSelectedId(null);
   };
@@ -162,7 +198,7 @@ export function DashLayoutEditor({ onClose, onSend, sendStatus }: {
     if (!window.confirm(`Delete layout “${layout.name}”?`)) return;
     setLib((p) => {
       const items = p.items.filter((l) => l.id !== p.activeId);
-      if (!items.length) { const d = withId(defaultLapCardLayout()); return { items: [d], activeId: d.id! }; }
+      if (!items.length) { const d = withId(screenDef(screenId).build()); return { items: [d], activeId: d.id! }; }
       return { items, activeId: items[0].id! };
     });
     setSelectedId(null);
@@ -213,40 +249,44 @@ export function DashLayoutEditor({ onClose, onSend, sendStatus }: {
 
   const addWidget = (t: WidgetType) => { const w = newWidget(t); setLayout((l) => ({ ...l, widgets: [...l.widgets, w] })); setSelectedId(w.id); };
   const removeSelected = () => { if (!selected) return; setLayout((l) => ({ ...l, widgets: l.widgets.filter((w) => w.id !== selected.id) })); setSelectedId(null); };
-  const resetDefault = () => { if (window.confirm('Reset this layout to the default lap card?')) { setLayout((l) => ({ ...defaultLapCardLayout(), id: l.id, name: l.name })); setSelectedId(null); } };
+  const resetDefault = () => { if (window.confirm(`Reset this layout to the default ${screenDef(screenId).name}?`)) { setLayout((l) => ({ ...screenDef(screenId).build(), id: l.id, name: l.name })); setSelectedId(null); } };
 
   return (
     <div className="modalOverlay" onMouseDown={onClose}>
       <div className="dashEditor" onMouseDown={(e) => e.stopPropagation()}>
         <div className="dashEditorHead">
           <div className="dashEditorTitle">
-            <strong>Lap-screen designer</strong>
+            <strong>Dash designer</strong>
+            <select className="tmplSelect" value={screenId} aria-label="Screen"
+              title="Which dash screen to design" onChange={(e) => switchScreen(e.target.value)}>
+              {DASH_SCREENS.map((s) => <option key={s.id} value={s.id}>{s.name}</option>)}
+            </select>
             <select className="tmplSelect" value={lib.activeId} aria-label="Saved layout"
               onChange={(e) => { setLib((p) => ({ ...p, activeId: e.target.value })); setSelectedId(null); }}>
               {lib.items.map((l) => <option key={l.id} value={l.id}>{l.name}</option>)}
             </select>
             <input value={layout.name} onChange={(e) => setLayout((l) => ({ ...l, name: e.target.value }))} aria-label="Layout name" title="Rename this layout" />
-            <button className="tool" onClick={() => addLayout(defaultLapCardLayout())} title="New layout"><Plus size={14} /> New</button>
+            <button className="tool" onClick={() => addLayout(screenDef(screenId).build())} title="New layout"><Plus size={14} /> New</button>
             <button className="tool" onClick={() => addLayout({ ...layout, name: `${layout.name} copy` })} title="Duplicate"><Copy size={14} /></button>
             <button className="tool dangerTool" disabled={lib.items.length <= 1} onClick={deleteActive} title="Delete layout"><Trash2 size={14} /></button>
           </div>
           <div className="dashEditorActions">
             <span className="syncChip" title="Saved layouts are shared with all clients"><Cloud size={13} /> {syncMsg}</span>
-            <button className="tool iconOnly" title="Refresh from server" onClick={() => pullFromServer()}><RefreshCw size={14} /></button>
+            <button className="tool iconOnly" title="Refresh from server" onClick={() => pullFromServer(screenId, lib.items)}><RefreshCw size={14} /></button>
             <select className="tmplSelect" value="" aria-label="New from template"
               onChange={(e) => {
-                const t = LAYOUT_TEMPLATES.find((x) => x.id === e.target.value);
+                const t = screenTemplates.find((x) => x.id === e.target.value);
                 if (t) addLayout(t.build());
                 e.target.value = '';
               }}>
               <option value="">New from template…</option>
-              {LAYOUT_TEMPLATES.map((t) => <option key={t.id} value={t.id}>{t.name}</option>)}
+              {screenTemplates.map((t) => <option key={t.id} value={t.id}>{t.name}</option>)}
             </select>
             <label className="checkInline" style={{ whiteSpace: 'nowrap' }}>
               <input type="checkbox" checked={snap} onChange={(e) => setSnap(e.target.checked)} /> Snap
             </label>
             <button className="tool" onClick={resetDefault}><RotateCcw size={14} /> Reset</button>
-            <button className="primary" onClick={() => onSend(layout)}><Send size={14} /> Send to car</button>
+            <button className="primary" onClick={() => onSend(screenId, layout)}><Send size={14} /> Send to car</button>
             <button className="tool iconOnly" onClick={onClose} aria-label="Close"><X size={16} /></button>
           </div>
         </div>
@@ -305,7 +345,7 @@ export function DashLayoutEditor({ onClose, onSend, sendStatus }: {
           {/* property panel */}
           <aside className="dashEditorProps">
             {!selected ? <p className="muted" style={{ padding: 8 }}>Select a widget to edit its data &amp; style.</p> : (
-              <PropertyPanel w={selected} onChange={(p) => patch(selected.id, p)} onDelete={removeSelected} />
+              <PropertyPanel w={selected} fields={fields} onChange={(p) => patch(selected.id, p)} onDelete={removeSelected} />
             )}
           </aside>
         </div>
@@ -318,7 +358,7 @@ function Row({ label, children }: { label: string; children: React.ReactNode }) 
   return <label className="propRow"><span>{label}</span>{children}</label>;
 }
 
-function PropertyPanel({ w, onChange, onDelete }: { w: Widget; onChange: (p: Partial<Widget>) => void; onDelete: () => void }) {
+function PropertyPanel({ w, fields, onChange, onDelete }: { w: Widget; fields: FieldDef[]; onChange: (p: Partial<Widget>) => void; onDelete: () => void }) {
   const hasBind = w.type !== 'text';
   return (
     <div className="propPanel">
@@ -343,9 +383,9 @@ function PropertyPanel({ w, onChange, onDelete }: { w: Widget; onChange: (p: Par
             }
             onChange(p);
           }}>
-            {Array.from(new Set(FIELD_CATALOG.map((f) => f.group))).map((g) => (
+            {Array.from(new Set(fields.map((f) => f.group))).map((g) => (
               <optgroup key={g} label={g}>
-                {FIELD_CATALOG.filter((f) => f.group === g).map((f) => <option key={f.bind} value={f.bind}>{f.label}{f.unit ? ` (${f.unit})` : ''}</option>)}
+                {fields.filter((f) => f.group === g).map((f) => <option key={f.bind} value={f.bind}>{f.label}{f.unit ? ` (${f.unit})` : ''}</option>)}
               </optgroup>
             ))}
           </select>

--- a/telemtry/analysis/database/viewer_tool/src/lib/dash/dashLayout.ts
+++ b/telemtry/analysis/database/viewer_tool/src/lib/dash/dashLayout.ts
@@ -145,7 +145,12 @@ export interface LapCardLayout {
 }
 
 // ---- bindable fields (the "pick a data point" catalog) ---------------------
-// Paths resolve against the lap-card data context: { lapCard, pacing, can, mqtt }.
+// Paths resolve against the dash data context. The lap card binds against
+// { lapCard, pacing, can, mqtt }; the park screen against { can, pacing, mqtt }.
+// This catalog is intentionally COMPREHENSIVE — every numeric channel dashd
+// forwards is exposed so any of them can be bound in the editor ("auto-expose
+// all upstream, refine labels/formats later"). `root` (derived from the bind
+// path) lets a screen filter to only the contexts it actually receives.
 export interface FieldDef {
   bind: string;
   label: string;
@@ -162,30 +167,72 @@ export interface FieldDef {
 }
 
 export const FIELD_CATALOG: FieldDef[] = [
-  // The just-finished lap (what the card is fundamentally about)
+  // The just-finished lap (lap card only — lapCard.* is null on other screens)
   { bind: 'lapCard.lapNumber', label: 'Lap number', group: 'Lap', defaultFormat: 'int', min: 0, max: 30 },
   { bind: 'lapCard.timeS', label: 'Lap time', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120 },
   { bind: 'lapCard.energyWh', label: 'Lap energy', group: 'Lap', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 400 },
   { bind: 'mqtt.bestLapTime', label: 'Best lap', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120 },
   { bind: 'mqtt.lastLapTime', label: 'Last lap', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120 },
-  // Pacing / strategy
+  { bind: 'mqtt.currentLapTime', label: 'Current lap time', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120 },
+  { bind: 'mqtt.lapTrigger', label: 'Lap count', group: 'Lap', defaultFormat: 'int', min: 0, max: 30 },
+  // Pacing / strategy (on-car authoritative pacing snapshot)
   { bind: 'pacing.lapEnergyWh', label: 'Energy (this lap)', group: 'Pacing', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 400 },
+  { bind: 'pacing.lapBudgetWh', label: 'Per-lap budget', group: 'Pacing', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 400 },
+  { bind: 'pacing.lapElapsedS', label: 'Lap elapsed', group: 'Pacing', unit: 's', defaultFormat: 'laptime', min: 0, max: 120 },
+  { bind: 'pacing.lapNumber', label: 'Lap (in progress)', group: 'Pacing', defaultFormat: 'int', min: 0, max: 30 },
   { bind: 'mqtt.lapsRemaining', label: 'Laps remaining', group: 'Pacing', defaultFormat: 'int', min: 0, max: 30 },
+  { bind: 'mqtt.lapsRemainingEnergy', label: 'Laps left (energy)', group: 'Pacing', defaultFormat: 'int', min: 0, max: 30 },
   { bind: 'mqtt.targetPower', label: 'Target power', group: 'Pacing', unit: 'kW', defaultFormat: 'kw', min: 0, max: 80 },
   // Deltas (signed — green/red by sign; lower/negative is "good" by default)
   { bind: 'mqtt.lapDelta', label: 'Lap Δ vs ref', group: 'Deltas', unit: 's', defaultFormat: 'float2', min: -5, max: 5, bidirectional: true, isDelta: true, goodSign: 'negative' },
   { bind: 'pacing.budgetDeltaWh', label: 'Energy budget Δ', group: 'Deltas', unit: 'Wh', defaultFormat: 'whSigned', min: -100, max: 100, bidirectional: true, isDelta: true, goodSign: 'negative' },
   { bind: 'mqtt.energyDelta', label: 'Energy Δ vs target', group: 'Deltas', unit: 'Wh', defaultFormat: 'whSigned', min: -100, max: 100, bidirectional: true, isDelta: true, goodSign: 'negative' },
   { bind: 'mqtt.lapDeltaRate', label: 'Lap Δ rate', group: 'Deltas', unit: 's/s', defaultFormat: 'float2', min: -2, max: 2, bidirectional: true, isDelta: true, goodSign: 'negative' },
-  // Live car
-  { bind: 'can.soc', label: 'State of charge', group: 'Battery', unit: '%', defaultFormat: 'pct', min: 0, max: 100 },
-  { bind: 'can.temperature', label: 'Battery temp', group: 'Battery', unit: '°C', defaultFormat: 'temp', min: 0, max: 80 },
-  { bind: 'can.power', label: 'Power', group: 'Dynamics', unit: 'kW', defaultFormat: 'kw', min: -80, max: 80, bidirectional: true },
+  // Energy / charge (VCU is the source of truth for running energy)
+  { bind: 'can.soc', label: 'State of energy', group: 'Energy', unit: '%', defaultFormat: 'pct', min: 0, max: 100 },
+  { bind: 'can.vcuNetEnergyWh', label: 'VCU net energy', group: 'Energy', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 8000 },
+  { bind: 'can.vcuRegenEnergyWh', label: 'VCU regen energy', group: 'Energy', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 2000 },
+  { bind: 'can.power', label: 'Pack power', group: 'Energy', unit: 'kW', defaultFormat: 'kw', min: -80, max: 80, bidirectional: true },
+  // Cell voltages (pack health)
+  { bind: 'can.cellVMax', label: 'Cell V max', group: 'Cells', unit: 'V', defaultFormat: 'volt', min: 2.5, max: 4.3 },
+  { bind: 'can.cellVMin', label: 'Cell V min', group: 'Cells', unit: 'V', defaultFormat: 'volt', min: 2.5, max: 4.3 },
+  { bind: 'can.cellVSpread', label: 'Cell V spread', group: 'Cells', unit: 'V', defaultFormat: 'float2', min: 0, max: 0.5 },
+  // Cell + pack temps
+  { bind: 'can.cellTempMax', label: 'Cell T max', group: 'Temps', unit: '°C', defaultFormat: 'temp', min: 0, max: 80 },
+  { bind: 'can.cellTempAvg', label: 'Cell T avg', group: 'Temps', unit: '°C', defaultFormat: 'temp', min: 0, max: 80 },
+  { bind: 'can.cellTempMin', label: 'Cell T min', group: 'Temps', unit: '°C', defaultFormat: 'temp', min: 0, max: 80 },
+  { bind: 'can.temperature', label: 'Battery temp', group: 'Temps', unit: '°C', defaultFormat: 'temp', min: 0, max: 80 },
+  // Powertrain temps
+  { bind: 'can.motorTemp', label: 'Motor temp', group: 'Temps', unit: '°C', defaultFormat: 'temp', min: 0, max: 120 },
+  { bind: 'can.inverterTemp', label: 'Inverter temp', group: 'Temps', unit: '°C', defaultFormat: 'temp', min: 0, max: 100 },
+  { bind: 'can.coolantTemp', label: 'Coolant temp', group: 'Temps', unit: '°C', defaultFormat: 'temp', min: 0, max: 80 },
+  // Driver inputs
+  { bind: 'can.apps', label: 'APPS (accel)', group: 'Driver', unit: '%', defaultFormat: 'pct', min: 0, max: 100 },
+  { bind: 'can.bpps', label: 'BPPS (brake)', group: 'Driver', unit: '%', defaultFormat: 'pct', min: 0, max: 100 },
+  { bind: 'can.brakeBias', label: 'Brake bias (front)', group: 'Driver', unit: '%', defaultFormat: 'pct', min: 0, max: 100 },
+  { bind: 'can.brakePressureFront', label: 'Brake pressure F', group: 'Driver', unit: 'psi', defaultFormat: 'int', min: 0, max: 1000 },
+  { bind: 'can.brakePressureRear', label: 'Brake pressure R', group: 'Driver', unit: 'psi', defaultFormat: 'int', min: 0, max: 1000 },
+  // Rails
+  { bind: 'can.hvVoltage', label: 'HV voltage', group: 'Rails', unit: 'V', defaultFormat: 'volt', min: 0, max: 600 },
+  { bind: 'can.hvCurrent', label: 'HV current', group: 'Rails', unit: 'A', defaultFormat: 'amp', min: -400, max: 400, bidirectional: true },
+  { bind: 'can.lvVoltage', label: 'LV voltage', group: 'Rails', unit: 'V', defaultFormat: 'volt', min: 0, max: 30 },
+  { bind: 'can.lvCurrent', label: 'LV current', group: 'Rails', unit: 'A', defaultFormat: 'amp', min: 0, max: 30 },
+  // Dynamics + wheels
   { bind: 'can.speed', label: 'Speed', group: 'Dynamics', unit: 'mph', defaultFormat: 'mph', min: 0, max: 100 },
+  { bind: 'can.eventMode', label: 'VCU event mode', group: 'Dynamics', defaultFormat: 'int', min: 0, max: 4 },
+  { bind: 'can.wheelSpeedFL', label: 'Wheel FL', group: 'Wheels', defaultFormat: 'float1', min: 0, max: 100 },
+  { bind: 'can.wheelSpeedFR', label: 'Wheel FR', group: 'Wheels', defaultFormat: 'float1', min: 0, max: 100 },
+  { bind: 'can.wheelSpeedRL', label: 'Wheel RL', group: 'Wheels', defaultFormat: 'float1', min: 0, max: 100 },
+  { bind: 'can.wheelSpeedRR', label: 'Wheel RR', group: 'Wheels', defaultFormat: 'float1', min: 0, max: 100 },
 ];
 
 export function fieldDef(bind: string): FieldDef | undefined {
   return FIELD_CATALOG.find((f) => f.bind === bind);
+}
+
+// The top-level context object a bind path reads from (e.g. 'can.cellVMax' -> 'can').
+export function bindRoot(bind: string): string {
+  return bind.split('.')[0];
 }
 
 // ---- value access + formatting --------------------------------------------
@@ -249,6 +296,77 @@ export function defaultLapCardLayout(): LapCardLayout {
   };
 }
 
+// ---- screens ---------------------------------------------------------------
+// Each editable dash screen authors independently: its own retained MQTT topic
+// (lhre/dash/<topic>), library namespace, default layout, and the set of data
+// contexts available to bind. Add a screen here + a render site that reads the
+// matching DashMessage field, and the unified editor picks it up automatically.
+export interface ScreenDef {
+  id: string;
+  name: string;
+  topic: string;            // lhre/dash/<topic> (retained)
+  libraryKey: string;       // localStorage key + server library namespace
+  contextRoots: string[];   // top-level ctx objects the screen receives
+  build: () => LapCardLayout;
+}
+
+// Default starter for the Park / pit-debug screen — SoE, cell-voltage health,
+// running VCU energy, key temps, brake bias. All can.* (no lapCard.* — that
+// only exists on the lap card).
+export function defaultParkLayout(): LapCardLayout {
+  return {
+    version: DASH_LAYOUT_VERSION,
+    name: 'Default park screen',
+    background: 'auto',
+    widgets: [
+      { id: 'soe', type: 'value', bind: 'can.soc', format: 'pct', label: 'SoE %',
+        x: 30, y: 24, w: 320, h: 150, fontSize: 110, color: 'auto', align: 'center', bold: true },
+      { id: 'vmax', type: 'value', bind: 'can.cellVMax', format: 'volt', label: 'CELL V MAX',
+        x: 380, y: 30, w: 180, h: 96, fontSize: 46, color: 'auto', align: 'center', bold: true },
+      { id: 'vmin', type: 'value', bind: 'can.cellVMin', format: 'volt', label: 'CELL V MIN',
+        x: 580, y: 30, w: 180, h: 96, fontSize: 46, color: 'auto', align: 'center', bold: true },
+      { id: 'vspread', type: 'value', bind: 'can.cellVSpread', format: 'float2', label: 'SPREAD V',
+        x: 380, y: 140, w: 180, h: 96, fontSize: 46, color: 'auto', align: 'center', bold: true,
+        thresholds: [{ cmp: 'gt', value: 0.05, color: '#FFD700' }, { cmp: 'gt', value: 0.1, color: '#FF3333' }] },
+      { id: 'net', type: 'value', bind: 'can.vcuNetEnergyWh', format: 'wh', label: 'NET Wh',
+        x: 580, y: 140, w: 180, h: 96, fontSize: 46, color: 'auto', align: 'center', bold: true },
+      { id: 'tmax', type: 'value', bind: 'can.cellTempMax', format: 'temp', label: 'CELL T MAX',
+        x: 30, y: 260, w: 180, h: 90, fontSize: 42, color: 'auto', align: 'center', bold: true,
+        thresholds: [{ cmp: 'gt', value: 50, color: '#FFD700' }, { cmp: 'gt', value: 60, color: '#FF3333' }] },
+      { id: 'motor', type: 'value', bind: 'can.motorTemp', format: 'temp', label: 'MOTOR °C',
+        x: 230, y: 260, w: 180, h: 90, fontSize: 42, color: 'auto', align: 'center', bold: true },
+      { id: 'inv', type: 'value', bind: 'can.inverterTemp', format: 'temp', label: 'INV °C',
+        x: 430, y: 260, w: 160, h: 90, fontSize: 42, color: 'auto', align: 'center', bold: true },
+      { id: 'hv', type: 'value', bind: 'can.hvVoltage', format: 'volt', label: 'HV V',
+        x: 610, y: 260, w: 150, h: 90, fontSize: 42, color: 'auto', align: 'center', bold: true },
+      { id: 'bias', type: 'value', bind: 'can.brakeBias', format: 'pct', label: 'BIAS F %',
+        x: 30, y: 372, w: 180, h: 84, fontSize: 40, color: 'auto', align: 'center', bold: true },
+      { id: 'pwr', type: 'value', bind: 'can.power', format: 'kw', label: 'PACK kW',
+        x: 230, y: 372, w: 180, h: 84, fontSize: 40, color: 'auto', align: 'center', bold: true },
+      { id: 'regen', type: 'value', bind: 'can.vcuRegenEnergyWh', format: 'wh', label: 'REGEN Wh',
+        x: 430, y: 372, w: 330, h: 84, fontSize: 40, color: 'auto', align: 'center', bold: true },
+    ],
+  };
+}
+
+export const DASH_SCREENS: ScreenDef[] = [
+  { id: 'lapCard', name: 'Lap Card', topic: 'layout', libraryKey: 'dash-lap-layouts',
+    contextRoots: ['lapCard', 'pacing', 'can', 'mqtt'], build: defaultLapCardLayout },
+  { id: 'park', name: 'Park / Pit', topic: 'parkLayout', libraryKey: 'dash-park-layouts',
+    contextRoots: ['can', 'pacing', 'mqtt'], build: defaultParkLayout },
+];
+
+export function screenDef(id: string): ScreenDef {
+  return DASH_SCREENS.find((s) => s.id === id) ?? DASH_SCREENS[0];
+}
+
+// Catalog fields a screen can bind — only those whose context it actually
+// receives (so the park picker doesn't offer lapCard.* which is always null).
+export function fieldsForScreen(screenId: string): FieldDef[] {
+  const roots = screenDef(screenId).contextRoots;
+  return FIELD_CATALOG.filter((f) => roots.includes(bindRoot(f.bind)));
+}
+
 // Starter presets the strategist can load and then tweak.
 export const LAYOUT_TEMPLATES: { id: string; name: string; build: () => LapCardLayout }[] = [
   { id: 'default', name: 'Default lap card', build: defaultLapCardLayout },
@@ -308,14 +426,26 @@ export function validateLapCardLayout(raw: unknown): LapCardLayout | null {
   };
 }
 
-// Synthetic data so the editor preview is realistic with the car off.
+// Synthetic data so the editor preview is realistic with the car off. Covers
+// every catalog field across all contexts so any bound widget renders a value
+// (both the lap card and the park screen preview from this).
 export function sampleLapCardData() {
   return {
     lapCard: { lapNumber: 7, timeS: 84.36, energyWh: 213 },
-    pacing: { lapEnergyWh: 213, budgetDeltaWh: -12, lapElapsedS: 84.36, lapNumber: 7,
-      lastLapNumber: 7, lastLapTimeS: 84.36, lastLapEnergyWh: 213 },
-    can: { soc: 62, temperature: 41.5, power: 47, speed: 38 },
-    mqtt: { lapDelta: -0.42, energyDelta: -12, lapsRemaining: 15, targetPower: 30,
-      bestLapTime: 83.1, lastLapTime: 84.36, lapDeltaRate: 0.08 },
+    pacing: { lapEnergyWh: 213, budgetDeltaWh: -12, lapBudgetWh: 225, lapElapsedS: 84.36,
+      lapNumber: 7, lastLapNumber: 7, lastLapTimeS: 84.36, lastLapEnergyWh: 213 },
+    can: {
+      soc: 62, temperature: 41.5, power: 47, speed: 38, eventMode: 4,
+      vcuNetEnergyWh: 4120, vcuRegenEnergyWh: 615,
+      cellVMax: 4.02, cellVMin: 3.91, cellVSpread: 0.11,
+      cellTempMax: 46.2, cellTempAvg: 42.8, cellTempMin: 38.4,
+      motorTemp: 64, inverterTemp: 52, coolantTemp: 38,
+      apps: 0, bpps: 0, brakeBias: 54, brakePressureFront: 0, brakePressureRear: 0,
+      hvVoltage: 449.3, hvCurrent: 10, lvVoltage: 25, lvCurrent: 9.3,
+      wheelSpeedFL: 38, wheelSpeedFR: 38, wheelSpeedRL: 38, wheelSpeedRR: 38,
+    },
+    mqtt: { lapDelta: -0.42, energyDelta: -12, lapsRemaining: 15, lapsRemainingEnergy: 14,
+      targetPower: 30, bestLapTime: 83.1, lastLapTime: 84.36, currentLapTime: 84.36,
+      lapDeltaRate: 0.08, lapTrigger: 7 },
   };
 }

--- a/telemtry/analysis/database/viewer_tool/src/lib/dash/dashSignals.ts
+++ b/telemtry/analysis/database/viewer_tool/src/lib/dash/dashSignals.ts
@@ -83,6 +83,8 @@ export interface DashSignals {
     publishGate: (gate: [number, number, number, number]) => void;
     /** Push the lap-card layout the dash renders (retained: sent once, used until replaced). */
     publishLayout: (layout: unknown) => boolean;
+    /** Push the park/pit-screen layout (retained, separate topic from the lap card). */
+    publishParkLayout: (layout: unknown) => boolean;
     /** Push the live dynamic per-lap energy budget (Wh) the dash shows (retained). */
     publishLapBudget: (wh: number) => boolean;
     publishLapCardMs: (ms: number) => boolean;
@@ -287,6 +289,15 @@ export function useDashSignals(): DashSignals {
         return true;
     }, []);
 
+    // Park / pit-screen layout — same retained pattern, separate topic so the
+    // two screens are authored independently.
+    const publishParkLayout = useCallback((layout: unknown): boolean => {
+        const client = clientRef.current;
+        if (!client || !client.connected) return false;
+        client.publish(`${TOPIC_PREFIX}parkLayout`, JSON.stringify(layout), { qos: 1, retain: true });
+        return true;
+    }, []);
+
     // Retained: the live per-lap Wh budget (remaining energy / remaining laps),
     // republished by trackside whenever it changes. The dash holds it and shows
     // the driver the current Wh/lap target.
@@ -359,6 +370,7 @@ export function useDashSignals(): DashSignals {
         resetLapCounter,
         publishGate,
         publishLayout,
+        publishParkLayout,
         publishLapBudget,
         publishLapCardMs,
         publishMessages,

--- a/telemtry/analysis/database/viewer_tool/src/lib/dash/layoutStore.ts
+++ b/telemtry/analysis/database/viewer_tool/src/lib/dash/layoutStore.ts
@@ -1,13 +1,17 @@
 // Server bridge for the shared dash-layout library (/api/dash/layouts). Lets
 // every client see the same saved layouts. localStorage stays as an offline
 // cache + instant initial render; the server copy is the shared source.
+//
+// Layouts are namespaced per screen via `?screen=`. The default (`lapCard`)
+// maps to the original library.json so existing saved lap cards are untouched;
+// other screens (e.g. `park`) get their own file server-side.
 
 import { validateLapCardLayout, type LapCardLayout } from './dashLayout';
 
-export async function fetchServerLayouts(): Promise<LapCardLayout[] | null> {
+export async function fetchServerLayouts(screen = 'lapCard'): Promise<LapCardLayout[] | null> {
   if (typeof fetch === 'undefined') return null;
   try {
-    const res = await fetch('/api/dash/layouts');
+    const res = await fetch(`/api/dash/layouts?screen=${encodeURIComponent(screen)}`);
     if (!res.ok) return null;
     const body = (await res.json()) as { items?: unknown[] };
     return (body.items ?? []).map((i) => validateLapCardLayout(i)).filter(Boolean) as LapCardLayout[];
@@ -16,10 +20,10 @@ export async function fetchServerLayouts(): Promise<LapCardLayout[] | null> {
   }
 }
 
-export async function saveServerLayouts(items: LapCardLayout[]): Promise<void> {
+export async function saveServerLayouts(screen: string, items: LapCardLayout[]): Promise<void> {
   if (typeof fetch === 'undefined') return;
   try {
-    await fetch('/api/dash/layouts', {
+    await fetch(`/api/dash/layouts?screen=${encodeURIComponent(screen)}`, {
       method: 'PUT',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ items }),


### PR DESCRIPTION
## What

Makes the **Park / pit screen customizable like the lap card** — full widget editing (drag/resize/bind/style) with control over which telemetry field each item reads. Done by generalizing the existing lap-card layout system into a **unified, multi-screen designer** rather than building anything new: the renderer and editor were already generic, so this mostly wires a second screen through them.

> **Stacked on #295** (the Park debug screen). Base is `telemetry/dash-park-debug`; retarget to `main` once #295 merges. **Not deployed to the car** (per request) — review-only for now.

## How it works

**Unified editor** (`DashLayoutEditor`) — adds a **screen picker** (Lap Card / Park). Each screen authors independently:
- its own layout library (localStorage + server, namespaced per screen)
- its own retained MQTT topic
- a field picker filtered to the contexts that screen actually receives (the Park picker drops `lapCard.*`, which is always null there)

Switching screens reloads that screen's library and pulls its shared copy. The lap card is unchanged in behavior — it's just one entry in the new `DASH_SCREENS` registry.

**Auto-exposed catalog** (`dashLayout.ts`) — per your "expose all upstream, refine later": `FIELD_CATALOG` now covers **every numeric channel dashd forwards** — all `can.*` (cell-V min/max/spread, cell + powertrain temps, brake bias/pressures, APPS/BPPS, HV/LV rails, VCU energy, wheel speeds, speed/power/eventMode), plus `pacing.*` and `mqtt.*`. Grouped for the picker; labels/formats are a sensible first pass meant to be refined. (Note: the website only receives the `lhre/dash/state` mirror, not the full `can.*`, so the catalog is a static field list rather than live-discovered — it's the comprehensive set from `DashData.ts`.)

**Transport** — `dashSignals.publishParkLayout` → retained `lhre/dash/parkLayout`. `dashd` (`main.rs`) mirrors the lap-card layout plumbing for `parkLayout` (state field, subscribe + disk-persist + ack, forwarded in `DashMessage.parkLayout`, restored on boot). `/api/dash/layouts` + `layoutStore` namespace the server library per screen via `?screen=` — `lapCard` keeps the original `library.json` (existing saved lap cards untouched), others get `library.<screen>.json`.

**Render** — `PitDiagnostic` renders the website-authored park layout via the shared `LapCardRenderer` when present + valid, else falls back to the built-in grid from #295 (never blanks). New `defaultParkLayout` starter: SoE, cell-V health, running VCU energy, key temps, brake bias.

## Decisions 

- **Faults**: left off the editable layout for now — fault reporting isn't trustworthy yet. The built-in fallback grid still shows them.
- **Unified editor**: one designer with a screen picker (extensible — add a `ScreenDef` + a render site and it appears).
- **Catalog**: auto-expose everything now, refine labels/formats later.

## Test plan

- viewer_tool `tsc --noEmit` clean. (Full `next build` + the car build run at deploy.)
- After deploy (separate, gated on #295): open Dash tab → Design dash screens → pick **Park** → drag/bind widgets → Send. Shift the car to **Park** and confirm the custom layout renders; clear it (or send empty) and confirm the built-in grid returns. Confirm the lap-card screen still authors/sends exactly as before (separate library + `lhre/dash/layout`).

## Review notes

- Pure dashd + website change; no CAN-schema/proto changes.
- The car's `BEVO/dashd/` frontend carries known divergence from `main` (driver-message overlay, lap-budget, ScreenOne layout). `PitDiagnostic` here derives its theme from the DOM class (`body.theme-light`) — matching the **car's** ScreenOne — so it does NOT depend on the repo-only `SettingsContext`, keeping it deployable to the car without dragging in that divergence. Reconciling the broader dashd-frontend divergence is still a separate cleanup.
- `parkLayout` persists to `/tmp/BEVO_dash_parklayout.json` on the car (override `DASHD_PARK_LAYOUT_PATH`), same as the lap-card layout.