### PR TITLE
Trackside: fix Max Cell T + realtime Cell Thermals grid

### DIFF
--- a/BEVO/dashd/frontend/src/dashLayout.ts
+++ b/BEVO/dashd/frontend/src/dashLayout.ts
@@ -170,8 +170,12 @@ export interface FieldDef {
 }
 
 export const FIELD_CATALOG: FieldDef[] = [
-  // The just-finished lap (what the card is fundamentally about)
-  { bind: 'lapCard.lapNumber', label: 'Lap number', group: 'Lap', defaultFormat: 'int', min: 0, max: 30 },
+  // The just-finished lap — only populated inside the lap-card popup.
+  { bind: 'lapCard.lapNumber', label: 'Lap number (card only)', group: 'Lap', defaultFormat: 'int', min: 0, max: 30 },
+  // Live running count of laps COMPLETED (dashd lap_count). Corrects up/down with
+  // trackside in real time — e.g. a deselected double-count / driver-change lap.
+  // Use THIS for a persistent "laps done" readout on the driving/park screen.
+  { bind: 'mqtt.lapTrigger', label: 'Laps completed (live)', group: 'Lap', defaultFormat: 'int', min: 0, max: 30 },
   { bind: 'lapCard.timeS', label: 'Lap time', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120 },
   { bind: 'lapCard.energyWh', label: 'Lap energy', group: 'Lap', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 400 },
   { bind: 'mqtt.bestLapTime', label: 'Best lap', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120 },

--- a/BEVO/dashd/main.rs
+++ b/BEVO/dashd/main.rs
@@ -1221,6 +1221,24 @@ fn mqtt_subscriber_loop(state: Arc<Mutex<DashState>>) {
                                 );
                             }
                         }
