### PR TITLE
dash: customizable primary/driving screen + lift lap-card overlay

### DIFF
--- a/BEVO/dashd/frontend/src/components/LapCardOverlay.tsx
+++ b/BEVO/dashd/frontend/src/components/LapCardOverlay.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { LapCardRenderer } from '../LapCardRenderer';
+import { validateLapCardLayout } from '../dashLayout';
+import { useEnergyPacing } from '../hooks/useEnergyPacing';
+import type { DashMessage } from '../types/DashData';
+
+const fmtLapTime = (secs: number | null | undefined): string => {
+    if (secs === null || secs === undefined) return "--:--.--";
+    const m = Math.floor(secs / 60);
+    const s = secs - m * 60;
+    return `${m}:${s.toFixed(2).padStart(5, '0')}`;
+};
+
+// Full-screen lap card — pops on each lapTrigger crossing and clears itself after
+// LAP_CARD_MS (see useEnergyPacing). Rendered by Dashboard (not a single screen) so
+// it floats over WHATEVER screen is active — built-in OR custom driving layout, Park,
+// Shutdown — exactly like the driver-message overlay. It owns its own useEnergyPacing
+// instance; that hook is driven purely by mqtt.lapTrigger, so it stays in sync with
+// any other instance (e.g. ScreenOne's energy readout) without shared state.
+//
+// z-index 1000: below the driver-message overlay (1100) so a strategist nudge still
+// wins, above all screen content.
+export function LapCardOverlay({ data, theme }: { data: DashMessage | null; theme: 'light' | 'dark' }) {
+    const pacing = useEnergyPacing(data);
+    if (!pacing.lapCard) return null;
+
+    // Trackside custom lap-card layout, if one was sent; else the built-in card.
+    // validateLapCardLayout returns null for a missing/malformed layout, so the
+    // driver screen never blanks.
+    const customLayout = validateLapCardLayout(data?.layout);
+    if (customLayout && customLayout.widgets.length) {
+        const ctx = {
+            lapCard: pacing.lapCard,
+            pacing: data?.pacing,
+            can: data?.can,
+            mqtt: data?.mqtt,
+        };
+        return (
+            <div style={{ position: 'absolute', inset: 0, zIndex: 1000 }}>
+                <LapCardRenderer layout={customLayout} data={ctx} scale={1} theme={theme} />
+            </div>
+        );
+    }
+    return (
+        <div style={{
+            position: 'absolute',
+            inset: 0,
+            zIndex: 1000,
+            background: theme === 'light' ? 'rgba(244,241,237,0.94)' : 'rgba(8,8,10,0.92)',
+            backdropFilter: 'blur(6px)',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: '8px'
+        }}>
+            <div className="label-small" style={{ fontSize: '1.4rem', letterSpacing: '8px', color: '#BF5700' }}>
+                LAP {pacing.lapCard.lapNumber}
+            </div>
+            <div className="value-display" style={{ fontSize: '7rem', fontWeight: 'bold', lineHeight: 0.9 }}>
+                {fmtLapTime(pacing.lapCard.timeS)}
+            </div>
+            <div className="value-display" style={{ fontSize: '3rem', fontWeight: 'bold', color: 'var(--fg-secondary)', lineHeight: 1 }}>
+                {Math.round(pacing.lapCard.energyWh)}
+                <span className="label-small" style={{ fontSize: '1.1rem', marginLeft: '8px' }}>Wh / LAP</span>
+            </div>
+        </div>
+    );
+}
+
+export default LapCardOverlay;

--- a/BEVO/dashd/frontend/src/components/LapCardOverlay.tsx
+++ b/BEVO/dashd/frontend/src/components/LapCardOverlay.tsx
@@ -1,8 +1,17 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { LapCardRenderer } from '../LapCardRenderer';
 import { validateLapCardLayout } from '../dashLayout';
-import { useEnergyPacing } from '../hooks/useEnergyPacing';
-import type { DashMessage } from '../types/DashData';
+import { useEnergyPacing, type LapSummary } from '../hooks/useEnergyPacing';
+import type { CanData, MqttData, PacingData, DashMessage } from '../types/DashData';
+
+// The data a lap card renders. Frozen once at lap completion (see below) so the
+// card is a still snapshot of that instant, not a live view.
+interface LapCardCtx {
+    lapCard: LapSummary;
+    pacing?: PacingData;
+    can?: CanData;
+    mqtt?: MqttData;
+}
 
 const fmtLapTime = (secs: number | null | undefined): string => {
     if (secs === null || secs === undefined) return "--:--.--";
@@ -22,7 +31,22 @@ const fmtLapTime = (secs: number | null | undefined): string => {
 // wins, above all screen content.
 export function LapCardOverlay({ data, theme }: { data: DashMessage | null; theme: 'light' | 'dark' }) {
     const pacing = useEnergyPacing(data);
-    if (!pacing.lapCard) return null;
+    const lapCard = pacing.lapCard;
+
+    // A lap card is a SNAPSHOT of the moment the lap completed — freeze the whole
+    // render context (pacing/can/mqtt) the first frame the card appears and reuse
+    // it for the card's lifetime. Otherwise live fields (notably the trackside
+    // mqtt.lapDelta / energyDelta a custom layout may bind) keep ticking for the
+    // seconds the card is up, so the driver sees the delta move on a "finished"
+    // lap. Re-snapshots only when the lap NUMBER changes (the next card).
+    const frozenRef = useRef<LapCardCtx | null>(null);
+    if (lapCard == null) {
+        frozenRef.current = null;
+    } else if (frozenRef.current?.lapCard.lapNumber !== lapCard.lapNumber) {
+        frozenRef.current = { lapCard, pacing: data?.pacing, can: data?.can, mqtt: data?.mqtt };
+    }
+    const frozen = frozenRef.current;
+    if (!frozen) return null;
 
     // Trackside custom lap-card layout, if one was sent; else the built-in card.
     // validateLapCardLayout returns null for a missing/malformed layout, so the
@@ -30,10 +54,10 @@ export function LapCardOverlay({ data, theme }: { data: DashMessage | null; them
     const customLayout = validateLapCardLayout(data?.layout);
     if (customLayout && customLayout.widgets.length) {
         const ctx = {
-            lapCard: pacing.lapCard,
-            pacing: data?.pacing,
-            can: data?.can,
-            mqtt: data?.mqtt,
+            lapCard: frozen.lapCard,
+            pacing: frozen.pacing,
+            can: frozen.can,
+            mqtt: frozen.mqtt,
         };
         return (
             <div style={{ position: 'absolute', inset: 0, zIndex: 1000 }}>
@@ -55,13 +79,13 @@ export function LapCardOverlay({ data, theme }: { data: DashMessage | null; them
             gap: '8px'
         }}>
             <div className="label-small" style={{ fontSize: '1.4rem', letterSpacing: '8px', color: '#BF5700' }}>
-                LAP {pacing.lapCard.lapNumber}
+                LAP {frozen.lapCard.lapNumber}
             </div>
             <div className="value-display" style={{ fontSize: '7rem', fontWeight: 'bold', lineHeight: 0.9 }}>
-                {fmtLapTime(pacing.lapCard.timeS)}
+                {fmtLapTime(frozen.lapCard.timeS)}
             </div>
             <div className="value-display" style={{ fontSize: '3rem', fontWeight: 'bold', color: 'var(--fg-secondary)', lineHeight: 1 }}>
-                {Math.round(pacing.lapCard.energyWh)}
+                {Math.round(frozen.lapCard.energyWh)}
                 <span className="label-small" style={{ fontSize: '1.1rem', marginLeft: '8px' }}>Wh / LAP</span>
             </div>
         </div>

--- a/BEVO/dashd/frontend/src/dashLayout.ts
+++ b/BEVO/dashd/frontend/src/dashLayout.ts
@@ -61,7 +61,8 @@ export type FormatId =
   | 'raw' | 'int' | 'float1' | 'float2'
   | 'laptime'   // M:SS.ss
   | 'wh' | 'whSigned' | 'kwh'
-  | 'kw' | 'pct' | 'temp' | 'volt' | 'amp' | 'mph';
+  | 'kw' | 'pct' | 'temp' | 'volt' | 'amp' | 'mph'
+  | 'bool';     // ON/OFF — booleans (e.g. can.regenEnabled) coerce to 1/0 in getByPath
 
 export interface BaseWidget {
   id: string;
@@ -203,6 +204,9 @@ export function getByPath(ctx: unknown, path: string): number | null {
     if (cur == null || typeof cur !== 'object') return null;
     cur = (cur as Record<string, unknown>)[key];
   }
+  // Booleans (e.g. can.regenEnabled, contactors) are exposed as 1/0 so they can
+  // bind to value widgets — rendered ON/OFF via the 'bool' format or a valueMap.
+  if (typeof cur === 'boolean') return cur ? 1 : 0;
   return typeof cur === 'number' && Number.isFinite(cur) ? cur : null;
 }
 
@@ -218,6 +222,9 @@ export function valueColor(v: number | null | undefined, base: string, rules?: C
 
 export function formatValue(v: number | null | undefined, fmt: FormatId, decimals?: number): string {
   if (v == null || !Number.isFinite(v)) return '--';
+  // ON/OFF for booleans (already coerced to 1/0 by getByPath). A widget valueMap
+  // (e.g. {0:'OPEN',1:'CLOSED'}) overrides these via applyValueMap.
+  if (fmt === 'bool') return v >= 0.5 ? 'ON' : 'OFF';
   // Optional per-widget precision override. Applies to the numeric formats —
   // keeps kwh's /1000 scaling and whSigned's +/- sign; lap-time ignores it.
   if (decimals != null && Number.isFinite(decimals) && fmt !== 'laptime') {

--- a/BEVO/dashd/frontend/src/screens/Dashboard.tsx
+++ b/BEVO/dashd/frontend/src/screens/Dashboard.tsx
@@ -19,6 +19,16 @@ const SCREENS: { name: string; component: React.FC }[] = [
 const DRIVING_INDEX = SCREENS.findIndex(s => s.name === 'Driving');
 const PARK_INDEX = SCREENS.findIndex(s => s.name === 'PitDiagnostic');
 
+// Trackside debug screen-override names -> SCREENS index. The website publishes
+// one of these on lhre/dash/screen; dashd forwards it as screenOverride and
+// clears it on a real gear change. Unknown names fall through to PRNDL routing.
+const OVERRIDE_INDEX: Record<string, number> = {
+    driving: DRIVING_INDEX,
+    park: PARK_INDEX,
+    shutdown: SCREENS.findIndex(s => s.name === 'Shutdown'),
+    settings: SCREENS.findIndex(s => s.name === 'Settings'),
+};
+
 const Dashboard: React.FC = () => {
     const [screenIndex, setScreenIndex] = useState<number>(0);
     const { data } = useDash();
@@ -51,7 +61,15 @@ const Dashboard: React.FC = () => {
         setScreenIndex(prndl === 'P' ? PARK_INDEX : DRIVING_INDEX);
     }, [prndl]);
 
-    const ActiveScreen = SCREENS[screenIndex].component;
+    // A trackside debug override (if one names a known screen) takes precedence
+    // over PRNDL/Enter routing without disturbing screenIndex — so when it
+    // clears (released from the website, or auto-cleared by dashd on a gear
+    // change) the dash snaps right back to whatever it was showing.
+    const override = data?.screenOverride ?? null;
+    const overrideIndex = override != null ? OVERRIDE_INDEX[override] : undefined;
+    const effectiveIndex = overrideIndex != null && overrideIndex >= 0 ? overrideIndex : screenIndex;
+
+    const ActiveScreen = SCREENS[effectiveIndex].component;
 
     // Driver-message overlay floats on top of WHATEVER screen is active — Drive,
     // Park/PitDiagnostic (built-in OR custom layout), Shutdown, Settings — so a

--- a/BEVO/dashd/frontend/src/screens/Dashboard.tsx
+++ b/BEVO/dashd/frontend/src/screens/Dashboard.tsx
@@ -6,6 +6,7 @@ import Settings from './Settings';
 import { useDash } from '../context/DashContext';
 import { MessageCardRenderer } from '../MessageCardRenderer';
 import { validateMessage } from '../dashMessages';
+import { LapCardOverlay } from '../components/LapCardOverlay';
 
 // Add new screens by appending to this array. Enter cycles in order.
 const SCREENS: { name: string; component: React.FC }[] = [
@@ -63,6 +64,9 @@ const Dashboard: React.FC = () => {
     return (
         <div style={{ width: '100vw', height: '100vh', overflow: 'hidden', position: 'relative' }}>
             <ActiveScreen />
+            {/* Lap card (z-1000) floats over every screen — built-in or custom driving
+                layout, Park, etc. — lifted out of ScreenOne so it isn't tied to one screen. */}
+            <LapCardOverlay data={data} theme={dashTheme} />
             {driverMsg ? (
                 <div style={{ position: 'absolute', inset: 0, zIndex: 1100 }}>
                     <MessageCardRenderer message={driverMsg} theme={dashTheme} scale={1} />

--- a/BEVO/dashd/frontend/src/screens/ScreenOne.tsx
+++ b/BEVO/dashd/frontend/src/screens/ScreenOne.tsx
@@ -136,6 +136,20 @@ const ScreenOne: React.FC = () => {
     const REGEN_MAX_KW = 20;
     const DRIVE_MAX_KW = 80;
 
+    // Trackside custom driving layout, if one was published — replaces the built-in
+    // driving view (the lap-card overlay still floats on top, rendered by Dashboard).
+    // Mirrors PitDiagnostic's custom-layout branch; the built-in view below is the
+    // fallback whenever no layout is set.
+    const customDriving = validateLapCardLayout(data?.drivingLayout);
+    if (customDriving && customDriving.widgets.length) {
+        const ctx = { can: data?.can, pacing: data?.pacing, mqtt: data?.mqtt };
+        return (
+            <div style={{ position: 'absolute', inset: 0, zIndex: 1 }}>
+                <LapCardRenderer layout={customDriving} data={ctx} scale={1} theme={dashTheme} />
+            </div>
+        );
+    }
+
     return (
         <div className="modern-dash-container" style={{ width: '100vw', height: '100vh', position: 'relative' }}>
 
@@ -817,54 +831,8 @@ const ScreenOne: React.FC = () => {
                 </div>
             </div>
 
-            {/* Full-screen lap card — pops on each lapTrigger crossing and
-                clears itself after a few seconds (LAP_CARD_MS in the hook).
-                Shows the just-finished lap's time and net energy so the driver
-                gets a clear glance as they cross start/finish. */}
-            {pacing.lapCard && (() => {
-                // If trackside sent a custom lap-card layout, render it; otherwise
-                // fall back to the built-in card. validateLapCardLayout returns null
-                // for a missing/malformed layout, so the driver screen never blanks.
-                const customLayout = validateLapCardLayout(data?.layout);
-                if (customLayout && customLayout.widgets.length) {
-                    const ctx = {
-                        lapCard: pacing.lapCard,
-                        pacing: data?.pacing,
-                        can: data?.can,
-                        mqtt: data?.mqtt,
-                    };
-                    return (
-                        <div style={{ position: 'absolute', inset: 0, zIndex: 1000 }}>
-                            <LapCardRenderer layout={customLayout} data={ctx} scale={1} theme={dashTheme} />
-                        </div>
-                    );
-                }
-                return (
-                    <div style={{
-                        position: 'absolute',
-                        inset: 0,
-                        zIndex: 1000,
-                        background: dashTheme === 'light' ? 'rgba(244,241,237,0.94)' : 'rgba(8,8,10,0.92)',
-                        backdropFilter: 'blur(6px)',
-                        display: 'flex',
-                        flexDirection: 'column',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        gap: '8px'
-                    }}>
-                        <div className="label-small" style={{ fontSize: '1.4rem', letterSpacing: '8px', color: '#BF5700' }}>
-                            LAP {pacing.lapCard.lapNumber}
-                        </div>
-                        <div className="value-display" style={{ fontSize: '7rem', fontWeight: 'bold', lineHeight: 0.9 }}>
-                            {fmtLapTime(pacing.lapCard.timeS)}
-                        </div>
-                        <div className="value-display" style={{ fontSize: '3rem', fontWeight: 'bold', color: 'var(--fg-secondary)', lineHeight: 1 }}>
-                            {Math.round(pacing.lapCard.energyWh)}
-                            <span className="label-small" style={{ fontSize: '1.1rem', marginLeft: '8px' }}>Wh / LAP</span>
-                        </div>
-                    </div>
-                );
-            })()}
+            {/* Lap card lifted to Dashboard (LapCardOverlay) so it floats over every
+                screen — including a custom driving layout — not just this one. */}
         </div>
     );
 };

--- a/BEVO/dashd/frontend/src/types/DashData.ts
+++ b/BEVO/dashd/frontend/src/types/DashData.ts
@@ -134,6 +134,10 @@ export interface DashMessage {
     // Active driver message to overlay (from lhre/dash/message), forwarded by
     // dashd. Validated at render; absent → nothing shown.
     message?: unknown;
+    // Debug screen override from trackside (lhre/dash/screen): forces the named
+    // screen ("driving"/"park"/"shutdown"/"settings") regardless of PRNDL.
+    // Absent/null → follow PRNDL. Auto-cleared by dashd on a real gear change.
+    screenOverride?: string | null;
 }
 
 // VCU event mode enum (matches firmware VCU_DEFAULT_PARAMS + per-event override

--- a/BEVO/dashd/frontend/src/types/DashData.ts
+++ b/BEVO/dashd/frontend/src/types/DashData.ts
@@ -128,6 +128,9 @@ export interface DashMessage {
     // Website-authored park/pit-screen layout (retained lhre/dash/parkLayout).
     // Validated at render; absent → the built-in park screen is used.
     parkLayout?: unknown;
+    // Website-authored primary/driving-screen layout (retained lhre/dash/drivingLayout).
+    // Validated at render; absent → the built-in driving screen is used.
+    drivingLayout?: unknown;
     // Active driver message to overlay (from lhre/dash/message), forwarded by
     // dashd. Validated at render; absent → nothing shown.
     message?: unknown;

--- a/BEVO/dashd/main.rs
+++ b/BEVO/dashd/main.rs
@@ -282,6 +282,10 @@ struct DashMessage {
     /// None until one is sent → frontend uses its built-in park screen.
     #[serde(rename = "parkLayout", skip_serializing_if = "Option::is_none")]
     park_layout: Option<serde_json::Value>,
+    /// Website-authored primary/driving-screen layout (retained `lhre/dash/drivingLayout`).
+    /// None until one is sent → frontend uses its built-in driving screen.
+    #[serde(rename = "drivingLayout", skip_serializing_if = "Option::is_none")]
+    driving_layout: Option<serde_json::Value>,
     /// Active driver message to overlay now (from `lhre/dash/message`); None when
     /// nothing is showing or it has expired.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -424,6 +428,9 @@ struct DashState {
     /// Website-authored park/pit-screen layout (retained `lhre/dash/parkLayout`).
     /// None → frontend's built-in park screen.
     park_layout: Option<serde_json::Value>,
+    /// Website-authored primary/driving-screen layout (retained `lhre/dash/drivingLayout`).
+    /// None → frontend's built-in driving screen.
+    driving_layout: Option<serde_json::Value>,
     /// Driver-message palette the car holds (retained `lhre/dash/messages`).
     messages: Option<serde_json::Value>,
     /// Active driver message + its expiry (from `lhre/dash/message`). expiry None
@@ -596,6 +603,36 @@ fn load_park_layout() -> Option<serde_json::Value> {
     match serde_json::from_str::<serde_json::Value>(data.trim()) {
         Ok(v) => {
             println!("[DASHD] Restored park layout from {}", path);
+            Some(v)
+        }
+        Err(_) => None,
+    }
+}
+
+// Primary/driving-screen layout — same disk-cache pattern + reboot-durable path
+// as the lap-card and park layouts, own file + env override.
+const DRIVING_LAYOUT_PATH: &str = "/var/lib/bevo-dash/drivinglayout.json";
+
+fn driving_layout_path() -> String {
+    env_or_default("DASHD_DRIVING_LAYOUT_PATH", DRIVING_LAYOUT_PATH)
+}
+
+fn persist_driving_layout(raw: &str) {
+    let path = driving_layout_path();
+    if let Some(dir) = std::path::Path::new(&path).parent() {
+        let _ = std::fs::create_dir_all(dir);
+    }
+    if let Err(e) = std::fs::write(&path, raw) {
+        eprintln!("[DASHD] Failed to persist driving layout: {}", e);
+    }
+}
+
+fn load_driving_layout() -> Option<serde_json::Value> {
+    let path = driving_layout_path();
+    let data = std::fs::read_to_string(&path).ok()?;
+    match serde_json::from_str::<serde_json::Value>(data.trim()) {
+        Ok(v) => {
+            println!("[DASHD] Restored driving layout from {}", path);
             Some(v)
         }
         Err(_) => None,
@@ -915,12 +952,13 @@ fn ws_server_loop(state: Arc<Mutex<DashState>>) {
                                 let pacing = locked.pacing(Instant::now());
                                 let layout = locked.layout.clone();
                                 let park_layout = locked.park_layout.clone();
+                                let driving_layout = locked.driving_layout.clone();
                                 // Expire a timed message before forwarding it.
                                 let message = match locked.message_expiry {
                                     Some(exp) if Instant::now() >= exp => None,
                                     _ => locked.active_message.clone(),
                                 };
-                                DashMessage { seq, can, mqtt, pacing, layout, park_layout, message }
+                                DashMessage { seq, can, mqtt, pacing, layout, park_layout, driving_layout, message }
                             };
 
                             let json = match serde_json::to_string(&message) {
@@ -1091,6 +1129,28 @@ fn mqtt_subscriber_loop(state: Arc<Mutex<DashState>>) {
                             }
                             Err(e) => {
                                 eprintln!("[DASHD] MQTT bad parkLayout payload: {}", e)
+                            }
+                        }
+                        continue;
+                    }
+                    if field == "drivingLayout" {
+                        match serde_json::from_str::<serde_json::Value>(payload_str) {
+                            Ok(v) => {
+                                {
+                                    let mut locked = state.lock().unwrap();
+                                    locked.driving_layout = Some(v);
+                                }
+                                persist_driving_layout(payload_str);
+                                let _ = client.publish(
+                                    format!("{}ack/drivingLayout", MQTT_TOPIC_PREFIX),
+                                    QoS::AtMostOnce,
+                                    true,
+                                    payload_str.as_bytes().to_vec(),
+                                );
+                                println!("[DASHD] Loaded driving layout ({} bytes)", payload_str.len());
+                            }
+                            Err(e) => {
+                                eprintln!("[DASHD] MQTT bad drivingLayout payload: {}", e)
                             }
                         }
                         continue;
@@ -1401,6 +1461,7 @@ fn main() -> Result<()> {
         // Restore the last layout from disk; the retained MQTT topic refreshes it.
         layout: load_layout(),
         park_layout: load_park_layout(),
+        driving_layout: load_driving_layout(),
         messages: None,
         active_message: None,
         message_expiry: None,

--- a/BEVO/dashd/main.rs
+++ b/BEVO/dashd/main.rs
@@ -293,6 +293,12 @@ struct DashMessage {
     /// nothing is showing or it has expired.
     #[serde(skip_serializing_if = "Option::is_none")]
     message: Option<serde_json::Value>,
+    /// Debug screen override from trackside (`lhre/dash/screen`): forces the dash
+    /// to show a named screen ("driving"/"park"/"shutdown"/"settings") regardless
+    /// of PRNDL. None = follow PRNDL normally. Cleared automatically on a real
+    /// gear transition so it can never strand the driver on the wrong screen.
+    #[serde(rename = "screenOverride", skip_serializing_if = "Option::is_none")]
+    screen_override: Option<String>,
 }
 
 /// Snapshot published to `lhre/dash/state` for the trackside link-health /
@@ -447,6 +453,13 @@ struct DashState {
     /// while a sticky (durationS=0) message is up; both cleared on replace.
     active_message: Option<serde_json::Value>,
     message_expiry: Option<Instant>,
+    /// Debug screen override from trackside (`lhre/dash/screen`). Forces the
+    /// named screen regardless of PRNDL; None = follow PRNDL. Auto-cleared on a
+    /// real gear transition (see `last_prndl`) so it can't strand the driver.
+    screen_override: Option<String>,
+    /// Last PRNDL seen by the IPC loop, for rising-edge detection of a real
+    /// gear change (which clears any active screen_override).
+    last_prndl: Option<&'static str>,
 }
 
 impl DashState {
@@ -876,8 +889,21 @@ fn ipc_reader_loop(state: Arc<Mutex<DashState>>) {
                             let mut locked = state.lock().unwrap();
                             let can_data = extract_can_data(&data, &mut locked.last_qualified_soc);
                             let power = can_data.power;
+                            let new_prndl = can_data.prndl;
                             locked.can = can_data;
                             locked.last_can_update = now;
+
+                            // A real gear change clears any trackside screen
+                            // override — the override is a debug convenience, and
+                            // the driver moving the shifter must always win so we
+                            // can't strand them on the wrong screen at speed.
+                            if let (Some(prev), Some(cur)) = (locked.last_prndl, new_prndl) {
+                                if prev != cur && locked.screen_override.is_some() {
+                                    println!("[DASHD] clearing screen override (PRNDL {} -> {})", prev, cur);
+                                    locked.screen_override = None;
+                                }
+                            }
+                            locked.last_prndl = new_prndl;
 
                             // Integrate energy for this lap: Wh += kW * dt(s) / 3.6.
                             // Regen (negative power) credits back. Budget tracks
@@ -968,7 +994,8 @@ fn ws_server_loop(state: Arc<Mutex<DashState>>) {
                                     Some(exp) if Instant::now() >= exp => None,
                                     _ => locked.active_message.clone(),
                                 };
-                                DashMessage { seq, can, mqtt, pacing, layout, park_layout, driving_layout, message }
+                                let screen_override = locked.screen_override.clone();
+                                DashMessage { seq, can, mqtt, pacing, layout, park_layout, driving_layout, message, screen_override }
                             };
 
                             let json = match serde_json::to_string(&message) {
@@ -1194,6 +1221,22 @@ fn mqtt_subscriber_loop(state: Arc<Mutex<DashState>>) {
                             }
                             Err(e) => eprintln!("[DASHD] MQTT bad message payload: {}", e),
                         }
+                        continue;
+                    }
+
+                    // Debug screen override (lhre/dash/screen): a bare string
+                    // naming the screen to force ("driving"/"park"/"shutdown"/
+                    // "settings"), or "auto"/"" to release back to PRNDL. Not
+                    // numeric — handle before the numeric parse below.
+                    if field == "screen" {
+                        let s = payload_str.trim();
+                        let mut locked = state.lock().unwrap();
+                        locked.screen_override = if s.is_empty() || s == "auto" {
+                            None
+                        } else {
+                            Some(s.to_string())
+                        };
+                        println!("[DASHD] screen override -> {:?}", locked.screen_override);
                         continue;
                     }
 
@@ -1479,6 +1522,8 @@ fn main() -> Result<()> {
         messages: None,
         active_message: None,
         message_expiry: None,
+        screen_override: None,
+        last_prndl: None,
     }));
 
     let ipc_state = Arc::clone(&state);

--- a/BEVO/dashd/main.rs
+++ b/BEVO/dashd/main.rs
@@ -214,6 +214,9 @@ struct MqttData {
     #[serde(rename = "energyDelta")]
     energy_delta: Option<f32>,
 
+    #[serde(rename = "energyDeltaStatic")]
+    energy_delta_static: Option<f32>,
+
     #[serde(rename = "lapsRemaining")]
     laps_remaining: Option<f32>,
 
@@ -323,11 +326,13 @@ struct DashStateMsg {
 struct MqttState {
     lap_delta: Option<f32>,
     energy_delta: Option<f32>,
+    energy_delta_static: Option<f32>,
     laps_remaining: Option<f32>,
     target_power: Option<f32>,
     lap_card_ms: Option<f32>,
     last_lap_delta: Instant,
     last_energy_delta: Instant,
+    last_energy_delta_static: Instant,
     last_laps_remaining: Instant,
     last_target_power: Instant,
 }
@@ -338,11 +343,13 @@ impl MqttState {
         Self {
             lap_delta: None,
             energy_delta: None,
+            energy_delta_static: None,
             laps_remaining: None,
             target_power: None,
             lap_card_ms: None,
             last_lap_delta: epoch,
             last_energy_delta: epoch,
+            last_energy_delta_static: epoch,
             last_laps_remaining: epoch,
             last_target_power: epoch,
         }
@@ -362,6 +369,9 @@ impl MqttState {
             energy_delta: self
                 .energy_delta
                 .filter(|_| now.duration_since(self.last_energy_delta) < MQTT_STALE_TIMEOUT),
+            energy_delta_static: self
+                .energy_delta_static
+                .filter(|_| now.duration_since(self.last_energy_delta_static) < MQTT_STALE_TIMEOUT),
             laps_remaining: self
                 .laps_remaining
                 .filter(|_| now.duration_since(self.last_laps_remaining) < MQTT_STALE_TIMEOUT),
@@ -1216,6 +1226,10 @@ fn mqtt_subscriber_loop(state: Arc<Mutex<DashState>>) {
                         "energyDelta" => {
                             locked.mqtt.energy_delta = Some(val);
                             locked.mqtt.last_energy_delta = now;
+                        }
+                        "energyDeltaStatic" => {
+                            locked.mqtt.energy_delta_static = Some(val);
+                            locked.mqtt.last_energy_delta_static = now;
                         }
                         "lapsRemaining" => {
                             locked.mqtt.laps_remaining = Some(val);

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
@@ -660,6 +660,14 @@ function App() {
   // + = banked margin vs the even split; − = over budget, must conserve.
   const budgetVsTargetWh = dynamicLapBudgetWh != null && targetEnergyPerLapWh != null
     ? dynamicLapBudgetWh - targetEnergyPerLapWh : null;
+  // --- per-lap strategy deltas published to the car dash (mqtt.lapDelta /
+  // energyDelta / energyDeltaStatic). All from the last COMPLETED lap vs the best
+  // lap / per-lap energy budgets. Null (→ stops publishing, dash shows nothing
+  // rather than a bogus 0) until there's a completed lap + a plan.
+  const lastLap = liveState.laps.length ? liveState.laps[liveState.laps.length - 1] : null;
+  const lapDeltaS = lastLap && bestLap ? (lastLap.durationMs - bestLap.durationMs) / 1000 : null;
+  const energyDeltaDynWh = lastLap && dynamicLapBudgetWh != null ? lastLap.energyWh - dynamicLapBudgetWh : null;
+  const energyDeltaStaticWh = lastLap && targetEnergyPerLapWh != null ? lastLap.energyWh - targetEnergyPerLapWh : null;
   // Auto-derive the dash target power from the energy plan: the live Wh/lap
   // budget ÷ the rolling average lap time is the power rate that spends the
   // budget evenly. A manual override (dashPowerMode='manual') wins when set.
@@ -903,6 +911,16 @@ function App() {
     if (isMirror || dashSignals.status !== "connected") return;
     if (dynamicLapBudgetWh != null) dashSignals.publishLapBudget(Math.round(dynamicLapBudgetWh));
   }, [dynamicLapBudgetWh, isMirror, dashSignals.status, dashSignals.publishLapBudget]);
+
+  // Push the per-lap strategy deltas to the car dash (leader only). Each rides the
+  // dashSignals keepalive; passing null stops it (dashd nulls it after ~5 s).
+  useEffect(() => {
+    if (isMirror || dashSignals.status !== "connected") return;
+    dashSignals.publishLapDelta(lapDeltaS);
+    dashSignals.publishEnergyDelta(energyDeltaDynWh);
+    dashSignals.publishEnergyDeltaStatic(energyDeltaStaticWh);
+    dashSignals.publishLapsRemaining(lapsRemainingPlan);
+  }, [lapDeltaS, energyDeltaDynWh, energyDeltaStaticWh, lapsRemainingPlan, isMirror, dashSignals.status, dashSignals.publishLapDelta, dashSignals.publishEnergyDelta, dashSignals.publishEnergyDeltaStatic, dashSignals.publishLapsRemaining]);
 
   // Push the active driver-message set to the car (retained) whenever it changes
   // or the link (re)connects, so the dash holds the current quick-send palette

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
@@ -2,7 +2,7 @@
 import './trackside.css';
 
 import { useEffect, useMemo, useRef, useState, type ChangeEvent, type Dispatch, type MouseEvent, type ReactNode, type SetStateAction } from "react";
-import { Activity, AlertTriangle, ArrowDown, ArrowUp, CalendarDays, ChevronLeft, ChevronRight, Disc3, Download, FileText, Flag, Gauge, GraduationCap, HelpCircle, MapPinned, Minus, MonitorCog, Moon, NotebookText, Plus, Power, Radio, RefreshCcw, Save, Scissors, SlidersHorizontal, Sun, Target, Thermometer, Timer, Trash2, Upload, Users, WifiOff, X, Zap } from "lucide-react";
+import { Activity, AlertTriangle, ArrowDown, ArrowUp, CalendarDays, ChevronLeft, ChevronRight, Crosshair, Disc3, Download, FileText, Flag, Gauge, GraduationCap, HelpCircle, MapPinned, Minus, MonitorCog, Moon, NotebookText, Plus, Power, Radio, RefreshCcw, Save, Scissors, SlidersHorizontal, Sun, Target, Thermometer, Timer, Trash2, Upload, Users, WifiOff, X, Zap } from "lucide-react";
 import { api } from "@/lib/trackside/api";
 import { useCarStatus, CAR_STATE_META, humanizeReason, type CarState, type CarStatusFeed } from "@/lib/trackside/useCarStatus";
 import { EVENT_TYPES, upsertSession, patchSession, syncRegistryWithServer, type TracksideSessionInfo } from "@/lib/trackside/sessionRegistry";
@@ -3611,6 +3611,7 @@ function App() {
                   center={builderCenter}
                   onCenter={setBuilderCenter}
                   targetSpanM={selectedTrackView?.spanM}
+                  follow
                   gpsUnavailable={filteredLiveState.lastSample != null && !filteredLiveState.samples.some(hasGps)}
                 />
               </Panel>
@@ -5682,6 +5683,7 @@ function TrackBuilderMap({
   onCenter,
   targetSpanM,
   gpsUnavailable = false,
+  follow = false,
 }: {
   points: GpsPoint[];
   liveSample: LiveSample | null;
@@ -5692,11 +5694,19 @@ function TrackBuilderMap({
   onCenter: (center: { lat: number; lon: number }) => void;
   targetSpanM?: number;
   gpsUnavailable?: boolean;
+  // When true, the viewport auto-centers on the live car position (liveSample)
+  // and stays locked on it as it moves. Panning disengages follow; the recenter
+  // button re-engages it. Off for the track-builder usage (manual center).
+  follow?: boolean;
 }) {
   const [drawStart, setDrawStart] = useState<{ x: number; y: number } | null>(null);
   const [drawEnd, setDrawEnd] = useState<{ x: number; y: number } | null>(null);
   const [panStart, setPanStart] = useState<{ x: number; y: number; cx: number; cy: number } | null>(null);
   const [spanM, setSpanM] = useState(520);
+  // Follow-the-car: when `follow` is on, the viewport tracks the live position.
+  // `following` is the live toggle — panning turns it off, the recenter button
+  // turns it back on. Defaults on so the map opens centered on the car.
+  const [following, setFollowing] = useState(true);
   const width = 920;
   const height = 620;
   const pad = 0;
@@ -5704,7 +5714,13 @@ function TrackBuilderMap({
     if (targetSpanM == null) return;
     setSpanM(Math.max(80, Math.min(8000, targetSpanM)));
   }, [targetSpanM]);
-  const projectedCenter = project(center.lat, center.lon);
+  // The car's current position, when follow is enabled and we have a fix.
+  const followPoint = follow && liveSample && liveSample.lat != null && liveSample.lon != null
+    ? { lat: liveSample.lat, lon: liveSample.lon }
+    : null;
+  // Viewport center: lock onto the car while following, else the manual center.
+  const viewCenter = followPoint && following ? followPoint : center;
+  const projectedCenter = project(viewCenter.lat, viewCenter.lon);
   const bounds = mapBoundsFromCenter(projectedCenter.mx, projectedCenter.my, width, height, spanM, pad);
   const tiles = satelliteTiles(bounds);
   const line = points.length >= 2
@@ -5754,6 +5770,12 @@ function TrackBuilderMap({
           return;
         }
         setPanStart({ ...start, cx: projectedCenter.mx, cy: projectedCenter.my });
+        // Grabbing to pan = manual control: hand the current (car) center to the
+        // parent so the drag continues from here, then stop following.
+        if (following && followPoint) {
+          onCenter(followPoint);
+          setFollowing(false);
+        }
       }}
       onMouseMove={(event) => {
         const current = pointer(event);
@@ -5819,6 +5841,18 @@ function TrackBuilderMap({
       <text className="mapCredit" x={width - 10} y={height - 10} textAnchor="end">Esri World Imagery</text>
     </svg>
       <div className="mapZoomBtns">
+        {follow ? (
+          <button
+            type="button"
+            aria-label="Center on car"
+            title={followPoint ? (following ? "Following car — drag to look around" : "Recenter on car") : "Waiting for GPS fix"}
+            className={following && followPoint ? "follow active" : "follow"}
+            disabled={!followPoint}
+            onClick={() => setFollowing(true)}
+          >
+            <Crosshair size={16} />
+          </button>
+        ) : null}
         <button type="button" aria-label="Zoom in" title="Zoom in" onClick={() => zoomBy(1 / 1.3)}><Plus size={16} /></button>
         <button type="button" aria-label="Zoom out" title="Zoom out" onClick={() => zoomBy(1.3)}><Minus size={16} /></button>
       </div>

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
@@ -1344,8 +1344,12 @@ function App() {
           .map((segment, index) => ({ ...segment, label: `Session ${index + 1}` }));
         setSegments(nextSegments);
         setSelectedSegments(new Set(nextSegments.map((segment) => segment.id)));
-        setPreviewSelectedSegments(new Set(nextSegments[0] ? [nextSegments[0].id] : []));
-        setLastPreviewSegmentId(nextSegments[0]?.id ?? "");
+        // Don't auto-preview the first session: that pulled its GPS into the
+        // shared `gps` state and made the Track Builder map open non-empty with
+        // a trace nobody picked. Start with no preview — the user clicks a
+        // session (Analysis) or checks a reference (Builder) to load a trace.
+        setPreviewSelectedSegments(new Set());
+        setLastPreviewSegmentId("");
         setSessionMetadata((prev) => {
           const next = { ...prev };
           nextSegments.forEach((segment) => {

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
@@ -2,7 +2,7 @@
 import './trackside.css';
 
 import { useEffect, useMemo, useRef, useState, type ChangeEvent, type Dispatch, type MouseEvent, type ReactNode, type SetStateAction } from "react";
-import { Activity, AlertTriangle, ArrowDown, ArrowUp, CalendarDays, ChevronLeft, ChevronRight, Disc3, Download, FileText, Flag, Gauge, GraduationCap, HelpCircle, MapPinned, Moon, NotebookText, Plus, Power, Radio, RefreshCcw, Save, Scissors, SlidersHorizontal, Sun, Target, Thermometer, Timer, Trash2, Upload, Users, WifiOff, X, Zap } from "lucide-react";
+import { Activity, AlertTriangle, ArrowDown, ArrowUp, CalendarDays, ChevronLeft, ChevronRight, Disc3, Download, FileText, Flag, Gauge, GraduationCap, HelpCircle, MapPinned, MonitorCog, Moon, NotebookText, Plus, Power, Radio, RefreshCcw, Save, Scissors, SlidersHorizontal, Sun, Target, Thermometer, Timer, Trash2, Upload, Users, WifiOff, X, Zap } from "lucide-react";
 import { api } from "@/lib/trackside/api";
 import { useCarStatus, CAR_STATE_META, humanizeReason, type CarState, type CarStatusFeed } from "@/lib/trackside/useCarStatus";
 import { EVENT_TYPES, upsertSession, patchSession, syncRegistryWithServer, type TracksideSessionInfo } from "@/lib/trackside/sessionRegistry";
@@ -544,6 +544,10 @@ function App() {
   const [dashPowerMode, setDashPowerMode] = useState<"auto" | "manual">(() => (localStorage.getItem("dash-power-mode") === "manual" ? "manual" : "auto"));
   const [dashAutoLap, setDashAutoLap] = useState(() => localStorage.getItem("dash-auto-lap") === "1");
   const [dashGatePushed, setDashGatePushed] = useState(false);
+  // Debug screen override the strategist is forcing on the dash (null = auto /
+  // follow PRNDL). Not persisted — it's a transient bench/pit aid, and the car
+  // clears it on a real gear change anyway, so it shouldn't survive a reload.
+  const [dashScreenOverride, setDashScreenOverride] = useState<string | null>(null);
   // How long the on-car full-screen lap card stays up after a lap (seconds).
   const [lapCardDurationS, setLapCardDurationS] = useState(() => {
     const v = Number(localStorage.getItem("dash-lap-card-duration-s"));
@@ -4079,6 +4083,63 @@ function App() {
               Lay out what the driver sees on each lap card, then send it to the car (used until replaced).
               The lap card auto-clears after the duration above.
             </p>
+          </Panel>
+
+          <Panel title="Dash Screen — debug override" icon={<MonitorCog size={18} />}>
+            <p style={{ margin: "0 0 8px", opacity: 0.75, fontSize: "0.85rem" }}>
+              Force the driver dash onto a specific screen without shifting the car into gear —
+              for bench checks and pit demos. The car snaps back to normal PRNDL routing the
+              moment the driver actually shifts, and a dash reboot drops the override too.
+            </p>
+            {(() => {
+              const connected = !isMirror && dashSignals.status === "connected";
+              const SCREENS: { id: string; label: string }[] = [
+                { id: "driving", label: "Driving" },
+                { id: "park", label: "Park / Pit" },
+                { id: "shutdown", label: "Shutdown" },
+                { id: "settings", label: "Settings" },
+              ];
+              const setOverride = (id: string | null) => {
+                if (!connected) return;
+                dashSignals.publishScreen(id);
+                setDashScreenOverride(id);
+              };
+              return (
+                <>
+                  <div className="screenOverrideButtons">
+                    {SCREENS.map((s) => (
+                      <button
+                        key={s.id}
+                        className={dashScreenOverride === s.id ? "tool active" : "tool"}
+                        disabled={!connected}
+                        onClick={() => setOverride(s.id)}
+                      >
+                        {s.label}
+                      </button>
+                    ))}
+                  </div>
+                  <div className="gateButtons" style={{ marginTop: 8 }}>
+                    <button
+                      className="primary"
+                      disabled={!connected || dashScreenOverride === null}
+                      onClick={() => setOverride(null)}
+                    >
+                      <Radio size={15} /> Release to auto (PRNDL)
+                    </button>
+                    <span style={{ alignSelf: "center", opacity: 0.8, fontSize: "0.85rem" }}>
+                      {dashScreenOverride
+                        ? `Forcing: ${dashScreenOverride}`
+                        : "Following PRNDL"}
+                    </span>
+                  </div>
+                  {!connected ? (
+                    <p style={{ marginTop: 6, opacity: 0.7, fontSize: "0.8rem" }}>
+                      Connect to the dash first (Dash tab → Connect to dash).
+                    </p>
+                  ) : null}
+                </>
+              );
+            })()}
           </Panel>
 
           <Panel title="Start/Finish — on-car laps" icon={<MapPinned size={18} />}>

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
@@ -1344,12 +1344,8 @@ function App() {
           .map((segment, index) => ({ ...segment, label: `Session ${index + 1}` }));
         setSegments(nextSegments);
         setSelectedSegments(new Set(nextSegments.map((segment) => segment.id)));
-        // Don't auto-preview the first session: that pulled its GPS into the
-        // shared `gps` state and made the Track Builder map open non-empty with
-        // a trace nobody picked. Start with no preview — the user clicks a
-        // session (Analysis) or checks a reference (Builder) to load a trace.
-        setPreviewSelectedSegments(new Set());
-        setLastPreviewSegmentId("");
+        setPreviewSelectedSegments(new Set(nextSegments[0] ? [nextSegments[0].id] : []));
+        setLastPreviewSegmentId(nextSegments[0]?.id ?? "");
         setSessionMetadata((prev) => {
           const next = { ...prev };
           nextSegments.forEach((segment) => {

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
@@ -3543,25 +3543,6 @@ function App() {
               <TractionControlPanel sample={filteredLiveState.lastSample} />
             </div>
             <div className="liveMainColumn">
-              {/* Live Position hidden until chudpi/GPS is reliable. The RadioLion
-                  receiver's draw browns out the chudpi rail, so no fix reaches
-                  the website. Re-enable this Panel block once chudpi power is
-                  fixed. */}
-              {/*
-              <Panel title="Live Position" icon={<MapPinned size={18} />} className="liveMapPanel">
-                <TrackBuilderMap
-                  points={filteredLiveState.samples.filter(hasGps).map((sample) => ({ t: sample.t, lat: sample.lat ?? 0, lon: sample.lon ?? 0 }))}
-                  liveSample={filteredLiveState.lastSample}
-                  gates={track.gates}
-                  drawMode={null}
-                  onDrawGate={handleDrawGate}
-                  center={builderCenter}
-                  onCenter={setBuilderCenter}
-                  targetSpanM={selectedTrackView?.spanM}
-                  gpsUnavailable={filteredLiveState.lastSample != null && !filteredLiveState.samples.some(hasGps)}
-                />
-              </Panel>
-              */}
               <Panel title="Energy Window" icon={<Zap size={18} />}>
                 <EnergyWindowChart
                   state={filteredLiveState}
@@ -3585,6 +3566,22 @@ function App() {
                   link. */}
               <DriverControlsPanel sample={filteredLiveState.lastSample} torqueParamSet={torqueParamSet} />
               <TempsStatusPanel sample={filteredLiveState.lastSample} />
+              {/* Live Position — re-enabled now that chudpi/GPS is reliable. Kept
+                  last in the column so it's available but out of the way; it
+                  self-indicates (gpsUnavailable) if a session has no fix. */}
+              <Panel title="Live Position" icon={<MapPinned size={18} />} className="liveMapPanel">
+                <TrackBuilderMap
+                  points={filteredLiveState.samples.filter(hasGps).map((sample) => ({ t: sample.t, lat: sample.lat ?? 0, lon: sample.lon ?? 0 }))}
+                  liveSample={filteredLiveState.lastSample}
+                  gates={track.gates}
+                  drawMode={null}
+                  onDrawGate={handleDrawGate}
+                  center={builderCenter}
+                  onCenter={setBuilderCenter}
+                  targetSpanM={selectedTrackView?.spanM}
+                  gpsUnavailable={filteredLiveState.lastSample != null && !filteredLiveState.samples.some(hasGps)}
+                />
+              </Panel>
             </div>
             <div className="rightRail">
               {/* Energy Strategy widget hidden for now — revisit later.

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
@@ -1798,6 +1798,11 @@ function App() {
       patchSession(sessionInfo.id, { endedAt: Date.now(), laps: liveStateRef.current.laps.length });
       setSessionInfo(null);
     }
+    // Reset the car's lap_count + baseline too, so the driver dash starts the
+    // re-armed session at Lap 0 instead of holding the prior high water mark —
+    // symmetric with Stop Event (stopEventAndDownload). Without this, Reset
+    // cleared the trackside laps but left the dash showing the old count.
+    if (dashSignals.status === "connected") dashSignals.resetLapCounter();
     markLiveSessionEnded();
     clearLiveSessionState();
     // The manual Start button is gone, so a reset re-arms the auto feed; the

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
@@ -1840,9 +1840,12 @@ function App() {
   function sendDashLayout(screenId: string, layout: LapCardLayout) {
     if (isMirrorRef.current) { setLayoutSendStatus("Read-only mirror — only the session leader can push to the car."); return; }
     if (dashSignals.status !== "connected") { setLayoutSendStatus("Connect to the dash first (Dash tab → Connect to dash)."); return; }
-    // Route to the screen's retained topic: park → parkLayout, else the lap card.
-    const ok = screenId === "park" ? dashSignals.publishParkLayout(layout) : dashSignals.publishLayout(layout);
-    const where = screenId === "park" ? "park screen" : "lap card";
+    // Route to the screen's retained topic: park → parkLayout, driving →
+    // drivingLayout, else the lap card.
+    const ok = screenId === "park" ? dashSignals.publishParkLayout(layout)
+      : screenId === "driving" ? dashSignals.publishDrivingLayout(layout)
+      : dashSignals.publishLayout(layout);
+    const where = screenId === "park" ? "park screen" : screenId === "driving" ? "driving screen" : "lap card";
     setLayoutSendStatus(ok ? `Sent “${layout.name}” to the ${where} ✓ (retained — used until replaced)` : "Publish failed — check the dash link.");
     window.setTimeout(() => setLayoutSendStatus(""), 5000);
   }

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
@@ -2,7 +2,7 @@
 import './trackside.css';
 
 import { useEffect, useMemo, useRef, useState, type ChangeEvent, type Dispatch, type MouseEvent, type ReactNode, type SetStateAction } from "react";
-import { Activity, AlertTriangle, ArrowDown, ArrowUp, CalendarDays, ChevronLeft, ChevronRight, Disc3, Download, FileText, Flag, Gauge, GraduationCap, HelpCircle, MapPinned, MonitorCog, Moon, NotebookText, Plus, Power, Radio, RefreshCcw, Save, Scissors, SlidersHorizontal, Sun, Target, Thermometer, Timer, Trash2, Upload, Users, WifiOff, X, Zap } from "lucide-react";
+import { Activity, AlertTriangle, ArrowDown, ArrowUp, CalendarDays, ChevronLeft, ChevronRight, Disc3, Download, FileText, Flag, Gauge, GraduationCap, HelpCircle, MapPinned, Minus, MonitorCog, Moon, NotebookText, Plus, Power, Radio, RefreshCcw, Save, Scissors, SlidersHorizontal, Sun, Target, Thermometer, Timer, Trash2, Upload, Users, WifiOff, X, Zap } from "lucide-react";
 import { api } from "@/lib/trackside/api";
 import { useCarStatus, CAR_STATE_META, humanizeReason, type CarState, type CarStatusFeed } from "@/lib/trackside/useCarStatus";
 import { EVENT_TYPES, upsertSession, patchSession, syncRegistryWithServer, type TracksideSessionInfo } from "@/lib/trackside/sessionRegistry";
@@ -751,6 +751,9 @@ function App() {
     return () => window.clearInterval(id);
   }, []);
   const dataAgeMs = lastDataAtMs == null ? null : Math.max(0, liveNowMs - lastDataAtMs);
+  // Last GPS coordinate we saw + when it last changed, for the Live Position
+  // readout's freshness (see gpsFixAgeMs).
+  const lastGpsFixRef = useRef<{ lat: number; lon: number; at: number } | null>(null);
   // Time spent trying to get telemetry since the feed started — used to escalate
   // 'waiting' to a hard 'down' after a grace period so a car-off page-load
   // doesn't sit on yellow forever just because the broker is reachable.
@@ -802,6 +805,21 @@ function App() {
     : liveHasGpsFix
       ? { dot: "live", label: sfGateDefined ? "GPS · auto-lap armed" : "GPS fix" }
       : { dot: "dead", label: "No GPS fix" };
+
+  // Raw lat/lon readout for the Live Position panel. We track when the coordinate
+  // last CHANGED (not just when a sample arrived) so a stuck/frozen fix reads as
+  // stale even while telemetry keeps flowing — that's the case the strategist
+  // wants to catch. `liveNowMs` ticks at 1 Hz to keep the age live.
+  const curGpsFix = liveHasGpsFix
+    ? { lat: liveState.lastSample!.lat as number, lon: liveState.lastSample!.lon as number }
+    : null;
+  if (curGpsFix) {
+    const prev = lastGpsFixRef.current;
+    if (!prev || prev.lat !== curGpsFix.lat || prev.lon !== curGpsFix.lon) {
+      lastGpsFixRef.current = { ...curGpsFix, at: liveNowMs };
+    }
+  }
+  const gpsFixAgeMs = lastGpsFixRef.current == null ? null : Math.max(0, liveNowMs - lastGpsFixRef.current.at);
 
   // Authoritative car state from the central classifier (PR #282), if reachable.
   const carStatus = useCarStatus(source, liveState.running);
@@ -3570,6 +3588,20 @@ function App() {
                   last in the column so it's available but out of the way; it
                   self-indicates (gpsUnavailable) if a session has no fix. */}
               <Panel title="Live Position" icon={<MapPinned size={18} />} className="liveMapPanel">
+                <div className="gpsReadout">
+                  <span className={`gpsDot ${liveHasGpsFix && dataAgeMs != null && dataAgeMs < 3000 ? "live" : liveHasGpsFix ? "stale" : "dead"}`} />
+                  <span className="gpsCoord">LAT <strong>{curGpsFix ? curGpsFix.lat.toFixed(6) : "—"}</strong></span>
+                  <span className="gpsCoord">LON <strong>{curGpsFix ? curGpsFix.lon.toFixed(6) : "—"}</strong></span>
+                  <span className="gpsAge">
+                    {curGpsFix == null
+                      ? "no fix"
+                      : gpsFixAgeMs == null
+                        ? "—"
+                        : gpsFixAgeMs < 2000
+                          ? "updating"
+                          : `unchanged ${(gpsFixAgeMs / 1000).toFixed(0)}s`}
+                  </span>
+                </div>
                 <TrackBuilderMap
                   points={filteredLiveState.samples.filter(hasGps).map((sample) => ({ t: sample.t, lat: sample.lat ?? 0, lon: sample.lon ?? 0 }))}
                   liveSample={filteredLiveState.lastSample}
@@ -5704,14 +5736,16 @@ function TrackBuilderMap({
       lon2: b.lon,
     });
   };
+  // Zoom via explicit buttons rather than the scroll wheel. React's wheel
+  // listener is passive, so an onWheel preventDefault() couldn't stop the page
+  // from also scrolling — zooming the map hijacked the whole page. Buttons keep
+  // pan-by-drag intact without fighting the page scroll. Smaller spanM = closer.
+  const zoomBy = (factor: number) => setSpanM((current) => Math.max(80, Math.min(8000, current * factor)));
   return (
+    <div className="mapWrap">
     <svg
       className={drawMode ? "map builderMap drawing" : "map builderMap"}
       viewBox={`0 0 ${width} ${height}`}
-      onWheel={(event) => {
-        event.preventDefault();
-        setSpanM((current) => nextMapSpan(current, event.deltaY));
-      }}
       onMouseDown={(event) => {
         const start = pointer(event);
         if (drawMode) {
@@ -5784,6 +5818,11 @@ function TrackBuilderMap({
       ) : null}
       <text className="mapCredit" x={width - 10} y={height - 10} textAnchor="end">Esri World Imagery</text>
     </svg>
+      <div className="mapZoomBtns">
+        <button type="button" aria-label="Zoom in" title="Zoom in" onClick={() => zoomBy(1 / 1.3)}><Plus size={16} /></button>
+        <button type="button" aria-label="Zoom out" title="Zoom out" onClick={() => zoomBy(1.3)}><Minus size={16} /></button>
+      </div>
+    </div>
   );
 }
 
@@ -6078,11 +6117,6 @@ function distanceMeters(lat1: number, lon1: number, lat2: number, lon2: number) 
   return radius * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
 }
 
-function nextMapSpan(currentSpanM: number, deltaY: number) {
-  const boundedDelta = Math.max(-120, Math.min(120, deltaY));
-  const zoomFactor = Math.exp(boundedDelta * 0.0007);
-  return Math.max(80, Math.min(8000, currentSpanM * zoomFactor));
-}
 
 function sampleCrossesGate(previous: LiveSample, current: LiveSample, gate: GateLine) {
   if (!hasGps(previous) || !hasGps(current)) return false;

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/trackside.css
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/trackside.css
@@ -883,6 +883,11 @@ textarea:focus-visible,
 .widgetItem.sel { border-color: #4ea1ff; background: color-mix(in srgb, #4ea1ff 14%, transparent); }
 .widgetItem .widgetKind { font-size: 0.7rem; text-transform: uppercase; letter-spacing: 1px; color: var(--muted-text); }
 .widgetItem .widgetBind { font-size: var(--fs-sm); font-family: ui-monospace, monospace; word-break: break-all; }
+/* Data-source provenance caption under the field picker (DashLayoutEditor). */
+.fieldSource { font-size: 0.68rem; line-height: 1.3; color: var(--muted-text); margin: 2px 0 6px; padding: 3px 7px; background: color-mix(in srgb, var(--muted-text) 9%, transparent); border-radius: 4px; font-family: ui-monospace, monospace; word-break: break-word; }
+.fieldSource .fieldSourceTag { font-weight: 700; letter-spacing: 1px; color: var(--accent, #d97757); margin-right: 5px; }
+.fieldSource.fieldSourceWarn { color: #b58900; background: color-mix(in srgb, #FFCC00 14%, transparent); }
+.fieldSource.fieldSourceWarn .fieldSourceTag { color: #b58900; }
 .dashEditorStage { display: flex; flex-direction: column; align-items: center; justify-content: center; padding: var(--s-3); background: #0b0c0e; overflow: auto; }
 .dashEditorProps { border-left: 1px solid var(--border); overflow-y: auto; }
 .propPanel { display: flex; flex-direction: column; gap: var(--s-2); padding: var(--s-3); }

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/trackside.css
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/trackside.css
@@ -919,6 +919,9 @@ textarea:focus-visible,
 }
 
 .gateButtons { display: flex; flex-wrap: wrap; gap: var(--s-2); margin: var(--s-3) 0; }
+.screenOverrideButtons { display: grid; grid-template-columns: repeat(2, 1fr); gap: var(--s-2); }
+.screenOverrideButtons .tool { justify-content: center; }
+.screenOverrideButtons .tool.active { border-color: var(--accent); color: var(--accent); background: color-mix(in srgb, var(--accent) 14%, transparent); }
 .fileTool { position: relative; overflow: hidden; }
 .fileTool input { position: absolute; inset: 0; opacity: 0; cursor: pointer; }
 

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/trackside.css
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/trackside.css
@@ -670,6 +670,16 @@ textarea:focus-visible,
 }
 .map.drawing, .builderMap.drawing { cursor: crosshair; }
 .builderMap { height: auto; max-height: 72vh; cursor: grab; }
+/* Map zoom controls — replace scroll-wheel zoom (which hijacked page scroll). */
+.mapWrap { position: relative; }
+.mapZoomBtns { position: absolute; top: var(--s-2); right: var(--s-2); display: flex; flex-direction: column; gap: 4px; }
+.mapZoomBtns button {
+  width: 32px; height: 32px; display: flex; align-items: center; justify-content: center;
+  border: 1px solid var(--border); border-radius: var(--r-sm);
+  background: color-mix(in srgb, var(--surface) 88%, transparent); color: var(--text);
+  cursor: pointer; backdrop-filter: blur(3px); padding: 0;
+}
+.mapZoomBtns button:hover { background: var(--surface); border-color: var(--accent); }
 .map .startGate { stroke: #ff5a40; stroke-width: 3; }
 .map .splitGate { stroke: #5bc7ff; stroke-width: 2.4; }
 .map .drawingGate { stroke-dasharray: 7 5; filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.7)); }
@@ -702,6 +712,17 @@ textarea:focus-visible,
 }
 
 .gpsPanel, .liveMapPanel, .builderMapPanel { align-self: start; }
+
+/* Raw lat/lon + freshness readout above the Live Position map. */
+.gpsReadout { display: flex; align-items: center; gap: var(--s-3); flex-wrap: wrap;
+  margin-bottom: var(--s-2); font-size: var(--fs-sm); }
+.gpsReadout .gpsDot { width: 9px; height: 9px; border-radius: 50%; flex: 0 0 auto; background: var(--dead); }
+.gpsReadout .gpsDot.live { background: var(--fresh); box-shadow: 0 0 0 3px color-mix(in srgb, var(--fresh) 26%, transparent); }
+.gpsReadout .gpsDot.stale { background: var(--stale); box-shadow: 0 0 0 3px color-mix(in srgb, var(--stale) 26%, transparent); }
+.gpsReadout .gpsDot.dead { background: var(--dead); }
+.gpsReadout .gpsCoord { font-variant-numeric: tabular-nums; letter-spacing: 0.3px; opacity: 0.85; }
+.gpsReadout .gpsCoord strong { font-variant-numeric: tabular-nums; opacity: 1; }
+.gpsReadout .gpsAge { margin-left: auto; opacity: 0.6; font-variant-numeric: tabular-nums; }
 
 /* ── Metadata grids ────────────────────────────────────────────────────────── */
 .metadataGrid {

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/trackside.css
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/trackside.css
@@ -680,6 +680,9 @@ textarea:focus-visible,
   cursor: pointer; backdrop-filter: blur(3px); padding: 0;
 }
 .mapZoomBtns button:hover { background: var(--surface); border-color: var(--accent); }
+.mapZoomBtns button.follow.active { background: var(--accent); border-color: var(--accent); color: #fff; }
+.mapZoomBtns button:disabled { opacity: 0.45; cursor: default; }
+.mapZoomBtns button:disabled:hover { background: color-mix(in srgb, var(--surface) 88%, transparent); border-color: var(--border); }
 .map .startGate { stroke: #ff5a40; stroke-width: 3; }
 .map .splitGate { stroke: #5bc7ff; stroke-width: 2.4; }
 .map .drawingGate { stroke-dasharray: 7 5; filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.7)); }

--- a/telemtry/analysis/database/viewer_tool/src/components/dashlayout/DashLayoutEditor.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/components/dashlayout/DashLayoutEditor.tsx
@@ -395,6 +395,7 @@ function PropertyPanel({ w, fields, onChange, onDelete }: { w: Widget; fields: F
         <Row label="Text"><input value={w.text} onChange={(e) => onChange({ text: e.target.value })} /></Row>
       )}
       {hasBind && (
+        <>
         <Row label="Data field">
           <select value={(w as { bind: string }).bind} onChange={(e) => {
             const fd = fieldDef(e.target.value);
@@ -415,11 +416,25 @@ function PropertyPanel({ w, fields, onChange, onDelete }: { w: Widget; fields: F
           }}>
             {Array.from(new Set(fields.map((f) => f.group))).map((g) => (
               <optgroup key={g} label={g}>
-                {fields.filter((f) => f.group === g).map((f) => <option key={f.bind} value={f.bind}>{f.label}{f.unit ? ` (${f.unit})` : ''}</option>)}
+                {fields.filter((f) => f.group === g).map((f) => <option key={f.bind} value={f.bind} title={f.source}>{f.label}{f.unit ? ` (${f.unit})` : ''}</option>)}
               </optgroup>
             ))}
           </select>
         </Row>
+        {/* True data-source provenance for the selected field — the CAN packet /
+            derivation / trackside topic, so the strategist isn't misled by the
+            abstract `can.*` bind path. "demo-only" fields never carry real data. */}
+        {(() => {
+          const fd = fieldDef((w as { bind?: string }).bind ?? '');
+          if (!fd?.source) return null;
+          const demo = fd.source.startsWith('demo-only');
+          return (
+            <div className={`fieldSource${demo ? ' fieldSourceWarn' : ''}`} title={fd.source}>
+              <span className="fieldSourceTag">SRC</span> {fd.source}
+            </div>
+          );
+        })()}
+        </>
       )}
       {(w.type === 'value' || w.type === 'gauge' || w.type === 'delta') && (
         <Row label="Format">

--- a/telemtry/analysis/database/viewer_tool/src/components/dashlayout/DashLayoutEditor.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/components/dashlayout/DashLayoutEditor.tsx
@@ -46,7 +46,7 @@ function snapMove(nx: number, ny: number, ow: number, oh: number, others: Widget
     guides,
   };
 }
-const FORMATS: FormatId[] = ['raw', 'int', 'float1', 'float2', 'laptime', 'wh', 'whSigned', 'kwh', 'kw', 'pct', 'temp', 'volt', 'amp', 'mph'];
+const FORMATS: FormatId[] = ['raw', 'int', 'float1', 'float2', 'laptime', 'wh', 'whSigned', 'kwh', 'kw', 'pct', 'temp', 'volt', 'amp', 'mph', 'bool'];
 
 function genLayoutId(): string {
   return `lay-${Date.now().toString(36)}-${Math.floor(Math.random() * 1e6).toString(36)}`;

--- a/telemtry/analysis/database/viewer_tool/src/lib/dash/dashLayout.ts
+++ b/telemtry/analysis/database/viewer_tool/src/lib/dash/dashLayout.ts
@@ -378,9 +378,38 @@ export function defaultParkLayout(): LapCardLayout {
   };
 }
 
+// Default starter for the Primary / Driving screen — speed + power gauges, SoE,
+// lap delta, and per-lap energy used vs budget. Binds can.* + pacing.* + mqtt.*
+// (no lapCard.* — the lap card is its own overlay). The on-car built-in driving
+// view stays as the fallback whenever no custom driving layout is published.
+export function defaultDrivingLayout(): LapCardLayout {
+  return {
+    version: DASH_LAYOUT_VERSION,
+    name: 'Default driving screen',
+    background: 'auto',
+    widgets: [
+      { id: 'soe', type: 'value', bind: 'can.soc', format: 'pct', label: 'SoE',
+        x: 300, y: 6, w: 200, h: 60, fontSize: 40, color: 'auto', align: 'center', bold: true,
+        thresholds: [{ cmp: 'lt', value: 20, color: '#FFD700' }, { cmp: 'lt', value: 10, color: '#FF3333' }] },
+      { id: 'speed', type: 'gauge', bind: 'can.speed', min: 0, max: 80, label: 'MPH', color: 'gradient', format: 'int',
+        x: 40, y: 80, w: 320, h: 300 },
+      { id: 'power', type: 'gauge', bind: 'can.power', min: -80, max: 80, label: 'kW', mode: 'bidirectional', format: 'kw',
+        x: 440, y: 80, w: 320, h: 300 },
+      { id: 'delta', type: 'delta', bind: 'mqtt.lapDelta', format: 'laptime', label: 'Δ LAP', fontSize: 44,
+        x: 40, y: 396, w: 240, h: 76, goodSign: 'negative', showArrow: true },
+      { id: 'used', type: 'value', bind: 'pacing.lapEnergyWh', format: 'wh', label: 'USED Wh', fontSize: 40,
+        x: 300, y: 396, w: 200, h: 76, color: 'auto', align: 'center', bold: true },
+      { id: 'budget', type: 'delta', bind: 'pacing.budgetDeltaWh', format: 'whSigned', label: 'BUDGET Δ', fontSize: 40,
+        x: 520, y: 396, w: 240, h: 76, goodSign: 'negative', showArrow: false },
+    ],
+  };
+}
+
 export const DASH_SCREENS: ScreenDef[] = [
   { id: 'lapCard', name: 'Lap Card', topic: 'layout', libraryKey: 'dash-lap-layouts',
     contextRoots: ['lapCard', 'pacing', 'can', 'mqtt'], build: defaultLapCardLayout },
+  { id: 'driving', name: 'Primary / Driving', topic: 'drivingLayout', libraryKey: 'dash-driving-layouts',
+    contextRoots: ['can', 'pacing', 'mqtt'], build: defaultDrivingLayout },
   { id: 'park', name: 'Park / Pit', topic: 'parkLayout', libraryKey: 'dash-park-layouts',
     contextRoots: ['can', 'pacing', 'mqtt'], build: defaultParkLayout },
 ];

--- a/telemtry/analysis/database/viewer_tool/src/lib/dash/dashLayout.ts
+++ b/telemtry/analysis/database/viewer_tool/src/lib/dash/dashLayout.ts
@@ -190,9 +190,15 @@ export const FIELD_CATALOG: FieldDef[] = [
   { bind: 'lapCard.lapNumber', label: 'Lap number', group: 'Lap', defaultFormat: 'int', min: 0, max: 30, source: 'on-car lap counter (GPS gate / trackside lapTrigger)' },
   { bind: 'lapCard.timeS', label: 'Lap time', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120, source: 'on-car: wall-clock since lap start' },
   { bind: 'lapCard.energyWh', label: 'Lap energy', group: 'Lap', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 400, source: 'on-car: ∫ CAN power over the lap' },
-  { bind: 'mqtt.bestLapTime', label: 'Best lap', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120, source: 'demo-only — dashd does not track best lap (always —)' },
-  { bind: 'mqtt.lastLapTime', label: 'Last lap', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120, source: 'demo-only — not emitted; real last-lap time is the lap card (lapCard.timeS), timed on-car' },
-  { bind: 'mqtt.currentLapTime', label: 'Current lap time', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120, source: 'demo-only — not emitted; use pacing.lapElapsedS for the live lap time' },
+  // Last completed lap — REAL, on-car (PacingData), forwarded every frame on ALL
+  // screens (unlike lapCard.* which only exists on the lap card). Prefer these over
+  // the mqtt.* lap stubs below. Null until the first lap completes.
+  { bind: 'pacing.lastLapTimeS', label: 'Last lap time', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120, source: 'on-car: time of the last completed lap (PacingData — any screen)' },
+  { bind: 'pacing.lastLapEnergyWh', label: 'Last lap energy', group: 'Lap', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 400, source: 'on-car: net Wh of the last completed lap (PacingData)' },
+  { bind: 'pacing.lastLapNumber', label: 'Last lap #', group: 'Lap', defaultFormat: 'int', min: 0, max: 30, source: 'on-car: number of the last completed lap (PacingData)' },
+  { bind: 'mqtt.bestLapTime', label: 'Best lap (demo)', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120, source: 'demo-only — best lap not tracked on-car yet (always —)' },
+  { bind: 'mqtt.lastLapTime', label: 'Last lap (demo)', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120, source: 'demo-only — not emitted; use pacing.lastLapTimeS instead (real, any screen)' },
+  { bind: 'mqtt.currentLapTime', label: 'Current lap (demo)', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120, source: 'demo-only — not emitted; use pacing.lapElapsedS for the live lap time' },
   { bind: 'mqtt.lapTrigger', label: 'Lap count', group: 'Lap', defaultFormat: 'int', min: 0, max: 30, source: 'on-car monotonic lap count (lhre/dash/lapTrigger)' },
   // Pacing / strategy (on-car authoritative pacing snapshot)
   { bind: 'pacing.lapEnergyWh', label: 'Energy (this lap)', group: 'Pacing', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 400, source: 'on-car: ∫ CAN power this lap' },

--- a/telemtry/analysis/database/viewer_tool/src/lib/dash/dashLayout.ts
+++ b/telemtry/analysis/database/viewer_tool/src/lib/dash/dashLayout.ts
@@ -174,67 +174,76 @@ export interface FieldDef {
   // enum/bitfield fields: value -> label map. When bound, the editor pre-fills a
   // value widget's valueMap with this so it renders labels instead of raw ints.
   enumMap?: Record<string, string>;
+  // Data-source provenance, shown in the editor so the strategist sees the REAL
+  // origin of a value — not the abstract `can.*` bind path. Traced through dashd's
+  // extract_can_data()/PacingData + drivers/longhorn-lib/config/can_packets.csv.
+  // Notes the CAN packet (0x___) + signal, derivation/aggregation formula, the
+  // trackside MQTT topic, or "demo-only" for fields dashd does not actually emit.
+  source?: string;
 }
 
+// `source` traces each value to its REAL origin (CAN packet 0x___ + signal,
+// derivation/aggregation, trackside MQTT topic, or demo-only) — see the
+// FieldDef.source comment. Traced through dashd extract_can_data + can_packets.csv.
 export const FIELD_CATALOG: FieldDef[] = [
   // The just-finished lap (lap card only — lapCard.* is null on other screens)
-  { bind: 'lapCard.lapNumber', label: 'Lap number', group: 'Lap', defaultFormat: 'int', min: 0, max: 30 },
-  { bind: 'lapCard.timeS', label: 'Lap time', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120 },
-  { bind: 'lapCard.energyWh', label: 'Lap energy', group: 'Lap', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 400 },
-  { bind: 'mqtt.bestLapTime', label: 'Best lap', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120 },
-  { bind: 'mqtt.lastLapTime', label: 'Last lap', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120 },
-  { bind: 'mqtt.currentLapTime', label: 'Current lap time', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120 },
-  { bind: 'mqtt.lapTrigger', label: 'Lap count', group: 'Lap', defaultFormat: 'int', min: 0, max: 30 },
+  { bind: 'lapCard.lapNumber', label: 'Lap number', group: 'Lap', defaultFormat: 'int', min: 0, max: 30, source: 'on-car lap counter (GPS gate / trackside lapTrigger)' },
+  { bind: 'lapCard.timeS', label: 'Lap time', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120, source: 'on-car: wall-clock since lap start' },
+  { bind: 'lapCard.energyWh', label: 'Lap energy', group: 'Lap', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 400, source: 'on-car: ∫ CAN power over the lap' },
+  { bind: 'mqtt.bestLapTime', label: 'Best lap', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120, source: 'demo-only — dashd does not track best lap (always —)' },
+  { bind: 'mqtt.lastLapTime', label: 'Last lap', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120, source: 'demo-only — not emitted; real last-lap time is the lap card (lapCard.timeS), timed on-car' },
+  { bind: 'mqtt.currentLapTime', label: 'Current lap time', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120, source: 'demo-only — not emitted; use pacing.lapElapsedS for the live lap time' },
+  { bind: 'mqtt.lapTrigger', label: 'Lap count', group: 'Lap', defaultFormat: 'int', min: 0, max: 30, source: 'on-car monotonic lap count (lhre/dash/lapTrigger)' },
   // Pacing / strategy (on-car authoritative pacing snapshot)
-  { bind: 'pacing.lapEnergyWh', label: 'Energy (this lap)', group: 'Pacing', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 400 },
-  { bind: 'pacing.lapBudgetWh', label: 'Per-lap budget', group: 'Pacing', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 400 },
-  { bind: 'pacing.lapElapsedS', label: 'Lap elapsed', group: 'Pacing', unit: 's', defaultFormat: 'laptime', min: 0, max: 120 },
-  { bind: 'pacing.lapNumber', label: 'Lap (in progress)', group: 'Pacing', defaultFormat: 'int', min: 0, max: 30 },
-  { bind: 'mqtt.lapsRemaining', label: 'Laps remaining', group: 'Pacing', defaultFormat: 'int', min: 0, max: 30 },
-  { bind: 'mqtt.lapsRemainingEnergy', label: 'Laps left (energy)', group: 'Pacing', defaultFormat: 'int', min: 0, max: 30 },
-  { bind: 'mqtt.targetPower', label: 'Target power', group: 'Pacing', unit: 'kW', defaultFormat: 'kw', min: 0, max: 80 },
+  { bind: 'pacing.lapEnergyWh', label: 'Energy (this lap)', group: 'Pacing', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 400, source: 'on-car: ∫ CAN power this lap' },
+  { bind: 'pacing.lapBudgetWh', label: 'Per-lap budget', group: 'Pacing', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 400, source: 'trackside (lhre/dash/lapBudgetWh)' },
+  { bind: 'pacing.lapElapsedS', label: 'Lap elapsed', group: 'Pacing', unit: 's', defaultFormat: 'laptime', min: 0, max: 120, source: 'on-car: wall-clock since lap start' },
+  { bind: 'pacing.lapNumber', label: 'Lap (in progress)', group: 'Pacing', defaultFormat: 'int', min: 0, max: 30, source: 'on-car: lap_count + 1' },
+  { bind: 'mqtt.lapsRemaining', label: 'Laps remaining', group: 'Pacing', defaultFormat: 'int', min: 0, max: 30, source: 'trackside (lhre/dash/lapsRemaining) — no current publisher' },
+  { bind: 'mqtt.lapsRemainingEnergy', label: 'Laps left (energy)', group: 'Pacing', defaultFormat: 'int', min: 0, max: 30, source: 'demo-only — dashd does not emit this (always —)' },
+  { bind: 'mqtt.targetPower', label: 'Target power', group: 'Pacing', unit: 'kW', defaultFormat: 'kw', min: 0, max: 80, source: 'trackside (lhre/dash/targetPower)' },
   // Deltas (signed — green/red by sign; lower/negative is "good" by default)
-  { bind: 'mqtt.lapDelta', label: 'Lap Δ vs ref', group: 'Deltas', unit: 's', defaultFormat: 'float2', min: -5, max: 5, bidirectional: true, isDelta: true, goodSign: 'negative' },
-  { bind: 'pacing.budgetDeltaWh', label: 'Energy budget Δ', group: 'Deltas', unit: 'Wh', defaultFormat: 'whSigned', min: -100, max: 100, bidirectional: true, isDelta: true, goodSign: 'negative' },
-  { bind: 'mqtt.energyDelta', label: 'Energy Δ vs target', group: 'Deltas', unit: 'Wh', defaultFormat: 'whSigned', min: -100, max: 100, bidirectional: true, isDelta: true, goodSign: 'negative' },
-  { bind: 'mqtt.lapDeltaRate', label: 'Lap Δ rate', group: 'Deltas', unit: 's/s', defaultFormat: 'float2', min: -2, max: 2, bidirectional: true, isDelta: true, goodSign: 'negative' },
+  { bind: 'mqtt.lapDelta', label: 'Lap Δ vs ref', group: 'Deltas', unit: 's', defaultFormat: 'float2', min: -5, max: 5, bidirectional: true, isDelta: true, goodSign: 'negative', source: 'trackside (lhre/dash/lapDelta) — no current publisher' },
+  { bind: 'pacing.budgetDeltaWh', label: 'Energy budget Δ', group: 'Deltas', unit: 'Wh', defaultFormat: 'whSigned', min: -100, max: 100, bidirectional: true, isDelta: true, goodSign: 'negative', source: 'on-car derived: lapEnergyWh − targetPower·elapsed' },
+  { bind: 'mqtt.energyDelta', label: 'Energy Δ vs target', group: 'Deltas', unit: 'Wh', defaultFormat: 'whSigned', min: -100, max: 100, bidirectional: true, isDelta: true, goodSign: 'negative', source: 'trackside (lhre/dash/energyDelta) — no current publisher' },
+  { bind: 'mqtt.lapDeltaRate', label: 'Lap Δ rate', group: 'Deltas', unit: 's/s', defaultFormat: 'float2', min: -2, max: 2, bidirectional: true, isDelta: true, goodSign: 'negative', source: 'demo-only — dashd does not emit this (always —)' },
   // Energy / charge (VCU is the source of truth for running energy)
-  { bind: 'can.soc', label: 'State of energy', group: 'Energy', unit: '%', defaultFormat: 'pct', min: 0, max: 100 },
-  { bind: 'can.vcuNetEnergyWh', label: 'VCU net energy', group: 'Energy', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 8000 },
-  { bind: 'can.vcuRegenEnergyWh', label: 'VCU regen energy', group: 'Energy', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 2000 },
-  { bind: 'can.power', label: 'Pack power', group: 'Energy', unit: 'kW', defaultFormat: 'kw', min: -80, max: 80, bidirectional: true },
+  { bind: 'can.soc', label: 'State of energy', group: 'Energy', unit: '%', defaultFormat: 'pct', min: 0, max: 100, source: '0x1C7 soc_estimate (VCU State)' },
+  { bind: 'can.vcuNetEnergyWh', label: 'VCU net energy', group: 'Energy', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 8000, source: '0x1C9 net_energy (VCU Energy Estimate)' },
+  { bind: 'can.vcuRegenEnergyWh', label: 'VCU regen energy', group: 'Energy', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 2000, source: '0x1C9 regen_energy (VCU Energy Estimate)' },
+  { bind: 'can.power', label: 'Pack power', group: 'Energy', unit: 'kW', defaultFormat: 'kw', min: -80, max: 80, bidirectional: true, source: 'derived: 0x0A7 dc_bus_v × 0x0A6 dc_bus_current ÷ 1000' },
   // Cell voltages (pack health)
-  { bind: 'can.cellVMax', label: 'Cell V max', group: 'Cells', unit: 'V', defaultFormat: 'volt', min: 2.5, max: 4.3 },
-  { bind: 'can.cellVMin', label: 'Cell V min', group: 'Cells', unit: 'V', defaultFormat: 'volt', min: 2.5, max: 4.3 },
-  { bind: 'can.cellVSpread', label: 'Cell V spread', group: 'Cells', unit: 'V', defaultFormat: 'float2', min: 0, max: 0.5 },
+  { bind: 'can.cellVMax', label: 'Cell V max', group: 'Cells', unit: 'V', defaultFormat: 'volt', min: 2.5, max: 4.3, source: 'max of 0x0D0 cells_v[] (BMS)' },
+  { bind: 'can.cellVMin', label: 'Cell V min', group: 'Cells', unit: 'V', defaultFormat: 'volt', min: 2.5, max: 4.3, source: 'min of 0x0D0 cells_v[] (BMS)' },
+  { bind: 'can.cellVSpread', label: 'Cell V spread', group: 'Cells', unit: 'V', defaultFormat: 'float2', min: 0, max: 0.5, source: 'derived: max − min of 0x0D0 cells_v[]' },
   // Cell + pack temps
-  { bind: 'can.cellTempMax', label: 'Cell T max', group: 'Temps', unit: '°C', defaultFormat: 'temp', min: 0, max: 80 },
-  { bind: 'can.cellTempAvg', label: 'Cell T avg', group: 'Temps', unit: '°C', defaultFormat: 'temp', min: 0, max: 80 },
-  { bind: 'can.cellTempMin', label: 'Cell T min', group: 'Temps', unit: '°C', defaultFormat: 'temp', min: 0, max: 80 },
-  { bind: 'can.temperature', label: 'Battery temp', group: 'Temps', unit: '°C', defaultFormat: 'temp', min: 0, max: 80 },
+  { bind: 'can.cellTempMax', label: 'Cell T max', group: 'Temps', unit: '°C', defaultFormat: 'temp', min: 0, max: 80, source: 'max of 0x100 cells_temps[] (BMS)' },
+  { bind: 'can.cellTempAvg', label: 'Cell T avg', group: 'Temps', unit: '°C', defaultFormat: 'temp', min: 0, max: 80, source: 'mean of 0x100 cells_temps[] (BMS)' },
+  { bind: 'can.cellTempMin', label: 'Cell T min', group: 'Temps', unit: '°C', defaultFormat: 'temp', min: 0, max: 80, source: 'min of 0x100 cells_temps[] (BMS)' },
+  { bind: 'can.temperature', label: 'Battery temp', group: 'Temps', unit: '°C', defaultFormat: 'temp', min: 0, max: 80, source: '= cell T max (0x100 cells_temps[])' },
   // Powertrain temps
-  { bind: 'can.motorTemp', label: 'Motor temp', group: 'Temps', unit: '°C', defaultFormat: 'temp', min: 0, max: 120 },
-  { bind: 'can.inverterTemp', label: 'Inverter temp', group: 'Temps', unit: '°C', defaultFormat: 'temp', min: 0, max: 100 },
-  { bind: 'can.coolantTemp', label: 'Coolant temp', group: 'Temps', unit: '°C', defaultFormat: 'temp', min: 0, max: 80 },
+  { bind: 'can.motorTemp', label: 'Motor temp', group: 'Temps', unit: '°C', defaultFormat: 'temp', min: 0, max: 120, source: '0x0A2 motor_temp (thermal)' },
+  { bind: 'can.inverterTemp', label: 'Inverter temp', group: 'Temps', unit: '°C', defaultFormat: 'temp', min: 0, max: 100, source: '0x182 inverter_temp (PDU Temps)' },
+  { bind: 'can.coolantTemp', label: 'Coolant temp', group: 'Temps', unit: '°C', defaultFormat: 'temp', min: 0, max: 80, source: '0x0A2 coolant_temp (thermal)' },
   // Driver inputs
-  { bind: 'can.apps', label: 'APPS (accel)', group: 'Driver', unit: '%', defaultFormat: 'pct', min: 0, max: 100 },
-  { bind: 'can.bpps', label: 'BPPS (brake)', group: 'Driver', unit: '%', defaultFormat: 'pct', min: 0, max: 100 },
-  { bind: 'can.brakeBias', label: 'Brake bias (front)', group: 'Driver', unit: '%', defaultFormat: 'pct', min: 0, max: 100 },
-  { bind: 'can.brakePressureFront', label: 'Brake pressure F', group: 'Driver', unit: 'psi', defaultFormat: 'int', min: 0, max: 1000 },
-  { bind: 'can.brakePressureRear', label: 'Brake pressure R', group: 'Driver', unit: 'psi', defaultFormat: 'int', min: 0, max: 1000 },
+  { bind: 'can.apps', label: 'APPS (accel)', group: 'Driver', unit: '%', defaultFormat: 'pct', min: 0, max: 100, source: '0x1C0 apps1_travel (APPS Voltages)' },
+  { bind: 'can.bpps', label: 'BPPS (brake)', group: 'Driver', unit: '%', defaultFormat: 'pct', min: 0, max: 100, source: '0x1C2 bpps1_travel (BPPS Voltages)' },
+  { bind: 'can.brakeBias', label: 'Brake bias (front)', group: 'Driver', unit: '%', defaultFormat: 'pct', min: 0, max: 100, source: 'derived: 0x1C5 brake_bias × 100' },
+  { bind: 'can.brakePressureFront', label: 'Brake pressure F', group: 'Driver', unit: 'psi', defaultFormat: 'int', min: 0, max: 1000, source: '0x1C5 brake_pressure_f (Brakes)' },
+  { bind: 'can.brakePressureRear', label: 'Brake pressure R', group: 'Driver', unit: 'psi', defaultFormat: 'int', min: 0, max: 1000, source: 'derived: mean of 0x1C5 brake_pressure_rall/rbll' },
   // Rails
-  { bind: 'can.hvVoltage', label: 'HV voltage', group: 'Rails', unit: 'V', defaultFormat: 'volt', min: 0, max: 600 },
-  { bind: 'can.hvCurrent', label: 'HV current', group: 'Rails', unit: 'A', defaultFormat: 'amp', min: -400, max: 400, bidirectional: true },
-  { bind: 'can.lvVoltage', label: 'LV voltage', group: 'Rails', unit: 'V', defaultFormat: 'volt', min: 0, max: 30 },
-  { bind: 'can.lvCurrent', label: 'LV current', group: 'Rails', unit: 'A', defaultFormat: 'amp', min: 0, max: 30 },
+  { bind: 'can.hvVoltage', label: 'HV voltage', group: 'Rails', unit: 'V', defaultFormat: 'volt', min: 0, max: 600, source: '0x132 hv_pack_v (HVC — not currently emitted)' },
+  { bind: 'can.hvCurrent', label: 'HV current', group: 'Rails', unit: 'A', defaultFormat: 'amp', min: -400, max: 400, bidirectional: true, source: '0x132 hv_c (HVC — not currently emitted)' },
+  { bind: 'can.lvVoltage', label: 'LV voltage', group: 'Rails', unit: 'V', defaultFormat: 'volt', min: 0, max: 30, source: '0x183 lv_batt_v (LV Battery)' },
+  { bind: 'can.lvCurrent', label: 'LV current', group: 'Rails', unit: 'A', defaultFormat: 'amp', min: 0, max: 30, source: '0x183 lv_batt_c (LV Battery)' },
   // Dynamics + wheels
-  { bind: 'can.speed', label: 'Speed', group: 'Dynamics', unit: 'mph', defaultFormat: 'mph', min: 0, max: 100 },
+  { bind: 'can.speed', label: 'Speed', group: 'Dynamics', unit: 'mph', defaultFormat: 'mph', min: 0, max: 100, source: 'derived: 0x0A5 motor_speed × 0.0142 → mph' },
   { bind: 'can.eventMode', label: 'VCU event mode', group: 'Dynamics', defaultFormat: 'int', min: 0, max: 4,
-    enumMap: { '0': '—', '1': 'ACCEL', '2': 'SKID', '3': 'AUTOX', '4': 'ENDUR' } },
-  { bind: 'can.wheelSpeedFL', label: 'Wheel FL', group: 'Wheels', defaultFormat: 'float1', min: 0, max: 100 },
-  { bind: 'can.wheelSpeedFR', label: 'Wheel FR', group: 'Wheels', defaultFormat: 'float1', min: 0, max: 100 },
-  { bind: 'can.wheelSpeedRL', label: 'Wheel RL', group: 'Wheels', defaultFormat: 'float1', min: 0, max: 100 },
-  { bind: 'can.wheelSpeedRR', label: 'Wheel RR', group: 'Wheels', defaultFormat: 'float1', min: 0, max: 100 },
+    enumMap: { '0': '—', '1': 'ACCEL', '2': 'SKID', '3': 'AUTOX', '4': 'ENDUR' }, source: '0x1C7 event_mode (VCU State)' },
+  { bind: 'can.wheelSpeedFL', label: 'Wheel FL', group: 'Wheels', defaultFormat: 'float1', min: 0, max: 100, source: '0x402 fl_wheel_speed (USM)' },
+  { bind: 'can.wheelSpeedFR', label: 'Wheel FR', group: 'Wheels', defaultFormat: 'float1', min: 0, max: 100, source: '0x403 fr_wheel_speed (USM)' },
+  { bind: 'can.wheelSpeedRL', label: 'Wheel RL', group: 'Wheels', defaultFormat: 'float1', min: 0, max: 100, source: '0x404 bl_wheel_speed (USM rear-left)' },
+  { bind: 'can.wheelSpeedRR', label: 'Wheel RR', group: 'Wheels', defaultFormat: 'float1', min: 0, max: 100, source: '0x405 br_wheel_speed (USM rear-right)' },
 ];
 
 export function fieldDef(bind: string): FieldDef | undefined {

--- a/telemtry/analysis/database/viewer_tool/src/lib/dash/dashLayout.ts
+++ b/telemtry/analysis/database/viewer_tool/src/lib/dash/dashLayout.ts
@@ -191,28 +191,24 @@ export const FIELD_CATALOG: FieldDef[] = [
   { bind: 'lapCard.timeS', label: 'Lap time', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120, source: 'on-car: wall-clock since lap start' },
   { bind: 'lapCard.energyWh', label: 'Lap energy', group: 'Lap', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 400, source: 'on-car: ∫ CAN power over the lap' },
   // Last completed lap — REAL, on-car (PacingData), forwarded every frame on ALL
-  // screens (unlike lapCard.* which only exists on the lap card). Prefer these over
-  // the mqtt.* lap stubs below. Null until the first lap completes.
+  // screens (unlike lapCard.* which only exists on the lap card). Null until the
+  // first lap completes.
   { bind: 'pacing.lastLapTimeS', label: 'Last lap time', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120, source: 'on-car: time of the last completed lap (PacingData — any screen)' },
   { bind: 'pacing.lastLapEnergyWh', label: 'Last lap energy', group: 'Lap', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 400, source: 'on-car: net Wh of the last completed lap (PacingData)' },
   { bind: 'pacing.lastLapNumber', label: 'Last lap #', group: 'Lap', defaultFormat: 'int', min: 0, max: 30, source: 'on-car: number of the last completed lap (PacingData)' },
-  { bind: 'mqtt.bestLapTime', label: 'Best lap (demo)', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120, source: 'demo-only — best lap not tracked on-car yet (always —)' },
-  { bind: 'mqtt.lastLapTime', label: 'Last lap (demo)', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120, source: 'demo-only — not emitted; use pacing.lastLapTimeS instead (real, any screen)' },
-  { bind: 'mqtt.currentLapTime', label: 'Current lap (demo)', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120, source: 'demo-only — not emitted; use pacing.lapElapsedS for the live lap time' },
   { bind: 'mqtt.lapTrigger', label: 'Lap count', group: 'Lap', defaultFormat: 'int', min: 0, max: 30, source: 'on-car monotonic lap count (lhre/dash/lapTrigger)' },
   // Pacing / strategy (on-car authoritative pacing snapshot)
   { bind: 'pacing.lapEnergyWh', label: 'Energy (this lap)', group: 'Pacing', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 400, source: 'on-car: ∫ CAN power this lap' },
   { bind: 'pacing.lapBudgetWh', label: 'Per-lap budget', group: 'Pacing', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 400, source: 'trackside (lhre/dash/lapBudgetWh)' },
   { bind: 'pacing.lapElapsedS', label: 'Lap elapsed', group: 'Pacing', unit: 's', defaultFormat: 'laptime', min: 0, max: 120, source: 'on-car: wall-clock since lap start' },
   { bind: 'pacing.lapNumber', label: 'Lap (in progress)', group: 'Pacing', defaultFormat: 'int', min: 0, max: 30, source: 'on-car: lap_count + 1' },
-  { bind: 'mqtt.lapsRemaining', label: 'Laps remaining', group: 'Pacing', defaultFormat: 'int', min: 0, max: 30, source: 'trackside (lhre/dash/lapsRemaining) — no current publisher' },
-  { bind: 'mqtt.lapsRemainingEnergy', label: 'Laps left (energy)', group: 'Pacing', defaultFormat: 'int', min: 0, max: 30, source: 'demo-only — dashd does not emit this (always —)' },
+  { bind: 'mqtt.lapsRemaining', label: 'Laps remaining', group: 'Pacing', defaultFormat: 'int', min: 0, max: 30, source: 'trackside: target laps − completed (lhre/dash/lapsRemaining)' },
   { bind: 'mqtt.targetPower', label: 'Target power', group: 'Pacing', unit: 'kW', defaultFormat: 'kw', min: 0, max: 80, source: 'trackside (lhre/dash/targetPower)' },
   // Deltas (signed — green/red by sign; lower/negative is "good" by default)
-  { bind: 'mqtt.lapDelta', label: 'Lap Δ vs ref', group: 'Deltas', unit: 's', defaultFormat: 'float2', min: -5, max: 5, bidirectional: true, isDelta: true, goodSign: 'negative', source: 'trackside (lhre/dash/lapDelta) — no current publisher' },
-  { bind: 'pacing.budgetDeltaWh', label: 'Energy budget Δ', group: 'Deltas', unit: 'Wh', defaultFormat: 'whSigned', min: -100, max: 100, bidirectional: true, isDelta: true, goodSign: 'negative', source: 'on-car derived: lapEnergyWh − targetPower·elapsed' },
-  { bind: 'mqtt.energyDelta', label: 'Energy Δ vs target', group: 'Deltas', unit: 'Wh', defaultFormat: 'whSigned', min: -100, max: 100, bidirectional: true, isDelta: true, goodSign: 'negative', source: 'trackside (lhre/dash/energyDelta) — no current publisher' },
-  { bind: 'mqtt.lapDeltaRate', label: 'Lap Δ rate', group: 'Deltas', unit: 's/s', defaultFormat: 'float2', min: -2, max: 2, bidirectional: true, isDelta: true, goodSign: 'negative', source: 'demo-only — dashd does not emit this (always —)' },
+  { bind: 'mqtt.lapDelta', label: 'Lap Δ vs best', group: 'Deltas', unit: 's', defaultFormat: 'float2', min: -5, max: 5, bidirectional: true, isDelta: true, goodSign: 'negative', source: 'trackside: last lap − best lap (lhre/dash/lapDelta)' },
+  { bind: 'pacing.budgetDeltaWh', label: 'Energy budget Δ (power)', group: 'Deltas', unit: 'Wh', defaultFormat: 'whSigned', min: -100, max: 100, bidirectional: true, isDelta: true, goodSign: 'negative', source: 'on-car: lapEnergyWh − targetPower·elapsed (POWER-based, live within lap)' },
+  { bind: 'mqtt.energyDelta', label: 'Energy Δ vs dyn budget', group: 'Deltas', unit: 'Wh', defaultFormat: 'whSigned', min: -100, max: 100, bidirectional: true, isDelta: true, goodSign: 'negative', source: 'trackside: last lap − DYNAMIC budget (remaining ÷ laps left); lhre/dash/energyDelta' },
+  { bind: 'mqtt.energyDeltaStatic', label: 'Energy Δ vs plan', group: 'Deltas', unit: 'Wh', defaultFormat: 'whSigned', min: -100, max: 100, bidirectional: true, isDelta: true, goodSign: 'negative', source: 'trackside: last lap − STATIC plan budget (kWh ÷ laps); lhre/dash/energyDeltaStatic' },
   // Energy / charge (VCU is the source of truth for running energy)
   { bind: 'can.soc', label: 'State of energy', group: 'Energy', unit: '%', defaultFormat: 'pct', min: 0, max: 100, source: '0x1C7 soc_estimate (VCU State)' },
   { bind: 'can.vcuNetEnergyWh', label: 'VCU net energy', group: 'Energy', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 8000, source: '0x1C9 net_energy (VCU Energy Estimate)' },

--- a/telemtry/analysis/database/viewer_tool/src/lib/dash/dashLayout.ts
+++ b/telemtry/analysis/database/viewer_tool/src/lib/dash/dashLayout.ts
@@ -59,7 +59,8 @@ export type FormatId =
   | 'raw' | 'int' | 'float1' | 'float2'
   | 'laptime'   // M:SS.ss
   | 'wh' | 'whSigned' | 'kwh'
-  | 'kw' | 'pct' | 'temp' | 'volt' | 'amp' | 'mph';
+  | 'kw' | 'pct' | 'temp' | 'volt' | 'amp' | 'mph'
+  | 'bool';     // ON/OFF — booleans (e.g. can.regenEnabled) coerce to 1/0 in getByPath
 
 export interface BaseWidget {
   id: string;
@@ -246,6 +247,13 @@ export const FIELD_CATALOG: FieldDef[] = [
   { bind: 'can.wheelSpeedFR', label: 'Wheel FR', group: 'Wheels', defaultFormat: 'float1', min: 0, max: 100, source: '0x403 fr_wheel_speed (USM)' },
   { bind: 'can.wheelSpeedRL', label: 'Wheel RL', group: 'Wheels', defaultFormat: 'float1', min: 0, max: 100, source: '0x404 bl_wheel_speed (USM rear-left)' },
   { bind: 'can.wheelSpeedRR', label: 'Wheel RR', group: 'Wheels', defaultFormat: 'float1', min: 0, max: 100, source: '0x405 br_wheel_speed (USM rear-right)' },
+  // Boolean status flags (rendered ON/OFF; booleans → 1/0 in getByPath). The
+  // editor pre-fills each widget's valueMap from enumMap, so the labels (and
+  // colors, via thresholds) are editable per widget.
+  { bind: 'can.regenEnabled', label: 'Regen', group: 'Controls', defaultFormat: 'bool', min: 0, max: 1, enumMap: { '0': 'OFF', '1': 'ON' }, source: '0x1C7 byte 5 (VCU State) — "line_lock_enabled" bit, used as the regen-armed flag' },
+  { bind: 'can.posContactor', label: 'HV+ contactor', group: 'Contactors', defaultFormat: 'bool', min: 0, max: 1, enumMap: { '0': 'OPEN', '1': 'CLOSED' }, source: '0x131 pos contactor (HVC)' },
+  { bind: 'can.negContactor', label: 'HV− contactor', group: 'Contactors', defaultFormat: 'bool', min: 0, max: 1, enumMap: { '0': 'OPEN', '1': 'CLOSED' }, source: '0x131 neg contactor (HVC)' },
+  { bind: 'can.prechargeContactor', label: 'Precharge', group: 'Contactors', defaultFormat: 'bool', min: 0, max: 1, enumMap: { '0': 'OPEN', '1': 'CLOSED' }, source: '0x131 precharge contactor (HVC)' },
 ];
 
 export function fieldDef(bind: string): FieldDef | undefined {
@@ -264,6 +272,9 @@ export function getByPath(ctx: unknown, path: string): number | null {
     if (cur == null || typeof cur !== 'object') return null;
     cur = (cur as Record<string, unknown>)[key];
   }
+  // Booleans (e.g. can.regenEnabled, contactors) are exposed as 1/0 so they can
+  // bind to value widgets — rendered ON/OFF via the 'bool' format or a valueMap.
+  if (typeof cur === 'boolean') return cur ? 1 : 0;
   return typeof cur === 'number' && Number.isFinite(cur) ? cur : null;
 }
 
@@ -279,6 +290,9 @@ export function valueColor(v: number | null | undefined, base: string, rules?: C
 
 export function formatValue(v: number | null | undefined, fmt: FormatId, decimals?: number): string {
   if (v == null || !Number.isFinite(v)) return '--';
+  // ON/OFF for booleans (already coerced to 1/0 by getByPath). A widget valueMap
+  // (e.g. {0:'OPEN',1:'CLOSED'}) overrides these via applyValueMap.
+  if (fmt === 'bool') return v >= 0.5 ? 'ON' : 'OFF';
   // Optional per-widget precision override. Applies to the numeric formats —
   // keeps kwh's /1000 scaling and whSigned's +/- sign; lap-time ignores it.
   if (decimals != null && Number.isFinite(decimals) && fmt !== 'laptime') {

--- a/telemtry/analysis/database/viewer_tool/src/lib/dash/dashSignals.ts
+++ b/telemtry/analysis/database/viewer_tool/src/lib/dash/dashSignals.ts
@@ -77,6 +77,11 @@ export interface DashSignals {
     disconnect: () => void;
     /** Set the live power budget (kW) shown on the dash energy bar. */
     publishTargetPower: (kw: number) => void;
+    /** Trackside strategy deltas (re-sent on keepalive; pass null to stop sending). */
+    publishLapDelta: (seconds: number | null) => void;
+    publishEnergyDelta: (wh: number | null) => void;
+    publishEnergyDeltaStatic: (wh: number | null) => void;
+    publishLapsRemaining: (laps: number | null) => void;
     /** Bump the lap counter — fires the dash's full-screen lap card + per-lap reset. */
     sendLap: (value?: number) => void;
     /** Re-publish a lap value without bumping the internal counter — for the drain
@@ -132,6 +137,12 @@ export function useDashSignals(): DashSignals {
 
     const clientRef = useRef<MqttClient | null>(null);
     const targetPowerRef = useRef<number | null>(null);
+    // Trackside-computed strategy deltas; re-sent each keepalive tick because dashd
+    // nulls them after 5 s of silence (MqttState staleness).
+    const lapDeltaRef = useRef<number | null>(null);
+    const energyDeltaRef = useRef<number | null>(null);
+    const energyDeltaStaticRef = useRef<number | null>(null);
+    const lapsRemainingRef = useRef<number | null>(null);
     const lapCounterRef = useRef(0);
     const keepaliveRef = useRef<number | null>(null);
 
@@ -233,12 +244,37 @@ export function useDashSignals(): DashSignals {
 
         keepaliveRef.current = window.setInterval(() => {
             if (targetPowerRef.current !== null) publish('targetPower', targetPowerRef.current);
+            // Re-send the strategy deltas so dashd's 5 s staleness gate doesn't blank them.
+            if (lapDeltaRef.current !== null) publish('lapDelta', lapDeltaRef.current);
+            if (energyDeltaRef.current !== null) publish('energyDelta', energyDeltaRef.current);
+            if (energyDeltaStaticRef.current !== null) publish('energyDeltaStatic', energyDeltaStaticRef.current);
+            if (lapsRemainingRef.current !== null) publish('lapsRemaining', lapsRemainingRef.current);
         }, KEEPALIVE_MS);
     }, [brokerUrl, publish]);
 
     const publishTargetPower = useCallback((kw: number) => {
         targetPowerRef.current = kw;
         publish('targetPower', kw);
+    }, [publish]);
+
+    // Trackside-computed strategy deltas. Each stores its value (for the keepalive
+    // re-send) and publishes immediately; pass null to stop sending (dashd nulls it
+    // out after the staleness window).
+    const publishLapDelta = useCallback((seconds: number | null) => {
+        lapDeltaRef.current = seconds;
+        if (seconds !== null) publish('lapDelta', seconds);
+    }, [publish]);
+    const publishEnergyDelta = useCallback((wh: number | null) => {
+        energyDeltaRef.current = wh;
+        if (wh !== null) publish('energyDelta', wh);
+    }, [publish]);
+    const publishEnergyDeltaStatic = useCallback((wh: number | null) => {
+        energyDeltaStaticRef.current = wh;
+        if (wh !== null) publish('energyDeltaStatic', wh);
+    }, [publish]);
+    const publishLapsRemaining = useCallback((laps: number | null) => {
+        lapsRemainingRef.current = laps;
+        if (laps !== null) publish('lapsRemaining', laps);
     }, [publish]);
 
     const sendLap = useCallback((value?: number) => {
@@ -381,6 +417,10 @@ export function useDashSignals(): DashSignals {
         connect,
         disconnect,
         publishTargetPower,
+        publishLapDelta,
+        publishEnergyDelta,
+        publishEnergyDeltaStatic,
+        publishLapsRemaining,
         sendLap,
         republishLap,
         resetLapCounter,

--- a/telemtry/analysis/database/viewer_tool/src/lib/dash/dashSignals.ts
+++ b/telemtry/analysis/database/viewer_tool/src/lib/dash/dashSignals.ts
@@ -106,6 +106,11 @@ export interface DashSignals {
     sendMessage: (message: DashMessage, durationS?: number) => boolean;
     /** Dismiss whatever message is currently on the dash. */
     clearMessage: () => boolean;
+    /** Debug: force the dash to show a named screen ("driving"/"park"/"shutdown"/
+     *  "settings"), or pass "auto"/null to release back to PRNDL routing. Not
+     *  retained, so a dash reboot returns to normal; dashd also auto-clears it on
+     *  a real gear change. */
+    publishScreen: (screen: string | null) => boolean;
     /** Latest mirror of the driver's screen (null until the car publishes state). */
     dashState: DashMirrorState | null;
     /** Wall-clock ms of the last lhre/dash/state message — for a link-silent warning. */
@@ -397,6 +402,17 @@ export function useDashSignals(): DashSignals {
         return true;
     }, []);
 
+    // Debug screen override (lhre/dash/screen). NOT retained: a one-shot string
+    // the dash applies as a precedence layer over PRNDL routing. dashd clears it
+    // on a real gear change and a dash reboot drops it (no replay), so it can't
+    // strand the driver. qos 1 so the press reliably lands. null/"auto" releases.
+    const publishScreen = useCallback((screen: string | null): boolean => {
+        const client = clientRef.current;
+        if (!client || !client.connected) return false;
+        client.publish(`${TOPIC_PREFIX}screen`, screen ?? 'auto', { qos: 1 });
+        return true;
+    }, []);
+
     const setBrokerUrl = useCallback((url: string) => {
         setBrokerUrlState(url);
         if (typeof window !== 'undefined') localStorage.setItem(BROKER_STORAGE_KEY, url);
@@ -433,6 +449,7 @@ export function useDashSignals(): DashSignals {
         publishMessages,
         sendMessage,
         clearMessage,
+        publishScreen,
         dashState,
         lastStateAt,
         acks,

--- a/telemtry/analysis/database/viewer_tool/src/lib/dash/dashSignals.ts
+++ b/telemtry/analysis/database/viewer_tool/src/lib/dash/dashSignals.ts
@@ -90,6 +90,8 @@ export interface DashSignals {
     publishLayout: (layout: unknown) => boolean;
     /** Push the park/pit-screen layout (retained, separate topic from the lap card). */
     publishParkLayout: (layout: unknown) => boolean;
+    /** Push the primary/driving-screen layout (retained, its own topic). */
+    publishDrivingLayout: (layout: unknown) => boolean;
     /** Push the live dynamic per-lap energy budget (Wh) the dash shows (retained). */
     publishLapBudget: (wh: number) => boolean;
     publishLapCardMs: (ms: number) => boolean;
@@ -303,6 +305,15 @@ export function useDashSignals(): DashSignals {
         return true;
     }, []);
 
+    // Primary / driving-screen layout — same retained pattern, its own topic so
+    // all three screens (lap card, driving, park) are authored independently.
+    const publishDrivingLayout = useCallback((layout: unknown): boolean => {
+        const client = clientRef.current;
+        if (!client || !client.connected) return false;
+        client.publish(`${TOPIC_PREFIX}drivingLayout`, JSON.stringify(layout), { qos: 1, retain: true });
+        return true;
+    }, []);
+
     // Retained: the live per-lap Wh budget (remaining energy / remaining laps),
     // republished by trackside whenever it changes. The dash holds it and shows
     // the driver the current Wh/lap target.
@@ -376,6 +387,7 @@ export function useDashSignals(): DashSignals {
         publishGate,
         publishLayout,
         publishParkLayout,
+        publishDrivingLayout,
         publishLapBudget,
         publishLapCardMs,
         publishMessages,


### PR DESCRIPTION
Makes the car's **primary / driving screen customizable** like the lap-card and Park screens, and **lifts the lap-card overlay** so it floats over any screen.

## What's in it
- **Lap-card overlay lifted** — moved from `ScreenOne` into a new `LapCardOverlay` component rendered by `Dashboard`, so it pops over whatever screen is active (built-in OR custom driving layout, Park, etc.), not just the driving screen. z-1000 (below the driver-message overlay's 1100).
- **Primary/driving screen customizable** — mirrors the Park mechanism end-to-end:
  - `dashLayout.ts`: `defaultDrivingLayout` (speed/power gauges, SoE, lap delta, USED/BUDGET) + a `{ id: 'driving', topic: 'drivingLayout', … }` registry entry — the editor + `/api/dash/layouts` pick it up generically.
  - `dashSignals.ts` `publishDrivingLayout` → retained `lhre/dash/drivingLayout`; `TracksideApp` send-routing handles `driving`.
  - `main.rs`: full `driving_layout` plumbing — `DashMessage`/`DashState` fields, reboot-durable `/var/lib/bevo-dash/drivinglayout.json` persist+load, ws forward, MQTT handler + ack.
  - `ScreenOne` early-returns the custom layout when published; the built-in driving view stays as the fallback.

## Verification
`cargo check` clean; website `tsc` clean. Car-frontend TS is validated by the on-car build at deploy (changes mirror the existing Park/overlay code).