+                        "lapCount" => {
+                            // Absolute lap-count correction from trackside (its
+                            // SELECTED completed-lap count). Adopt in EITHER
+                            // direction with NO card and no integrator reset —
+                            // this is how the dash count follows a DESELECT on
+                            // the live list (lapTrigger above is forward-only and
+                            // would ignore a backward value).
+                            let new_count = val.round().max(0.0) as u64;
+                            locked.lap_count = new_count;
+                            locked.last_offcar_trigger = Some(val);
+                            let _ = client.publish(
+                                format!("{}ack/lapCount", MQTT_TOPIC_PREFIX),
+                                QoS::AtMostOnce,
+                                true,
+                                new_count.to_string(),
+                            );
+                            println!("[DASHD] Trackside lapCount -> lap_count {}", new_count);
+                        }
                         "lapReset" => {
                             // Trackside started a new session: drop both the
                             // baseline and the running lap_count. The next

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
@@ -575,6 +575,10 @@ function App() {
   const [msgSendStatus, setMsgSendStatus] = useState("");
   const [dashNow, setDashNow] = useState(0); // 1 Hz tick for link-health "age" displays
   const dashLastLapCountRef = useRef(0);
+  // Set by markLap so the dash-count sync effect fires a lap CARD for the next
+  // newly-counted lap even when GPS auto-card (dashAutoLap) is off — a manual
+  // "Log Lap" is an explicit request to show the card.
+  const dashCardForceRef = useRef(false);
   const lastRegistryPatchRef = useRef(0);
   // Multi-client sync: one leader owns the session, others mirror it read-only.
   const presence = usePresence(true);
@@ -1039,13 +1043,29 @@ function App() {
 
   // Auto-fire a dash lap card whenever the trackside lap detector completes a
   // lap — optional, off by default so the thread's "manual for now" still holds.
+  // Keep the dash lap count in sync with the SELECTED (counted) laps — the same
+  // source as lapsCompletedPlan — in BOTH directions:
+  //   • count up (new counted lap)   -> fire the card via lapTrigger if auto-card
+  //     is on OR a manual Log Lap requested it; otherwise just sync the number.
+  //   • count down (a lap deselected) -> publishLapCount pulls the dash count
+  //     down with NO card (lapTrigger is forward-only by design).
+  // So deselecting a double-count / driver-change lap updates the driver dash too.
   useEffect(() => {
-    const count = liveState.laps.length;
-    if (count > dashLastLapCountRef.current) {
-      if (!isMirror && dashAutoLap && dashSignals.status === "connected") dashSignals.sendLap();
-      dashLastLapCountRef.current = count;
+    if (isMirror || dashSignals.status !== "connected") return;
+    const n = selectedLaps.length;
+    const prev = dashLastLapCountRef.current;
+    if (n === prev) return;
+    dashLastLapCountRef.current = n;
+    if (n > prev) {
+      const wantCard = dashAutoLap || dashCardForceRef.current;
+      dashCardForceRef.current = false;
+      if (wantCard) dashSignals.sendLap(n);
+      else dashSignals.publishLapCount(n); // count up, no card
+    } else {
+      dashCardForceRef.current = false;
+      dashSignals.publishLapCount(n); // deselect: pull the dash count down, no card
     }
-  }, [liveState.laps.length, dashAutoLap, dashSignals.status, dashSignals.sendLap, isMirror]);
+  }, [selectedLaps.length, dashAutoLap, dashSignals.status, dashSignals.sendLap, dashSignals.publishLapCount, isMirror]);
 
   // Drain: re-publish the website's lap count whenever the car's mirror shows
   // fewer laps than we've logged. Catches both the dashd-restart and
@@ -1059,12 +1079,12 @@ function App() {
     if (dashSignals.status !== "connected") return;
     const carLapCount = dashSignals.dashState?.lapCount ?? null;
     if (carLapCount == null) return; // no mirror yet — nothing to compare against
-    const websiteLapCount = liveState.laps.length;
+    const websiteLapCount = selectedLaps.length;
     if (websiteLapCount > carLapCount) {
       dashSignals.republishLap(websiteLapCount);
     }
   }, [
-    liveState.laps.length,
+    selectedLaps.length,
     dashSignals.status,
     dashSignals.dashState?.lapCount,
     dashSignals.republishLap,
@@ -2375,14 +2395,11 @@ function App() {
     triggerManualLap();
     const after = liveStateRef.current.laps.length;
     const lapClosed = after > beforeLaps;
-    // On a completed lap, always fire the car's lap card. sendLap advances the
-    // lap counter in lockstep with the Live tab even if the publish is dropped
-    // (link mid-handshake), and the auto-connect keeps the uplink up — so both
-    // lap buttons reliably log to the Live tab AND reach the car.
-    // Send the website's authoritative lap count to the car so dashd adopts it
-    // (rather than running its own +1 counter that drifted from trackside).
-    if (lapClosed) dashSignals.sendLap(after);
-    dashLastLapCountRef.current = after;
+    // On a completed lap, request the car's lap card. The actual lapTrigger is
+    // sent by the dash-count sync effect when the newly-logged lap shows up in
+    // the SELECTED count — so the card fires at the corrected lap number, and a
+    // manual Log Lap always cards even if GPS auto-card is off.
+    if (lapClosed) dashCardForceRef.current = true;
     // Visible feedback so the user knows whether this click STARTED a lap (no
     // dash card yet — by design, the card represents 'lap COMPLETE') or CLOSED
     // a lap (dash card fires). Earlier this was silent, which made the two

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
@@ -644,12 +644,22 @@ function App() {
     [torqueParamSetId],
   );
   const targetEnergyPerLapWh = targetLaps > 0 && targetEnergyKwh > 0 ? (targetEnergyKwh * 1000) / targetLaps : null;
+  // Laps the strategist counts as REAL completed laps = the checkbox selection in
+  // the live list. Deselecting a double-counted trigger or a driver-change lap
+  // drops the completed count (and raises laps-remaining), so the plan/budget
+  // aren't offset by them. Every lap is auto-selected on completion, so the
+  // default count equals the raw lap count until something is deselected.
+  const selectedLaps = useMemo(() => liveState.laps.filter((lap) => selectedLapIds.has(lap.id)), [liveState.laps, selectedLapIds]);
   // --- dynamic per-lap energy budget (Wh), recomputed each completed lap ---
+  // energyUsedWh stays the ACTUAL total over ALL laps: a deselected lap's energy
+  // was still physically consumed, and a double-count splits one real lap's
+  // energy across two records (total conserved). So only the COUNT follows the
+  // selection — the energy figure must not.
   const energyUsedWh = useMemo(
     () => liveState.laps.reduce((sum, lap) => sum + (lap.energyWh || 0), 0),
     [liveState.laps],
   );
-  const lapsCompletedPlan = liveState.laps.length;
+  const lapsCompletedPlan = selectedLaps.length;
   const totalBudgetWh = targetEnergyKwh > 0 ? targetEnergyKwh * 1000 : null;
   const remainingBudgetWh = totalBudgetWh != null ? totalBudgetWh - energyUsedWh : null;
   const lapsRemainingPlan = targetLaps > 0 ? Math.max(0, targetLaps - lapsCompletedPlan) : null;
@@ -684,7 +694,6 @@ function App() {
       setSoeCutoffCellV(normalizeSoeCutoffCellV(p.soeCutoffCellV));
     }
   });
-  const selectedLaps = useMemo(() => liveState.laps.filter((lap) => selectedLapIds.has(lap.id)), [liveState.laps, selectedLapIds]);
   const lapAverages = useMemo(() => {
     if (!selectedLaps.length) {
       return {
@@ -701,11 +710,11 @@ function App() {
     const avgEnergyInWh = selectedLaps.reduce((sum, lap) => sum + lapEnergyInWh(lap), 0) / selectedLaps.length;
     return { count: selectedLaps.length, avgMs, avgEnergyWh, avgEnergyOutWh, avgEnergyInWh };
   }, [selectedLaps]);
-  // Hero "Lap" tile reads COMPLETED laps, not click count. A lap is counted
-  // when its end-of-lap click closes it (or when GPS auto-detect crosses S/F).
-  // The lap currently in progress is implied by the running timer above, not
-  // by the counter — so 4/22 means "4 done, on the 5th".
-  const currentLapNumber = liveState.laps.length;
+  // Hero "Lap" tile reads SELECTED completed laps (same source as the plan's
+  // lapsCompletedPlan), so deselecting a double-count / driver-change lap in the
+  // live list updates "4/22" to the real count. The lap in progress is implied
+  // by the running timer above, not the counter — so 4/22 means "4 done, on 5th".
+  const currentLapNumber = selectedLaps.length;
   const liveSectorCount = sessionFromFile && hasStartFinish && splitGates.length ? splitGates.length + 1 : 0;
   const liveLapElapsedMs = liveState.lastSample && liveState.lapStartMs ? Math.max(0, liveState.lastSample.t - liveState.lapStartMs) : 0;
   // Wall-clock ticker for the manual recording timer (runs only while recording).
@@ -3456,7 +3465,13 @@ function App() {
                 running={liveState.running}
               />
               </div>
-              <Panel title="Live Laps" icon={<Timer size={18} />}>
+              <Panel
+                title="Live Laps"
+                icon={<Timer size={18} />}
+                headerRight={liveState.laps.length !== selectedLaps.length
+                  ? <><strong>{selectedLaps.length}</strong>/{liveState.laps.length} counted</>
+                  : undefined}
+              >
                 <LiveLapTable
                   laps={liveState.laps}
                   bestLap={bestLap}
@@ -5086,7 +5101,7 @@ function LiveLapTable({
         <table className="lapTable">
           <thead>
             <tr>
-              <th aria-label="Include in average" />
+              <th aria-label="Count this lap (completed total + average); deselect double-counts / driver-change laps" title="Counts toward completed laps & the average. Deselect double-counts or driver-change laps to correct the lap count." />
               <th>Lap</th>
               <th>Time</th>
               {Array.from({ length: columns }, (_sector, index) => <th key={`sector-head-${index}`}>S{index + 1}</th>)}
@@ -5107,7 +5122,8 @@ function LiveLapTable({
                       type="checkbox"
                       checked={selected}
                       onChange={() => onToggleLap(lap.id)}
-                      aria-label={`Include ${lap.label} in average`}
+                      aria-label={`Count ${lap.label} toward completed laps and the average`}
+                      title={`Count ${lap.label} toward completed laps & the average — deselect a double-count or driver-change lap`}
                     />
                   </td>
                   <td className={bestLap?.id === lap.id ? "purpleText" : ""}>

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
@@ -3332,15 +3332,11 @@ function App() {
               <div className="heroMetricRow">
                 <Metric label="Best" value={bestLap ? formatLapTime(bestLap.durationMs) : "--"} tone="purple" />
                 <Metric label="Lap" value={`${currentLapNumber} / ${targetLaps > 0 ? targetLaps : "—"}`} />
-                <Metric label="Energy" value={`${liveState.totalEnergyOutWh.toFixed(1)} Wh`} />
+                <Metric label="Energy" value={`${liveState.totalEnergyWh.toFixed(1)} Wh`} />
               </div>
               {/* Tier 2 — compact inline strip, smaller because they're checked
                   every few seconds, not every second. */}
               <div className="heroMetricStrip">
-                <span className="heroMetricInline">
-                  <small>Regen In</small>
-                  <b className={liveState.totalEnergyInWh > 0 ? "goodText" : ""}>{liveState.totalEnergyInWh.toFixed(1)} Wh</b>
-                </span>
                 <span className="heroMetricInline">
                   <small>Torque</small>
                   <b className={liveTorqueNm != null && liveTorqueNm < 0 ? "goodText" : ""}>
@@ -4643,8 +4639,6 @@ function EnergyStrategyPanel({
 }) {
   const sample = state.lastSample;
   const signedPowerKw = signedVcuPowerKwFor(state.previousSample, sample);
-  const drivePowerKw = signedPowerKw == null ? null : Math.max(0, signedPowerKw);
-  const regenPowerKw = signedPowerKw == null ? null : Math.max(0, -signedPowerKw);
   const pack = packStatus(state.samples, soeCutoffCellV, sample);
   const targetWh = targetEnergyKwh > 0 ? targetEnergyKwh * 1000 : null;
   const vcuUsedWh = state.totalEnergyWh;
@@ -4681,15 +4675,9 @@ function EnergyStrategyPanel({
           <Metric label="SOE Remaining" value={soeRemainingWh == null ? "--" : formatKwhFromWh(soeRemainingWh)} />
           <Metric label="Net Used (VCU)" value={formatKwhFromWh(vcuUsedWh)} />
           <Metric label="Net / Lap" value={targetEnergyPerLapWh == null ? "--" : `${targetEnergyPerLapWh.toFixed(0)} Wh`} />
-          <Metric label="Drive (VCU)" value={formatKwhFromWh(state.totalEnergyOutWh)} />
-          <Metric label="Regen (VCU)" value={formatKwhFromWh(state.totalEnergyInWh)} />
-          <Metric label="Drive Power" value={drivePowerKw == null ? "--" : `${drivePowerKw.toFixed(2)} kW`} />
-          <Metric label="Regen Power" value={regenPowerKw == null ? "--" : `${regenPowerKw.toFixed(2)} kW`} />
+          <Metric label="Power" value={signedPowerKw == null ? "--" : `${signedPowerKw.toFixed(2)} kW`} tone={signedPowerKw != null && signedPowerKw < 0 ? "good" : ""} />
           <Metric label="Lap Net" value={`${state.lapEnergyWh.toFixed(1)} Wh`} />
-          <Metric label="Lap Drive" value={`${state.lapEnergyOutWh.toFixed(1)} Wh`} />
-          <Metric label="Lap Regen" value={`${state.lapEnergyInWh.toFixed(1)} Wh`} />
           <Metric label="Avg Net Lap" value={averages.avgEnergyWh == null ? "--" : `${averages.avgEnergyWh.toFixed(1)} Wh`} />
-          <Metric label="Avg Regen" value={averages.avgEnergyInWh == null ? "--" : `${averages.avgEnergyInWh.toFixed(1)} Wh`} />
         </div>
         <small className="muted">
           {selectedAvgDelta != null
@@ -4894,18 +4882,11 @@ function EnergyWindowChart({
   const plotH = height - padTop - padBottom;
   const lastT = state.lastSample?.t ?? Date.now();
   const startT = lastT - windowS * 1000;
-  const maxEnergy = Math.max(1, ...trace.flatMap((point) => [point.energyOutWh, point.energyInWh, Math.max(0, point.energyWh)]));
-  const outPoints = trace
+  const maxEnergy = Math.max(1, ...trace.map((point) => Math.max(0, point.energyWh)));
+  const netPoints = trace
     .map((point) => {
       const x = padLeft + Math.max(0, Math.min(1, (point.t - startT) / (windowS * 1000))) * plotW;
-      const y = padTop + (1 - Math.max(0, Math.min(1, point.energyOutWh / maxEnergy))) * plotH;
-      return `${x.toFixed(1)},${y.toFixed(1)}`;
-    })
-    .join(" ");
-  const inPoints = trace
-    .map((point) => {
-      const x = padLeft + Math.max(0, Math.min(1, (point.t - startT) / (windowS * 1000))) * plotW;
-      const y = padTop + (1 - Math.max(0, Math.min(1, point.energyInWh / maxEnergy))) * plotH;
+      const y = padTop + (1 - Math.max(0, Math.min(1, point.energyWh / maxEnergy))) * plotH;
       return `${x.toFixed(1)},${y.toFixed(1)}`;
     })
     .join(" ");
@@ -4915,9 +4896,7 @@ function EnergyWindowChart({
   return (
     <div className="energyWindow">
       <div className="energyToolbar">
-        <Metric label="Window Out" value={`${(latest?.energyOutWh ?? 0).toFixed(1)} Wh`} />
-        <Metric label="Regen In" value={`${(latest?.energyInWh ?? 0).toFixed(1)} Wh`} tone="good" />
-        <Metric label="Net" value={`${latestEnergy.toFixed(1)} Wh`} />
+        <Metric label="Energy" value={`${latestEnergy.toFixed(1)} Wh`} />
         <label>
           <span>Window</span>
           <select value={windowS} onChange={(event) => onWindowS(Number(event.target.value))}>
@@ -4937,8 +4916,7 @@ function EnergyWindowChart({
         <text x={width - padRight - 28} y={height - 7}>now</text>
         <text x={6} y={padTop + 10}>{maxEnergy.toFixed(1)} Wh</text>
         <text x={10} y={height - padBottom}>0 Wh</text>
-        {outPoints ? <polyline className="energyOutLine" points={outPoints} /> : null}
-        {inPoints ? <polyline className="energyInLine" points={inPoints} /> : null}
+        {netPoints ? <polyline className="energyNetLine" points={netPoints} /> : null}
         {lapBreaks.map((lap) => {
           const x = padLeft + Math.max(0, Math.min(1, (lap.endMs - startT) / (windowS * 1000))) * plotW;
           return (
@@ -5005,8 +4983,6 @@ function LiveDataPanel({ state }: { state: LiveSessionState }) {
   const energyV = energyVoltageFor(sample);
   const dcBusCurrent = dcBusCurrentFor(sample);
   const signedPowerKw = signedVcuPowerKwFor(state.previousSample, sample);
-  const drivePowerKw = signedPowerKw == null ? null : Math.max(0, signedPowerKw);
-  const regenPowerKw = signedPowerKw == null ? null : Math.max(0, -signedPowerKw);
   const motorRpm = firstLiveValue(values, ["controls_motor_speed", "motor_speed", "dynamics_inverter_rpm", "inverter_rpm"]);
   const rawApps = rawAppsTravelDetails(values);
   const rawRows = [...rawAppsLiveRows(rawApps), ...topLiveValues(values)];
@@ -5015,8 +4991,7 @@ function LiveDataPanel({ state }: { state: LiveSessionState }) {
       <div className="liveDataGrid">
         <Metric label="Samples" value={state.samples.length.toLocaleString()} />
         <Metric label="Last Sample" value={sample ? formatTime(sample.t) : "--"} />
-        <Metric label="Drive Power" value={drivePowerKw == null ? "--" : `${drivePowerKw.toFixed(2)} kW`} />
-        <Metric label="Regen Power" value={regenPowerKw == null ? "--" : `${regenPowerKw.toFixed(2)} kW`} tone="good" />
+        <Metric label="Power" value={signedPowerKw == null ? "--" : `${signedPowerKw.toFixed(2)} kW`} tone={signedPowerKw != null && signedPowerKw < 0 ? "good" : ""} />
         <Metric label={dcBusV == null && energyV != null ? "Est V / I" : "DC Bus"} value={energyV == null || dcBusCurrent == null ? "--" : `${energyV.toFixed(1)} V / ${dcBusCurrent.toFixed(1)} A`} />
         <Metric label="Power Src" value="VCU 0x1C9" />
         <Metric label="Motor RPM" value={motorRpm == null ? "--" : `${Math.round(motorRpm).toLocaleString()} rpm`} />
@@ -5090,7 +5065,7 @@ function LiveLapTable({
   };
 }) {
   const columns = sectorCount;
-  const totalCols = 3 + columns + 3 + (targetEnergyPerLapWh != null ? 1 : 0) + 1; // +1 = Notes
+  const totalCols = 3 + columns + 1 + (targetEnergyPerLapWh != null ? 1 : 0) + 1; // energy col (Net) + optional Δ + Notes
   const currentTargetEnergyWh = currentLapEnergyWh;
   const averageTargetEnergyWh = averages.avgEnergyWh;
   const tableWrapRef = useRef<HTMLDivElement | null>(null);
@@ -5115,10 +5090,8 @@ function LiveLapTable({
               <th>Lap</th>
               <th>Time</th>
               {Array.from({ length: columns }, (_sector, index) => <th key={`sector-head-${index}`}>S{index + 1}</th>)}
-              <th>Drive</th>
-              <th>Regen</th>
-              <th>Net</th>
-              {targetEnergyPerLapWh != null ? <th>Δ Net</th> : null}
+              <th>Energy</th>
+              {targetEnergyPerLapWh != null ? <th>Δ Energy</th> : null}
               <th>Notes</th>
             </tr>
           </thead>
@@ -5166,8 +5139,6 @@ function LiveLapTable({
                     </td>
                     );
                   })}
-                  <td>{lapEnergyOutWh(lap).toFixed(1)} Wh</td>
-                  <td className="goodText">{lapEnergyInWh(lap).toFixed(1)} Wh</td>
                   <td>{lap.energyWh.toFixed(1)} Wh</td>
                   {targetEnergyPerLapWh != null ? <td className={delta != null && delta > 0 ? "deltaOver" : "deltaUnder"}>{delta == null ? "--" : formatEnergyDelta(delta)}</td> : null}
                   <td>
@@ -5200,8 +5171,6 @@ function LiveLapTable({
                 {Array.from({ length: columns }, (_unused, index) => (
                   <td key={`current-sector-${index}`}>{currentSectors[index] == null ? "--" : formatLapTime(currentSectors[index])}</td>
                 ))}
-                <td>{currentLapEnergyOutWh.toFixed(1)} Wh</td>
-                <td className="goodText">{currentLapEnergyInWh.toFixed(1)} Wh</td>
                 <td>{currentLapEnergyWh.toFixed(1)} Wh</td>
                 {targetEnergyPerLapWh != null ? <td>{formatEnergyDelta(currentTargetEnergyWh - targetEnergyPerLapWh)}</td> : null}
                 <td />
@@ -5215,8 +5184,6 @@ function LiveLapTable({
                 <td>Avg ({averages.count})</td>
                 <td>{averages.avgMs == null ? "--" : formatLapTime(averages.avgMs)}</td>
                 {Array.from({ length: columns }, (_unused, index) => <td key={`avg-sector-${index}`} />)}
-                <td>{averages.avgEnergyOutWh == null ? "--" : `${averages.avgEnergyOutWh.toFixed(1)} Wh`}</td>
-                <td className="goodText">{averages.avgEnergyInWh == null ? "--" : `${averages.avgEnergyInWh.toFixed(1)} Wh`}</td>
                 <td>{averages.avgEnergyWh == null ? "--" : `${averages.avgEnergyWh.toFixed(1)} Wh`}</td>
                 {targetEnergyPerLapWh != null ? (
                   <td>{averageTargetEnergyWh == null ? "--" : formatEnergyDelta(averageTargetEnergyWh - targetEnergyPerLapWh)}</td>
@@ -5235,9 +5202,7 @@ function LiveLapTable({
           </div>
           <div className="lapMiniGrid">
             <Metric label="Time" value={lastLap == null ? "--" : formatLapTime(lastLap.durationMs)} />
-            <Metric label="Net" value={lastLap == null ? "--" : `${lastLap.energyWh.toFixed(1)} Wh`} />
-            <Metric label="Drive" value={lastLap == null ? "--" : `${lapEnergyOutWh(lastLap).toFixed(1)} Wh`} />
-            <Metric label="Regen" value={lastLap == null ? "--" : `${lapEnergyInWh(lastLap).toFixed(1)} Wh`} />
+            <Metric label="Energy" value={lastLap == null ? "--" : `${lastLap.energyWh.toFixed(1)} Wh`} />
             <Metric label="Target Δ" value={lastLapDeltaWh == null ? "--" : formatEnergyDelta(lastLapDeltaWh)} />
           </div>
         </div>
@@ -5248,9 +5213,7 @@ function LiveLapTable({
           </div>
           <div className="lapMiniGrid">
             <Metric label="Time" value={averages.avgMs == null ? "--" : formatLapTime(averages.avgMs)} />
-            <Metric label="Net" value={averages.avgEnergyWh == null ? "--" : `${averages.avgEnergyWh.toFixed(1)} Wh`} />
-            <Metric label="Drive" value={averages.avgEnergyOutWh == null ? "--" : `${averages.avgEnergyOutWh.toFixed(1)} Wh`} />
-            <Metric label="Regen" value={averages.avgEnergyInWh == null ? "--" : `${averages.avgEnergyInWh.toFixed(1)} Wh`} />
+            <Metric label="Energy" value={averages.avgEnergyWh == null ? "--" : `${averages.avgEnergyWh.toFixed(1)} Wh`} />
             <Metric label="Target Δ" value={averageDeltaWh == null ? "--" : formatEnergyDelta(averageDeltaWh)} />
           </div>
         </div>

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
@@ -132,6 +132,9 @@ type LiveLap = {
   distanceM: number;
   avgSpeedMps: number | null;
   samples: LiveSample[];
+  /** Peak battery (max-cell) temp °C reached during this lap, captured at close
+   *  from the lap's samples. Drives the battery thermal-projection trend. */
+  maxCellTempC?: number;
   notes?: string; // per-lap note (synced to the classifier DB)
 };
 type LiveSessionState = {
@@ -513,6 +516,13 @@ function App() {
   const [recordingBusy, setRecordingBusy] = useState(false);
   const [energyWindowS, setEnergyWindowS] = useState(60);
   const [targetLaps, setTargetLaps] = useState(() => Number(localStorage.getItem("motec-target-laps") || 0));
+  // Battery max-cell-temp limit (°C) for the thermal projection — the line the
+  // projection colors against. Configurable trackside (the team is still dialing
+  // it in); persisted. Default 60 °C (the design target from PTN thermals).
+  const [batteryTempLimitC, setBatteryTempLimitC] = useState(() => {
+    const v = Number(localStorage.getItem("battery-temp-limit-c"));
+    return Number.isFinite(v) && v > 0 ? v : 60;
+  });
   const [targetEnergyKwh, setTargetEnergyKwh] = useState(() => Number(localStorage.getItem("motec-target-energy-kwh") || PACK_ENERGY_KWH));
   const [soeCutoffCellV, setSoeCutoffCellV] = useState(loadSoeCutoffCellV);
   const [selectedLapIds, setSelectedLapIds] = useState<Set<string>>(() => new Set());
@@ -667,6 +677,29 @@ function App() {
   const totalBudgetWh = targetEnergyKwh > 0 ? targetEnergyKwh * 1000 : null;
   const remainingBudgetWh = totalBudgetWh != null ? totalBudgetWh - energyUsedWh : null;
   const lapsRemainingPlan = targetLaps > 0 ? Math.max(0, targetLaps - lapsCompletedPlan) : null;
+
+  // --- battery thermal projection (computa's 80/20 recent-lap trend) ---------
+  // Per-lap PEAK battery temp from SELECTED laps; project to the finish with a
+  // conservative deg/lap slope: max(median(last 3 deltas), last delta), clamped
+  // >= 0 so it catches the end-of-run ramp and biases hot. Frontend-only.
+  const batteryThermalProjection = useMemo(() => {
+    const lapTemps = selectedLaps
+      .map((lap) => lap.maxCellTempC)
+      .filter((t): t is number => t != null && Number.isFinite(t));
+    const currentTemp = maxCellTempFor(filteredLiveState.lastSample);
+    if (lapTemps.length < 2 || currentTemp == null) {
+      return { ready: false as const, lapTemps, currentTemp };
+    }
+    const deltas: number[] = [];
+    for (let i = 1; i < lapTemps.length; i++) deltas.push(lapTemps[i] - lapTemps[i - 1]);
+    const recent = deltas.slice(-3);
+    const slopeDegPerLap = Math.max(0, Math.max(medianOf(recent), deltas[deltas.length - 1]));
+    const projectedFinishTemp = lapsRemainingPlan != null
+      ? currentTemp + slopeDegPerLap * lapsRemainingPlan
+      : null;
+    return { ready: true as const, lapTemps, currentTemp, slopeDegPerLap, projectedFinishTemp };
+  }, [selectedLaps, filteredLiveState.lastSample, lapsRemainingPlan]);
+
   // Headline budget: how much you can spend on EACH remaining lap from here.
   // Over-use shrinks remaining Wh → this drops; under-use grows it → this rises.
   const dynamicLapBudgetWh = remainingBudgetWh != null && lapsRemainingPlan != null && lapsRemainingPlan > 0
@@ -2239,6 +2272,7 @@ function App() {
             distanceM: lapDistanceM,
             avgSpeedMps: durationMs > 0 && lapDistanceM > 0 ? lapDistanceM / (durationMs / 1000) : null,
             samples: [],
+            maxCellTempC: lapMaxCellTempC(lapSamples),
           };
           laps.push(completedLap);
         }
@@ -2357,6 +2391,7 @@ function App() {
       distanceM: current.lapDistanceM,
       avgSpeedMps: durationMs > 0 && current.lapDistanceM > 0 ? current.lapDistanceM / (durationMs / 1000) : null,
       samples: [],
+      maxCellTempC: lapMaxCellTempC(current.lapSamples),
     };
     laps.push(completedLap);
     const nextState = {
@@ -3574,6 +3609,14 @@ function App() {
                   windowS={energyWindowS}
                 />
               </Panel>
+              <BatteryThermalProjectionPanel
+                projection={batteryThermalProjection}
+                targetLaps={targetLaps}
+                lapsCompleted={lapsCompletedPlan}
+                limitC={batteryTempLimitC}
+                onLimitC={(v) => { setBatteryTempLimitC(v); localStorage.setItem("battery-temp-limit-c", String(v)); }}
+                isMirror={isMirror}
+              />
               <Panel title="Vitals Window" icon={<Gauge size={18} />}>
                 <VitalsWindowChart state={filteredLiveState} windowS={energyWindowS} />
               </Panel>
@@ -4546,6 +4589,88 @@ function TractionControlPanel({ sample }: { sample: LiveSample | null }) {
         <Metric label="Final (TC)" value={fmtNm(finalTq)} tone={tcActive ? "" : "good"} />
       </div>
       <small className="muted">VCU torque path: lookup → derated → power-limited → traction-controlled.</small>
+    </Panel>
+  );
+}
+
+// Battery thermal projection — computa's 80/20 recent-lap trend (NOT a thermal
+// model). Plots per-lap PEAK battery temp vs lap, then a dashed projection from
+// the current temp to the finish at the recent deg/lap slope, against a limit
+// line. Battery only. "Color by margin to limit, not confidence."
+function BatteryThermalProjectionPanel({
+  projection, targetLaps, lapsCompleted, limitC, onLimitC, isMirror,
+}: {
+  projection: { ready: boolean; lapTemps: number[]; currentTemp: number | null; slopeDegPerLap?: number; projectedFinishTemp?: number | null };
+  targetLaps: number;
+  lapsCompleted: number;
+  limitC: number;
+  onLimitC: (v: number) => void;
+  isMirror: boolean;
+}) {
+  const width = 900, height = 180, padLeft = 52, padRight = 16, padTop = 16, padBottom = 28;
+  const plotW = width - padLeft - padRight;
+  const plotH = height - padTop - padBottom;
+  const { ready, lapTemps, currentTemp } = projection;
+  const proj = ready ? projection.projectedFinishTemp ?? null : null;
+  const slope = ready ? projection.slopeDegPerLap ?? 0 : 0;
+  const fmt1 = (v: number | null | undefined) => (v == null ? "--" : v.toFixed(1));
+  const overLimit = proj != null && proj >= limitC;
+  const nearLimit = proj != null && proj >= limitC - 5;
+  const projColor = overLimit ? "#ff4d4f" : nearLimit ? "#FFD700" : "var(--fresh)";
+
+  const limitInput = (
+    <label>
+      <span>Limit °C</span>
+      <input
+        type="number" min={20} max={120} step={1} value={limitC} disabled={isMirror}
+        onChange={(e) => onLimitC(Math.max(20, Math.min(120, Number(e.target.value) || 60)))}
+      />
+    </label>
+  );
+
+  if (!ready || currentTemp == null) {
+    return (
+      <Panel title="Battery Thermal Projection" icon={<Thermometer size={18} />}
+        headerRight={<span style={{ opacity: 0.7 }}>collecting…</span>}>
+        <div className="energyToolbar">{limitInput}</div>
+        <small className="muted">Collecting — need 2+ completed (selected) laps with battery temp to project.</small>
+      </Panel>
+    );
+  }
+
+  const xMax = Math.max(targetLaps || 0, lapsCompleted, lapTemps.length, 1);
+  const xOf = (lap: number) => padLeft + (lap / xMax) * plotW;
+  const ys = [...lapTemps, limitC, currentTemp];
+  if (proj != null) ys.push(proj);
+  const yLo = Math.min(...ys) - 3;
+  const yHi = Math.max(...ys) + 3;
+  const yOf = (t: number) => padTop + (1 - (t - yLo) / Math.max(1, yHi - yLo)) * plotH;
+  const histPts = lapTemps.map((t, i) => `${xOf(i + 1).toFixed(1)},${yOf(t).toFixed(1)}`).join(" ");
+
+  return (
+    <Panel title="Battery Thermal Projection" icon={<Thermometer size={18} />}
+      headerRight={<span style={{ color: projColor }}><strong>{fmt1(currentTemp)}</strong>°C now → <strong>{fmt1(proj)}</strong>°C @ finish</span>}>
+      <div className="energyToolbar">
+        <Metric label="Now" value={`${fmt1(currentTemp)} °C`} />
+        <Metric label="@ Finish" value={proj == null ? "--" : `${fmt1(proj)} °C`} />
+        <Metric label="Trend" value={`+${fmt1(slope)} °C/lap`} />
+        {limitInput}
+      </div>
+      <svg className="energyChart" viewBox={`0 0 ${width} ${height}`} role="img" aria-label="Battery temperature projected to finish">
+        <rect x={padLeft} y={padTop} width={plotW} height={plotH} rx="6" />
+        <line className="thermalLimitLine" x1={padLeft} x2={width - padRight} y1={yOf(limitC)} y2={yOf(limitC)} />
+        <text x={width - padRight} y={yOf(limitC) - 4} textAnchor="end">limit {limitC}°C</text>
+        {histPts ? <polyline className="energyNetLine" points={histPts} /> : null}
+        {proj != null && targetLaps > 0 ? (
+          <line className="thermalProjLine" x1={xOf(lapsCompleted)} y1={yOf(currentTemp)} x2={xOf(targetLaps)} y2={yOf(proj)} style={{ stroke: projColor }} />
+        ) : null}
+        <circle className="thermalNowDot" cx={xOf(lapsCompleted)} cy={yOf(currentTemp)} r="4" />
+        <text x={padLeft} y={height - 8}>lap 0</text>
+        <text x={width - padRight - 36} y={height - 8}>{targetLaps > 0 ? `lap ${targetLaps}` : "now"}</text>
+        <text x={8} y={padTop + 10}>{yHi.toFixed(0)}°C</text>
+        <text x={8} y={height - padBottom}>{yLo.toFixed(0)}°C</text>
+      </svg>
+      <small className="muted">Linear recent-lap trend — projects current battery temp by deg/lap to the finish (selected laps, biased hot). Not a thermal model.</small>
     </Panel>
   );
 }
@@ -6674,6 +6799,24 @@ function maxCellTempFor(sample: LiveSample | null) {
     firstLiveValue(sample.values, ["cell_bottom_temp", "thermal_cell_bottom_temp"]),
   ].map(validTemp).filter((value): value is number => value != null && value > 0);
   return candidates.length ? Math.max(...candidates) : null;
+}
+
+// Peak battery (max-cell) temp °C over a lap's samples — captured at lap close
+// as the lap's representative battery temp for the thermal-projection trend.
+function lapMaxCellTempC(samples: LiveSample[]): number | undefined {
+  let max: number | null = null;
+  for (const s of samples) {
+    const t = maxCellTempFor(s);
+    if (t != null && (max == null || t > max)) max = t;
+  }
+  return max ?? undefined;
+}
+
+function medianOf(values: number[]): number {
+  if (!values.length) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
 }
 
 function packVoltageFor(sample: LiveSample | null) {

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
@@ -523,6 +523,9 @@ function App() {
     const v = Number(localStorage.getItem("battery-temp-limit-c"));
     return Number.isFinite(v) && v > 0 ? v : 60;
   });
+  // Diagnostics & charts (Live Data, energy/temp windows, non-battery temps) are
+  // collapsed by default so the glance panels fit without scrolling. Persisted.
+  const [showDiagnostics, setShowDiagnostics] = useState(() => localStorage.getItem("live-show-diagnostics") === "1");
   const [targetEnergyKwh, setTargetEnergyKwh] = useState(() => Number(localStorage.getItem("motec-target-energy-kwh") || PACK_ENERGY_KWH));
   const [soeCutoffCellV, setSoeCutoffCellV] = useState(loadSoeCutoffCellV);
   const [selectedLapIds, setSelectedLapIds] = useState<Set<string>>(() => new Set());
@@ -652,6 +655,8 @@ function App() {
     samples: filteredLiveSamples,
   }), [liveState, filteredLiveLastSample, filteredLiveSamples]);
   const bestLap = useMemo(() => liveState.laps.reduce<LiveLap | null>((best, lap) => (!best || lap.durationMs < best.durationMs ? lap : best), null), [liveState.laps]);
+  // Most recently completed lap — drives the hero "Last lap" (net + time) tile.
+  const lastLap = liveState.laps.length ? liveState.laps[liveState.laps.length - 1] : null;
   const bestSectors = useMemo(() => bestSectorTimes(liveState.laps), [liveState.laps]);
   const torqueParamSet = useMemo(
     () => VCU_TORQUE_PARAM_SETS.find((item) => item.id === torqueParamSetId) ?? VCU_TORQUE_PARAM_SETS[0],
@@ -3391,9 +3396,16 @@ function App() {
             <div className="liveHeroStats">
               {/* Tier 1 race-state metrics — biggest, glanced every second. */}
               <div className="heroMetricRow">
+                <div className="heroLapBig">
+                  <small>LAP</small>
+                  <strong>{currentLapNumber}<span className="heroLapTarget"> / {targetLaps > 0 ? targetLaps : "—"}</span></strong>
+                </div>
+                <div className="heroLastLap">
+                  <small>LAST LAP</small>
+                  <strong>{lastLap ? formatLapTime(lastLap.durationMs) : "--:--"}</strong>
+                  <span>{lastLap ? `${lastLap.energyWh.toFixed(0)} Wh net` : "—"}</span>
+                </div>
                 <Metric label="Best" value={bestLap ? formatLapTime(bestLap.durationMs) : "--"} tone="purple" />
-                <Metric label="Lap" value={`${currentLapNumber} / ${targetLaps > 0 ? targetLaps : "—"}`} />
-                <Metric label="Energy" value={`${liveState.totalEnergyWh.toFixed(1)} Wh`} />
               </div>
               {/* Tier 2 — compact inline strip, smaller because they're checked
                   every few seconds, not every second. */}
@@ -3577,38 +3589,7 @@ function App() {
               <TractionControlPanel sample={filteredLiveState.lastSample} />
             </div>
             <div className="liveMainColumn">
-              {/* Live Position hidden until chudpi/GPS is reliable. The RadioLion
-                  receiver's draw browns out the chudpi rail, so no fix reaches
-                  the website. Re-enable this Panel block once chudpi power is
-                  fixed. */}
-              {/*
-              <Panel title="Live Position" icon={<MapPinned size={18} />} className="liveMapPanel">
-                <TrackBuilderMap
-                  points={filteredLiveState.samples.filter(hasGps).map((sample) => ({ t: sample.t, lat: sample.lat ?? 0, lon: sample.lon ?? 0 }))}
-                  liveSample={filteredLiveState.lastSample}
-                  gates={track.gates}
-                  drawMode={null}
-                  onDrawGate={handleDrawGate}
-                  center={builderCenter}
-                  onCenter={setBuilderCenter}
-                  targetSpanM={selectedTrackView?.spanM}
-                  gpsUnavailable={filteredLiveState.lastSample != null && !filteredLiveState.samples.some(hasGps)}
-                />
-              </Panel>
-              */}
-              <Panel title="Energy Window" icon={<Zap size={18} />}>
-                <EnergyWindowChart
-                  state={filteredLiveState}
-                  windowS={energyWindowS}
-                  onWindowS={setEnergyWindowS}
-                />
-              </Panel>
-              <Panel title="Temperature Window" icon={<Thermometer size={18} />}>
-                <TemperatureWindowChart
-                  state={filteredLiveState}
-                  windowS={energyWindowS}
-                />
-              </Panel>
+              {/* Primary glance: battery thermals + vitals up top. */}
               <BatteryThermalProjectionPanel
                 projection={batteryThermalProjection}
                 targetLaps={targetLaps}
@@ -3620,13 +3601,39 @@ function App() {
               <Panel title="Vitals Window" icon={<Gauge size={18} />}>
                 <VitalsWindowChart state={filteredLiveState} windowS={energyWindowS} />
               </Panel>
-              {/* G-Forces hidden until the chudpi power issue is fixed — the
-                  RadioLion GPS receiver's draw is browning out the chudpi rail
-                  so no PIMU sentences reach cand. Re-enable with <GForcePanel
-                  state={filteredLiveState} /> once the chudpi holds a stable
-                  link. */}
+              {/* Cool-to-see, lower priority — kept visible but below the glance set. */}
               <DriverControlsPanel sample={filteredLiveState.lastSample} torqueParamSet={torqueParamSet} />
-              <TempsStatusPanel sample={filteredLiveState.lastSample} />
+              {/* Diagnostics & charts — collapsed by default so the glance panels
+                  fit without scrolling. Live Data (right rail) collapses too. */}
+              <button
+                type="button"
+                className="diagToggle"
+                onClick={() => setShowDiagnostics((v) => { const n = !v; localStorage.setItem("live-show-diagnostics", n ? "1" : "0"); return n; })}
+                aria-expanded={showDiagnostics}
+              >
+                <ChevronRight size={15} style={{ transform: showDiagnostics ? "rotate(90deg)" : "none", transition: "transform 0.15s" }} />
+                Diagnostics &amp; charts
+              </button>
+              {showDiagnostics ? (
+                <>
+                  <Panel title="Energy Window" icon={<Zap size={18} />}>
+                    <EnergyWindowChart
+                      state={filteredLiveState}
+                      windowS={energyWindowS}
+                      onWindowS={setEnergyWindowS}
+                    />
+                  </Panel>
+                  <Panel title="Temperature Window" icon={<Thermometer size={18} />}>
+                    <TemperatureWindowChart
+                      state={filteredLiveState}
+                      windowS={energyWindowS}
+                    />
+                  </Panel>
+                  {/* Non-battery temps (motor/inverter/coolant) — battery is the
+                      thermal priority; these live in diagnostics. */}
+                  <TempsStatusPanel sample={filteredLiveState.lastSample} />
+                </>
+              ) : null}
             </div>
             <div className="rightRail">
               {/* Energy Strategy widget hidden for now — revisit later.
@@ -3639,9 +3646,11 @@ function App() {
                 averages={lapAverages}
               />
               */}
-              <Panel title="Live Data" icon={<Gauge size={18} />}>
-                <LiveDataPanel state={filteredLiveState} />
-              </Panel>
+              {showDiagnostics ? (
+                <Panel title="Live Data" icon={<Gauge size={18} />}>
+                  <LiveDataPanel state={filteredLiveState} />
+                </Panel>
+              ) : null}
               <Panel title="Live Setup" icon={<SlidersHorizontal size={18} />}>
                 <div className="trackForm">
                   <label>
@@ -5253,7 +5262,23 @@ function LiveLapTable({
             </tr>
           </thead>
           <tbody>
-            {laps.map((lap) => {
+            {/* Recent-at-top: in-progress lap first, then completed laps newest-first. */}
+            {currentLapElapsedMs > 0 ? (
+              <tr className="currentLapRow">
+                <td>
+                  <span className="lapCurrentDot" aria-hidden="true" />
+                </td>
+                <td>Current</td>
+                <td>{formatLapTime(currentLapElapsedMs)}</td>
+                {Array.from({ length: columns }, (_unused, index) => (
+                  <td key={`current-sector-${index}`}>{currentSectors[index] == null ? "--" : formatLapTime(currentSectors[index])}</td>
+                ))}
+                <td>{currentLapEnergyWh.toFixed(1)} Wh</td>
+                {targetEnergyPerLapWh != null ? <td>{formatEnergyDelta(currentTargetEnergyWh - targetEnergyPerLapWh)}</td> : null}
+                <td />
+              </tr>
+            ) : null}
+            {[...laps].reverse().map((lap) => {
               const selected = selectedLapIds.has(lap.id);
               const targetEnergyWh = lap.energyWh;
               const delta = targetEnergyPerLapWh != null ? targetEnergyWh - targetEnergyPerLapWh : null;
@@ -5317,21 +5342,6 @@ function LiveLapTable({
             {!laps.length && currentLapElapsedMs <= 0 ? (
               <tr>
                 <td colSpan={totalCols}>No completed flying laps yet. Out lap and in lap are excluded from best lap.</td>
-              </tr>
-            ) : null}
-            {currentLapElapsedMs > 0 ? (
-              <tr className="currentLapRow">
-                <td>
-                  <span className="lapCurrentDot" aria-hidden="true" />
-                </td>
-                <td>Current</td>
-                <td>{formatLapTime(currentLapElapsedMs)}</td>
-                {Array.from({ length: columns }, (_unused, index) => (
-                  <td key={`current-sector-${index}`}>{currentSectors[index] == null ? "--" : formatLapTime(currentSectors[index])}</td>
-                ))}
-                <td>{currentLapEnergyWh.toFixed(1)} Wh</td>
-                {targetEnergyPerLapWh != null ? <td>{formatEnergyDelta(currentTargetEnergyWh - targetEnergyPerLapWh)}</td> : null}
-                <td />
               </tr>
             ) : null}
           </tbody>

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
@@ -3482,6 +3482,7 @@ function App() {
                 />
               </Panel>
               <PackStatusPanel state={liveState} displayState={filteredLiveState} soeCutoffCellV={soeCutoffCellV} />
+              <CellThermalsPanel sample={filteredLiveState.lastSample} />
               {/* Live energy-plan tiles: used vs remaining + laps done/left +
                   live per-lap budget that recomputes from energy used each
                   completed lap. Configured up in Live Setup; surfaced here
@@ -4517,6 +4518,60 @@ function TractionControlPanel({ sample }: { sample: LiveSample | null }) {
         <Metric label="Final (TC)" value={fmtNm(finalTq)} tone={tcActive ? "" : "good"} />
       </div>
       <small className="muted">VCU torque path: lookup → derated → power-limited → traction-controlled.</small>
+    </Panel>
+  );
+}
+
+// Realtime per-cell thermal grid (Grafana-style heatmap). Reads the cellTemps
+// array carried through the derived feed — same data dashd uses on-car. Each
+// populated cell (temp > 0; the array is zero-padded for cells not yet reported)
+// is a colored tile on a fixed 20-60 °C blue→red scale so colors mean the same
+// thing across sessions.
+function CellThermalsPanel({ sample }: { sample: LiveSample | null }) {
+  const populated = (sample?.cellTemps ?? [])
+    .map((t, i) => ({ i, t }))
+    .filter((c) => c.t > 0);
+  if (!populated.length) {
+    return (
+      <Panel title="Cell Thermals" icon={<Thermometer size={18} />}>
+        <small className="muted">No per-cell temperatures in the live feed yet.</small>
+      </Panel>
+    );
+  }
+  const vals = populated.map((c) => c.t);
+  const min = Math.min(...vals);
+  const max = Math.max(...vals);
+  const avg = vals.reduce((a, b) => a + b, 0) / vals.length;
+  const LO = 20, HI = 60; // fixed color domain (°C)
+  const cellColor = (t: number) => {
+    const frac = Math.max(0, Math.min(1, (t - LO) / (HI - LO)));
+    return `hsl(${Math.round(220 - 220 * frac)}, 70%, 45%)`; // 220 blue (cool) → 0 red (hot)
+  };
+  return (
+    <Panel
+      title="Cell Thermals"
+      icon={<Thermometer size={18} />}
+      headerRight={
+        <>{populated.length} cells · min <strong>{min.toFixed(0)}</strong> · avg <strong>{avg.toFixed(0)}</strong> · max <strong style={{ color: "#ff6b4a" }}>{max.toFixed(0)}</strong> °C</>
+      }
+    >
+      <div className="cellThermalGrid">
+        {populated.map((c) => (
+          <div
+            key={c.i}
+            className="cellThermalCell"
+            style={{ background: cellColor(c.t) }}
+            title={`Cell ${c.i}: ${c.t.toFixed(1)} °C`}
+          >
+            {c.t.toFixed(0)}
+          </div>
+        ))}
+      </div>
+      <div className="cellThermalLegend">
+        <span>{LO}°C</span>
+        <div className="cellThermalScale" />
+        <span>≥{HI}°C</span>
+      </div>
     </Panel>
   );
 }
@@ -6609,10 +6664,19 @@ function validCellVoltage(value: number | null | undefined): value is number {
 
 function maxCellTempFor(sample: LiveSample | null) {
   if (!sample) return null;
+  // Prefer the per-cell array — the same source dashd uses — taking the max over
+  // POSITIVE temps so the zero-padded unreported slots don't count. This is the
+  // fix for "Max Cell T stuck at 0": the old path read cell_top_temp (CAN 0x132),
+  // which HVC doesn't emit, so it sat at 0. Fall back to the enricher's
+  // max_cell_temp scalar, then the legacy 0x132 fields; require > 0 so a no-data
+  // 0 reads as "--" instead of a misleading 0.
+  const fromArray = sample.cellTemps?.filter((t) => t > 0) ?? [];
+  if (fromArray.length) return Math.max(...fromArray);
   const candidates = [
+    firstLiveValue(sample.values, ["max_cell_temp"]),
     firstLiveValue(sample.values, ["cell_top_temp", "thermal_cell_top_temp"]),
     firstLiveValue(sample.values, ["cell_bottom_temp", "thermal_cell_bottom_temp"]),
-  ].map(validTemp).filter((value): value is number => value != null);
+  ].map(validTemp).filter((value): value is number => value != null && value > 0);
   return candidates.length ? Math.max(...candidates) : null;
 }
 

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/trackside.css
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/trackside.css
@@ -1183,6 +1183,43 @@ textarea:focus-visible,
 }
 .opsCards, .liveHeroStats { min-width: 0; }
 .opsCards { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: var(--s-2); }
+
+/* Cell-thermals heatmap grid (realtime per-cell pack temps). */
+.cellThermalGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(34px, 1fr));
+  gap: 3px;
+}
+.cellThermalCell {
+  aspect-ratio: 1 / 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--r-sm);
+  font-size: 0.72rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: #fff;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.55);
+  cursor: default;
+}
+.cellThermalLegend {
+  display: flex;
+  align-items: center;
+  gap: var(--s-2);
+  margin-top: var(--s-2);
+  font-size: var(--fs-sm);
+  opacity: 0.75;
+  font-variant-numeric: tabular-nums;
+}
+.cellThermalScale {
+  flex: 1;
+  height: 8px;
+  border-radius: 4px;
+  /* Match cellColor(): hsl 220 (cool) -> 0 (hot). */
+  background: linear-gradient(to right,
+    hsl(220, 70%, 45%), hsl(165, 70%, 45%), hsl(110, 70%, 45%), hsl(55, 70%, 45%), hsl(0, 70%, 45%));
+}
 /* Energy Plan tiles live in the leftRail (narrow), so the values like
    "450 / 4150 Wh" don't fit a 4-col grid. Use horizontal pills: small
    label on top of the value, font sized to fit a compact tile, and the

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/trackside.css
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/trackside.css
@@ -1460,8 +1460,7 @@ textarea:focus-visible,
 .energyChart rect { fill: var(--surface-alt); stroke: var(--border); }
 .energyChart line { stroke: var(--border); stroke-width: 1; }
 .energyChart polyline { fill: none; stroke: var(--info); stroke-width: 3; stroke-linejoin: round; stroke-linecap: round; }
-.energyChart .energyInLine { stroke: var(--good); }
-.energyChart .energyOutLine { stroke: var(--info); }
+.energyChart .energyNetLine { stroke: var(--accent); }
 .energyChart text { font-weight: 800; }
 .energyChart .lapBreak line { stroke: var(--best); stroke-dasharray: 4 4; }
 .energyChart .lapBreak text { fill: var(--best); }

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/trackside.css
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/trackside.css
@@ -1080,6 +1080,25 @@ textarea:focus-visible,
   gap: var(--s-2);
 }
 .heroMetricRow .metric { min-height: 52px; }
+/* Hero: dominant lap counter + prominent last-lap (net + time). */
+.heroLapBig, .heroLastLap {
+  display: flex; flex-direction: column; justify-content: center; min-width: 0;
+  background: var(--surface-alt); border: 1px solid var(--border);
+  border-radius: var(--r-md); padding: 6px 12px; min-height: 52px;
+}
+.heroLapBig small, .heroLastLap small { color: var(--muted-text); font-size: var(--fs-sm); letter-spacing: 1.5px; }
+.heroLapBig strong { font-size: clamp(2.2rem, 5vw, 3.4rem); line-height: 1; font-variant-numeric: tabular-nums; }
+.heroLapBig .heroLapTarget { font-size: 0.5em; color: var(--muted-text); font-weight: 600; }
+.heroLastLap strong { font-size: clamp(1.6rem, 3.4vw, 2.3rem); line-height: 1.05; font-variant-numeric: tabular-nums; }
+.heroLastLap span { color: var(--muted-text); font-size: var(--fs-sm); font-variant-numeric: tabular-nums; }
+/* Diagnostics & charts collapse toggle. */
+.diagToggle {
+  display: flex; align-items: center; gap: 6px; width: 100%;
+  background: var(--surface-alt); border: 1px solid var(--border); border-radius: var(--r-md);
+  color: var(--muted-text); padding: 8px 12px; margin-top: var(--s-2);
+  cursor: pointer; font-size: var(--fs-sm); font-weight: 600; letter-spacing: 0.3px;
+}
+.diagToggle:hover { border-color: var(--accent); color: var(--text); }
 /* Tier 2: Regen In + Torque — compact inline label/value pairs, no tile chrome
    so they're visibly subordinate to Tier 1. */
 .heroMetricStrip {

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/trackside.css
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/trackside.css
@@ -1461,6 +1461,10 @@ textarea:focus-visible,
 .energyChart line { stroke: var(--border); stroke-width: 1; }
 .energyChart polyline { fill: none; stroke: var(--info); stroke-width: 3; stroke-linejoin: round; stroke-linecap: round; }
 .energyChart .energyNetLine { stroke: var(--accent); }
+/* Battery thermal projection chart */
+.energyChart .thermalLimitLine { stroke: #ff4d4f; stroke-width: 1.5; stroke-dasharray: 6 5; opacity: 0.85; }
+.energyChart .thermalProjLine { stroke-width: 2.6; stroke-dasharray: 7 5; fill: none; stroke-linecap: round; } /* stroke color set inline by margin */
+.energyChart .thermalNowDot { fill: var(--text); }
 .energyChart text { font-weight: 800; }
 .energyChart .lapBreak line { stroke: var(--best); stroke-dasharray: 4 4; }
 .energyChart .lapBreak text { fill: var(--best); }

--- a/telemtry/analysis/database/viewer_tool/src/lib/dash/dashLayout.ts
+++ b/telemtry/analysis/database/viewer_tool/src/lib/dash/dashLayout.ts
@@ -178,13 +178,16 @@ export interface FieldDef {
 
 export const FIELD_CATALOG: FieldDef[] = [
   // The just-finished lap (lap card only — lapCard.* is null on other screens)
-  { bind: 'lapCard.lapNumber', label: 'Lap number', group: 'Lap', defaultFormat: 'int', min: 0, max: 30 },
+  { bind: 'lapCard.lapNumber', label: 'Lap number (card only)', group: 'Lap', defaultFormat: 'int', min: 0, max: 30 },
   { bind: 'lapCard.timeS', label: 'Lap time', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120 },
   { bind: 'lapCard.energyWh', label: 'Lap energy', group: 'Lap', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 400 },
   { bind: 'mqtt.bestLapTime', label: 'Best lap', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120 },
   { bind: 'mqtt.lastLapTime', label: 'Last lap', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120 },
   { bind: 'mqtt.currentLapTime', label: 'Current lap time', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120 },
-  { bind: 'mqtt.lapTrigger', label: 'Lap count', group: 'Lap', defaultFormat: 'int', min: 0, max: 30 },
+  // Live running count of laps COMPLETED (dashd lap_count). Corrects up/down with
+  // trackside in real time — e.g. a deselected double-count / driver-change lap —
+  // so use THIS for a persistent "laps done" readout, not the card-only number.
+  { bind: 'mqtt.lapTrigger', label: 'Laps completed (live)', group: 'Lap', defaultFormat: 'int', min: 0, max: 30 },
   // Pacing / strategy (on-car authoritative pacing snapshot)
   { bind: 'pacing.lapEnergyWh', label: 'Energy (this lap)', group: 'Pacing', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 400 },
   { bind: 'pacing.lapBudgetWh', label: 'Per-lap budget', group: 'Pacing', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 400 },

--- a/telemtry/analysis/database/viewer_tool/src/lib/dash/dashSignals.ts
+++ b/telemtry/analysis/database/viewer_tool/src/lib/dash/dashSignals.ts
@@ -83,6 +83,10 @@ export interface DashSignals {
      *  effect that catches up the car after a missed publish. dashd's forward-only
      *  edge check makes a duplicate publish harmless. */
     republishLap: (value: number) => void;
+    /** Set the dash's absolute completed-lap count WITHOUT firing a card. Used to
+     *  pull the count DOWN when a lap is deselected on the live list (lapTrigger
+     *  is forward-only); dashd adopts this value in either direction. */
+    publishLapCount: (count: number) => void;
     resetLapCounter: () => void;
     /** Push the start/finish gate [lat1,lon1,lat2,lon2] so the car counts laps itself (retained). */
     publishGate: (gate: [number, number, number, number]) => void;
@@ -267,6 +271,17 @@ export function useDashSignals(): DashSignals {
         publish('lapTrigger', value, 1);
     }, [publish]);
 
+    // Absolute lap-count set (no card). dashd adopts it in either direction, so
+    // this is how the count is pulled DOWN after a lap is deselected. Keep the
+    // local lapCounterRef aligned so the next forward sendLap still computes the
+    // right next number. qos 1 — a deliberate correction shouldn't be dropped.
+    const publishLapCount = useCallback((count: number) => {
+        const v = Math.max(0, Math.round(count));
+        lapCounterRef.current = v;
+        setLapsSent(v);
+        publish('lapCount', v, 1);
+    }, [publish]);
+
     // Tell dashd to drop its lap counter + baseline (new session on trackside).
     // Without this the FIRST few clicks of a fresh session would be silently
     // ignored on the car because dashd was still holding the prior session's
@@ -372,6 +387,7 @@ export function useDashSignals(): DashSignals {
         publishTargetPower,
         sendLap,
         republishLap,
+        publishLapCount,
         resetLapCounter,
         publishGate,
         publishLayout,

--- a/telemtry/analysis/database/viewer_tool/src/lib/motec/live.ts
+++ b/telemtry/analysis/database/viewer_tool/src/lib/motec/live.ts
@@ -63,6 +63,14 @@ function flattenNumeric(payload: Record<string, unknown>): Record<string, number
   return out;
 }
 
+// Coerce a JSON array of numbers, PRESERVING index/position (non-numeric -> 0).
+// cells_temps is a fixed-length, zero-padded array (cand fills slots as the
+// per-cell CAN frames arrive), so the index IS the cell id — don't compact it.
+function numArray(value: unknown): number[] | undefined {
+  if (!Array.isArray(value) || value.length === 0) return undefined;
+  return value.map((v) => { const n = num(v); return n === null ? 0 : n; });
+}
+
 function gpsOf(payload: Record<string, unknown>): [number | null, number | null] {
   const lat = num(first(payload, ["latitude", "lat", "gps_latitude", "dynamics_gps_latitude", "dynamics.latitude"]));
   const lon = num(first(payload, ["longitude", "lon", "lng", "gps_longitude", "dynamics_gps_longitude", "dynamics.longitude"]));
@@ -127,7 +135,11 @@ export function normalizeLivePayload(raw: string | Record<string, unknown>, sour
   if (hvC !== null && values.hv_c === undefined) values.hv_c = hvC;
   if (powerKw !== null && values.power_kw === undefined) values.power_kw = powerKw;
 
-  return { t, source, lat, lon, speed, hv_pack_v: hvV, hv_c: hvC, power_kw: powerKw, values };
+  // Per-cell temps: top-level `cells_temps` in the derived feed, `pack.cells_temps`
+  // in the raw sensor_data frames. flattenNumeric drops arrays, so pull it here.
+  const cellTemps = numArray(first(payload, ["cells_temps", "pack.cells_temps", "pack.cellsTemps", "pack_cells_temps"]));
+
+  return { t, source, lat, lon, speed, hv_pack_v: hvV, hv_c: hvC, power_kw: powerKw, values, cellTemps };
 }
 
 // ── Orion-schema enrichment ───────────────────────────────────────────────────

--- a/telemtry/analysis/database/viewer_tool/src/lib/motec/types.ts
+++ b/telemtry/analysis/database/viewer_tool/src/lib/motec/types.ts
@@ -108,6 +108,9 @@ export type LiveSample = {
   hv_c: number | null;
   power_kw: number | null;
   values: Record<string, number>;
+  /** Per-cell pack temperatures (°C) from pack.cells_temps[], carried through
+   *  the derived feed (zero-padded for cells not yet reported this frame). */
+  cellTemps?: number[];
 };
 
 export type LiveStreamEvent =

--- a/telemtry/analysis/database/viewer_tool/src/lib/trackside/types.ts
+++ b/telemtry/analysis/database/viewer_tool/src/lib/trackside/types.ts
@@ -110,6 +110,11 @@ export type LiveSample = {
   hv_c: number | null;
   power_kw: number | null;
   values: Record<string, number>;
+  /** Per-cell pack temperatures (°C) from pack.cells_temps[], carried through
+   *  the derived feed. Zero-padded for cells not yet reported this frame. Kept
+   *  as an array (values{} can't hold it) for the cell-thermals grid + a
+   *  dashd-equivalent zero-filtered max. */
+  cellTemps?: number[];
 };
 
 export type LiveStreamEvent =


### PR DESCRIPTION
## What
- **Fix "Max Cell T" stuck at 0.** It read `cell_top_temp` (CAN `0x132`), which HVC does not emit, so it sat at 0. Now uses the per-cell `cells_temps[]` array — **the same source the driver park dash (dashd) uses on-car** — taking the max over *positive* temps (the array is zero-padded for not-yet-reported cells). Falls back to the enricher's `max_cell_temp` scalar, then the legacy fields; requires `> 0` so genuine no-data reads `--` instead of a misleading 0.
- **New "Cell Thermals" panel** on the Live tab: a Grafana-style heatmap grid of every populated cell, fixed 20–60 °C blue→red scale, with min/avg/max in the header. Tooltip shows cell index + exact °C.

## Why it was 0 (and the dash wasn't)
Two different sources: trackside read the unemitted `0x132` scalar; the dash computes max from the emitted `0x100` `cells_temps[]` array (zero-filtered). This aligns trackside to the dash's source.

## Scope — client-only
The derived feed `grafana_data_orion_derived` **already carries** `cells_temps` (the bridge emits the array; the enricher passes lists through) plus a computed `max_cell_temp`. The only gaps were client-side: trackside read the wrong key, and `flattenNumeric` drops arrays. So this PR touches only the viewer_tool — **no enricher/bridge/firmware changes**.

Changes: `LiveSample` (+`cellTemps`, both type defs), `normalizeLivePayload` extracts the array, `maxCellTempFor` rewrite, `CellThermalsPanel` + CSS.

## Verify
`tsc --noEmit` clean; `next build` green. Data path traced end-to-end (SSE JSON → `event.sample.cellTemps` → stored raw → `smoothLiveSample` preserves via spread → panel).