### PR TITLE
Trackside consolidated: primary-screen + cell-thermals + VCU mode-set (supersedes #300, #307, #308)

### DIFF
--- a/BEVO/cand/main.rs
+++ b/BEVO/cand/main.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use prost::Message;
 use std::collections::HashMap;
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{TcpListener, UdpSocket};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::Path;
@@ -16,7 +16,7 @@ use sensor_proto::config::PacketConfig;
 use sensor_proto::generated_mapping;
 
 #[cfg(target_os = "linux")]
-use socketcan::{CanSocket, EmbeddedFrame, Id, Socket};
+use socketcan::{CanFrame, CanSocket, EmbeddedFrame, Id, Socket, StandardId};
 
 //use std::process::Command;
 
@@ -24,6 +24,10 @@ const MOCK_ADDR_0: &str = "127.0.0.1:5005";
 const MOCK_ADDR_1: &str = "127.0.0.1:5006";
 const SOCKET_PATH: &str = "/tmp/BEVO_cand.sock";
 const PUBLISHD_SOCKET_PATH: &str = "/tmp/BEVO_cand_publishd.sock";
+/// CAN transmit request socket. dashd connects here and sends frame requests;
+/// cand owns the only write socket on the critical bus, so it stays the sole
+/// CAN writer. Wire format below in `can_tx_listener_loop`.
+const CAND_TX_SOCKET_PATH: &str = "/tmp/BEVO_cand_tx.sock";
 const STARTUP_SEMAPHORE_PATH: &str = "/tmp/BEVO_publishd_ready";
 //const OTA_SEMAPHORE_PATH: &str = "/tmp/BEVO_ota_request"; 
 const CAN_INTERFACE_0: &str = "can0";
@@ -113,6 +117,16 @@ fn main() -> Result<()> {
         thread::spawn(move || {
             if let Err(e) = can_socket_reader_loop(can_reader_tx_1, can_interface_1_clone) {
                 eprintln!("[CAND-CAN-1] Error: {:?}", e);
+            }
+        });
+
+        // CAN transmit path on the critical bus (can0) — where the VCU listens.
+        // Single writer thread owns the only TX socket; dashd feeds it frame
+        // requests over CAND_TX_SOCKET_PATH (e.g. the 0x029 VCU Mode Command).
+        let can_interface_tx = can_interface_0.clone();
+        thread::spawn(move || {
+            if let Err(e) = can_tx_listener_loop(can_interface_tx) {
+                eprintln!("[CAND-TX] Error: {:?}", e);
             }
         });
     }
@@ -328,6 +342,57 @@ fn can_socket_reader_loop(raw_tx: Sender<RawCanMessage>, can_interface: String) 
             }
         }
     }
+}
+
+// Single-writer CAN transmit path. dashd connects to CAND_TX_SOCKET_PATH and
+// sends frame requests; we own the only write socket on `can_interface` so cand
+// stays the sole CAN writer. One write socket is opened up front and reused.
+//
+// Wire format per request (13 bytes, fixed):
+//   [0..4]  CAN id   (u32, little-endian; standard 11-bit)
+//   [4]     dlc      (u8, clamped 0..=8)
+//   [5..13] data     (8 bytes; only the first `dlc` are transmitted)
+// A client may send multiple back-to-back requests on one connection.
+#[cfg(target_os = "linux")]
+fn can_tx_listener_loop(can_interface: String) -> Result<()> {
+    let _ = std::fs::remove_file(CAND_TX_SOCKET_PATH);
+    let listener = UnixListener::bind(CAND_TX_SOCKET_PATH)?;
+    let socket = CanSocket::open(&can_interface)?;
+    println!(
+        "[CAND-TX] CAN transmit listener on {} -> {}",
+        CAND_TX_SOCKET_PATH, can_interface
+    );
+    for stream in listener.incoming() {
+        let mut stream = match stream {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        let mut buf = [0u8; 13];
+        // read_exact returns Err at EOF / short read -> connection done.
+        while stream.read_exact(&mut buf).is_ok() {
+            let id = u32::from_le_bytes([buf[0], buf[1], buf[2], buf[3]]);
+            let dlc = (buf[4] as usize).min(8);
+            let data = &buf[5..5 + dlc];
+            let sid = match StandardId::new(id as u16) {
+                Some(s) => s,
+                None => {
+                    eprintln!("[CAND-TX] rejecting non-standard CAN id {:#x}", id);
+                    continue;
+                }
+            };
+            match CanFrame::new(sid, data) {
+                Some(frame) => match socket.write_frame(&frame) {
+                    Ok(()) => println!(
+                        "[CAND-TX] sent CAN {:#05x} dlc={} data={:02x?}",
+                        id, dlc, data
+                    ),
+                    Err(e) => eprintln!("[CAND-TX] write_frame failed: {:?}", e),
+                },
+                None => eprintln!("[CAND-TX] could not build frame (dlc {})", dlc),
+            }
+        }
+    }
+    Ok(())
 }
 
 // reads CAN frames from the mock UDP socket used for local testing.

--- a/BEVO/cand/main.rs
+++ b/BEVO/cand/main.rs
@@ -373,7 +373,10 @@ fn can_tx_listener_loop(can_interface: String) -> Result<()> {
             let id = u32::from_le_bytes([buf[0], buf[1], buf[2], buf[3]]);
             let dlc = (buf[4] as usize).min(8);
             let data = &buf[5..5 + dlc];
-            let sid = match StandardId::new(id as u16) {
+            // Standard CAN ids are 11-bit (<= 0x7FF). Range-check BEFORE casting:
+            // `id as u16` would silently truncate a >16-bit / extended id
+            // (e.g. 0x10005 -> 0x5) and transmit to the wrong node.
+            let sid = match (id <= 0x7FF).then(|| StandardId::new(id as u16)).flatten() {
                 Some(s) => s,
                 None => {
                     eprintln!("[CAND-TX] rejecting non-standard CAN id {:#x}", id);

--- a/BEVO/dashd/frontend/src/components/LapCardOverlay.tsx
+++ b/BEVO/dashd/frontend/src/components/LapCardOverlay.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { LapCardRenderer } from '../LapCardRenderer';
+import { validateLapCardLayout } from '../dashLayout';
+import { useEnergyPacing } from '../hooks/useEnergyPacing';
+import type { DashMessage } from '../types/DashData';
+
+const fmtLapTime = (secs: number | null | undefined): string => {
+    if (secs === null || secs === undefined) return "--:--.--";
+    const m = Math.floor(secs / 60);
+    const s = secs - m * 60;
+    return `${m}:${s.toFixed(2).padStart(5, '0')}`;
+};
+
+// Full-screen lap card — pops on each lapTrigger crossing and clears itself after
+// LAP_CARD_MS (see useEnergyPacing). Rendered by Dashboard (not a single screen) so
+// it floats over WHATEVER screen is active — built-in OR custom driving layout, Park,
+// Shutdown — exactly like the driver-message overlay. It owns its own useEnergyPacing
+// instance; that hook is driven purely by mqtt.lapTrigger, so it stays in sync with
+// any other instance (e.g. ScreenOne's energy readout) without shared state.
+//
+// z-index 1000: below the driver-message overlay (1100) so a strategist nudge still
+// wins, above all screen content.
+export function LapCardOverlay({ data, theme }: { data: DashMessage | null; theme: 'light' | 'dark' }) {
+    const pacing = useEnergyPacing(data);
+    if (!pacing.lapCard) return null;
+
+    // Trackside custom lap-card layout, if one was sent; else the built-in card.
+    // validateLapCardLayout returns null for a missing/malformed layout, so the
+    // driver screen never blanks.
+    const customLayout = validateLapCardLayout(data?.layout);
+    if (customLayout && customLayout.widgets.length) {
+        const ctx = {
+            lapCard: pacing.lapCard,
+            pacing: data?.pacing,
+            can: data?.can,
+            mqtt: data?.mqtt,
+        };
+        return (
+            <div style={{ position: 'absolute', inset: 0, zIndex: 1000 }}>
+                <LapCardRenderer layout={customLayout} data={ctx} scale={1} theme={theme} />
+            </div>
+        );
+    }
+    return (
+        <div style={{
+            position: 'absolute',
+            inset: 0,
+            zIndex: 1000,
+            background: theme === 'light' ? 'rgba(244,241,237,0.94)' : 'rgba(8,8,10,0.92)',
+            backdropFilter: 'blur(6px)',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: '8px'
+        }}>
+            <div className="label-small" style={{ fontSize: '1.4rem', letterSpacing: '8px', color: '#BF5700' }}>
+                LAP {pacing.lapCard.lapNumber}
+            </div>
+            <div className="value-display" style={{ fontSize: '7rem', fontWeight: 'bold', lineHeight: 0.9 }}>
+                {fmtLapTime(pacing.lapCard.timeS)}
+            </div>
+            <div className="value-display" style={{ fontSize: '3rem', fontWeight: 'bold', color: 'var(--fg-secondary)', lineHeight: 1 }}>
+                {Math.round(pacing.lapCard.energyWh)}
+                <span className="label-small" style={{ fontSize: '1.1rem', marginLeft: '8px' }}>Wh / LAP</span>
+            </div>
+        </div>
+    );
+}
+
+export default LapCardOverlay;

--- a/BEVO/dashd/frontend/src/components/LapCardOverlay.tsx
+++ b/BEVO/dashd/frontend/src/components/LapCardOverlay.tsx
@@ -1,8 +1,17 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { LapCardRenderer } from '../LapCardRenderer';
 import { validateLapCardLayout } from '../dashLayout';
-import { useEnergyPacing } from '../hooks/useEnergyPacing';
-import type { DashMessage } from '../types/DashData';
+import { useEnergyPacing, type LapSummary } from '../hooks/useEnergyPacing';
+import type { CanData, MqttData, PacingData, DashMessage } from '../types/DashData';
+
+// The data a lap card renders. Frozen once at lap completion (see below) so the
+// card is a still snapshot of that instant, not a live view.
+interface LapCardCtx {
+    lapCard: LapSummary;
+    pacing?: PacingData;
+    can?: CanData;
+    mqtt?: MqttData;
+}
 
 const fmtLapTime = (secs: number | null | undefined): string => {
     if (secs === null || secs === undefined) return "--:--.--";
@@ -22,7 +31,22 @@ const fmtLapTime = (secs: number | null | undefined): string => {
 // wins, above all screen content.
 export function LapCardOverlay({ data, theme }: { data: DashMessage | null; theme: 'light' | 'dark' }) {
     const pacing = useEnergyPacing(data);
-    if (!pacing.lapCard) return null;
+    const lapCard = pacing.lapCard;
+
+    // A lap card is a SNAPSHOT of the moment the lap completed — freeze the whole
+    // render context (pacing/can/mqtt) the first frame the card appears and reuse
+    // it for the card's lifetime. Otherwise live fields (notably the trackside
+    // mqtt.lapDelta / energyDelta a custom layout may bind) keep ticking for the
+    // seconds the card is up, so the driver sees the delta move on a "finished"
+    // lap. Re-snapshots only when the lap NUMBER changes (the next card).
+    const frozenRef = useRef<LapCardCtx | null>(null);
+    if (lapCard == null) {
+        frozenRef.current = null;
+    } else if (frozenRef.current?.lapCard.lapNumber !== lapCard.lapNumber) {
+        frozenRef.current = { lapCard, pacing: data?.pacing, can: data?.can, mqtt: data?.mqtt };
+    }
+    const frozen = frozenRef.current;
+    if (!frozen) return null;
 
     // Trackside custom lap-card layout, if one was sent; else the built-in card.
     // validateLapCardLayout returns null for a missing/malformed layout, so the
@@ -30,10 +54,10 @@ export function LapCardOverlay({ data, theme }: { data: DashMessage | null; them
     const customLayout = validateLapCardLayout(data?.layout);
     if (customLayout && customLayout.widgets.length) {
         const ctx = {
-            lapCard: pacing.lapCard,
-            pacing: data?.pacing,
-            can: data?.can,
-            mqtt: data?.mqtt,
+            lapCard: frozen.lapCard,
+            pacing: frozen.pacing,
+            can: frozen.can,
+            mqtt: frozen.mqtt,
         };
         return (
             <div style={{ position: 'absolute', inset: 0, zIndex: 1000 }}>
@@ -55,13 +79,13 @@ export function LapCardOverlay({ data, theme }: { data: DashMessage | null; them
             gap: '8px'
         }}>
             <div className="label-small" style={{ fontSize: '1.4rem', letterSpacing: '8px', color: '#BF5700' }}>
-                LAP {pacing.lapCard.lapNumber}
+                LAP {frozen.lapCard.lapNumber}
             </div>
             <div className="value-display" style={{ fontSize: '7rem', fontWeight: 'bold', lineHeight: 0.9 }}>
-                {fmtLapTime(pacing.lapCard.timeS)}
+                {fmtLapTime(frozen.lapCard.timeS)}
             </div>
             <div className="value-display" style={{ fontSize: '3rem', fontWeight: 'bold', color: 'var(--fg-secondary)', lineHeight: 1 }}>
-                {Math.round(pacing.lapCard.energyWh)}
+                {Math.round(frozen.lapCard.energyWh)}
                 <span className="label-small" style={{ fontSize: '1.1rem', marginLeft: '8px' }}>Wh / LAP</span>
             </div>
         </div>

--- a/BEVO/dashd/frontend/src/dashLayout.ts
+++ b/BEVO/dashd/frontend/src/dashLayout.ts
@@ -170,8 +170,12 @@ export interface FieldDef {
 }
 
 export const FIELD_CATALOG: FieldDef[] = [
-  // The just-finished lap (what the card is fundamentally about)
-  { bind: 'lapCard.lapNumber', label: 'Lap number', group: 'Lap', defaultFormat: 'int', min: 0, max: 30 },
+  // The just-finished lap — only populated inside the lap-card popup.
+  { bind: 'lapCard.lapNumber', label: 'Lap number (card only)', group: 'Lap', defaultFormat: 'int', min: 0, max: 30 },
+  // Live running count of laps COMPLETED (dashd lap_count). Corrects up/down with
+  // trackside in real time — e.g. a deselected double-count / driver-change lap.
+  // Use THIS for a persistent "laps done" readout on the driving/park screen.
+  { bind: 'mqtt.lapTrigger', label: 'Laps completed (live)', group: 'Lap', defaultFormat: 'int', min: 0, max: 30 },
   { bind: 'lapCard.timeS', label: 'Lap time', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120 },
   { bind: 'lapCard.energyWh', label: 'Lap energy', group: 'Lap', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 400 },
   { bind: 'mqtt.bestLapTime', label: 'Best lap', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120 },

--- a/BEVO/dashd/frontend/src/dashLayout.ts
+++ b/BEVO/dashd/frontend/src/dashLayout.ts
@@ -61,7 +61,8 @@ export type FormatId =
   | 'raw' | 'int' | 'float1' | 'float2'
   | 'laptime'   // M:SS.ss
   | 'wh' | 'whSigned' | 'kwh'
-  | 'kw' | 'pct' | 'temp' | 'volt' | 'amp' | 'mph';
+  | 'kw' | 'pct' | 'temp' | 'volt' | 'amp' | 'mph'
+  | 'bool';     // ON/OFF — booleans (e.g. can.regenEnabled) coerce to 1/0 in getByPath
 
 export interface BaseWidget {
   id: string;
@@ -203,6 +204,9 @@ export function getByPath(ctx: unknown, path: string): number | null {
     if (cur == null || typeof cur !== 'object') return null;
     cur = (cur as Record<string, unknown>)[key];
   }
+  // Booleans (e.g. can.regenEnabled, contactors) are exposed as 1/0 so they can
+  // bind to value widgets — rendered ON/OFF via the 'bool' format or a valueMap.
+  if (typeof cur === 'boolean') return cur ? 1 : 0;
   return typeof cur === 'number' && Number.isFinite(cur) ? cur : null;
 }
 
@@ -218,6 +222,9 @@ export function valueColor(v: number | null | undefined, base: string, rules?: C
 
 export function formatValue(v: number | null | undefined, fmt: FormatId, decimals?: number): string {
   if (v == null || !Number.isFinite(v)) return '--';
+  // ON/OFF for booleans (already coerced to 1/0 by getByPath). A widget valueMap
+  // (e.g. {0:'OPEN',1:'CLOSED'}) overrides these via applyValueMap.
+  if (fmt === 'bool') return v >= 0.5 ? 'ON' : 'OFF';
   // Optional per-widget precision override. Applies to the numeric formats —
   // keeps kwh's /1000 scaling and whSigned's +/- sign; lap-time ignores it.
   if (decimals != null && Number.isFinite(decimals) && fmt !== 'laptime') {

--- a/BEVO/dashd/frontend/src/screens/Dashboard.tsx
+++ b/BEVO/dashd/frontend/src/screens/Dashboard.tsx
@@ -19,6 +19,16 @@ const SCREENS: { name: string; component: React.FC }[] = [
 const DRIVING_INDEX = SCREENS.findIndex(s => s.name === 'Driving');
 const PARK_INDEX = SCREENS.findIndex(s => s.name === 'PitDiagnostic');
 
+// Trackside debug screen-override names -> SCREENS index. The website publishes
+// one of these on lhre/dash/screen; dashd forwards it as screenOverride and
+// clears it on a real gear change. Unknown names fall through to PRNDL routing.
+const OVERRIDE_INDEX: Record<string, number> = {
+    driving: DRIVING_INDEX,
+    park: PARK_INDEX,
+    shutdown: SCREENS.findIndex(s => s.name === 'Shutdown'),
+    settings: SCREENS.findIndex(s => s.name === 'Settings'),
+};
+
 const Dashboard: React.FC = () => {
     const [screenIndex, setScreenIndex] = useState<number>(0);
     const { data } = useDash();
@@ -51,7 +61,15 @@ const Dashboard: React.FC = () => {
         setScreenIndex(prndl === 'P' ? PARK_INDEX : DRIVING_INDEX);
     }, [prndl]);
 
-    const ActiveScreen = SCREENS[screenIndex].component;
+    // A trackside debug override (if one names a known screen) takes precedence
+    // over PRNDL/Enter routing without disturbing screenIndex — so when it
+    // clears (released from the website, or auto-cleared by dashd on a gear
+    // change) the dash snaps right back to whatever it was showing.
+    const override = data?.screenOverride ?? null;
+    const overrideIndex = override != null ? OVERRIDE_INDEX[override] : undefined;
+    const effectiveIndex = overrideIndex != null && overrideIndex >= 0 ? overrideIndex : screenIndex;
+
+    const ActiveScreen = SCREENS[effectiveIndex].component;
 
     // Driver-message overlay floats on top of WHATEVER screen is active — Drive,
     // Park/PitDiagnostic (built-in OR custom layout), Shutdown, Settings — so a

--- a/BEVO/dashd/frontend/src/screens/Dashboard.tsx
+++ b/BEVO/dashd/frontend/src/screens/Dashboard.tsx
@@ -6,6 +6,7 @@ import Settings from './Settings';
 import { useDash } from '../context/DashContext';
 import { MessageCardRenderer } from '../MessageCardRenderer';
 import { validateMessage } from '../dashMessages';
+import { LapCardOverlay } from '../components/LapCardOverlay';
 
 // Add new screens by appending to this array. Enter cycles in order.
 const SCREENS: { name: string; component: React.FC }[] = [
@@ -63,6 +64,9 @@ const Dashboard: React.FC = () => {
     return (
         <div style={{ width: '100vw', height: '100vh', overflow: 'hidden', position: 'relative' }}>
             <ActiveScreen />
+            {/* Lap card (z-1000) floats over every screen — built-in or custom driving
+                layout, Park, etc. — lifted out of ScreenOne so it isn't tied to one screen. */}
+            <LapCardOverlay data={data} theme={dashTheme} />
             {driverMsg ? (
                 <div style={{ position: 'absolute', inset: 0, zIndex: 1100 }}>
                     <MessageCardRenderer message={driverMsg} theme={dashTheme} scale={1} />

--- a/BEVO/dashd/frontend/src/screens/ScreenOne.tsx
+++ b/BEVO/dashd/frontend/src/screens/ScreenOne.tsx
@@ -136,6 +136,20 @@ const ScreenOne: React.FC = () => {
     const REGEN_MAX_KW = 20;
     const DRIVE_MAX_KW = 80;
 
+    // Trackside custom driving layout, if one was published — replaces the built-in
+    // driving view (the lap-card overlay still floats on top, rendered by Dashboard).
+    // Mirrors PitDiagnostic's custom-layout branch; the built-in view below is the
+    // fallback whenever no layout is set.
+    const customDriving = validateLapCardLayout(data?.drivingLayout);
+    if (customDriving && customDriving.widgets.length) {
+        const ctx = { can: data?.can, pacing: data?.pacing, mqtt: data?.mqtt };
+        return (
+            <div style={{ position: 'absolute', inset: 0, zIndex: 1 }}>
+                <LapCardRenderer layout={customDriving} data={ctx} scale={1} theme={dashTheme} />
+            </div>
+        );
+    }
+
     return (
         <div className="modern-dash-container" style={{ width: '100vw', height: '100vh', position: 'relative' }}>
 
@@ -817,54 +831,8 @@ const ScreenOne: React.FC = () => {
                 </div>
             </div>
 
-            {/* Full-screen lap card — pops on each lapTrigger crossing and
-                clears itself after a few seconds (LAP_CARD_MS in the hook).
-                Shows the just-finished lap's time and net energy so the driver
-                gets a clear glance as they cross start/finish. */}
-            {pacing.lapCard && (() => {
-                // If trackside sent a custom lap-card layout, render it; otherwise
-                // fall back to the built-in card. validateLapCardLayout returns null
-                // for a missing/malformed layout, so the driver screen never blanks.
-                const customLayout = validateLapCardLayout(data?.layout);
-                if (customLayout && customLayout.widgets.length) {
-                    const ctx = {
-                        lapCard: pacing.lapCard,
-                        pacing: data?.pacing,
-                        can: data?.can,
-                        mqtt: data?.mqtt,
-                    };
-                    return (
-                        <div style={{ position: 'absolute', inset: 0, zIndex: 1000 }}>
-                            <LapCardRenderer layout={customLayout} data={ctx} scale={1} theme={dashTheme} />
-                        </div>
-                    );
-                }
-                return (
-                    <div style={{
-                        position: 'absolute',
-                        inset: 0,
-                        zIndex: 1000,
-                        background: dashTheme === 'light' ? 'rgba(244,241,237,0.94)' : 'rgba(8,8,10,0.92)',
-                        backdropFilter: 'blur(6px)',
-                        display: 'flex',
-                        flexDirection: 'column',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        gap: '8px'
-                    }}>
-                        <div className="label-small" style={{ fontSize: '1.4rem', letterSpacing: '8px', color: '#BF5700' }}>
-                            LAP {pacing.lapCard.lapNumber}
-                        </div>
-                        <div className="value-display" style={{ fontSize: '7rem', fontWeight: 'bold', lineHeight: 0.9 }}>
-                            {fmtLapTime(pacing.lapCard.timeS)}
-                        </div>
-                        <div className="value-display" style={{ fontSize: '3rem', fontWeight: 'bold', color: 'var(--fg-secondary)', lineHeight: 1 }}>
-                            {Math.round(pacing.lapCard.energyWh)}
-                            <span className="label-small" style={{ fontSize: '1.1rem', marginLeft: '8px' }}>Wh / LAP</span>
-                        </div>
-                    </div>
-                );
-            })()}
+            {/* Lap card lifted to Dashboard (LapCardOverlay) so it floats over every
+                screen — including a custom driving layout — not just this one. */}
         </div>
     );
 };

--- a/BEVO/dashd/frontend/src/types/DashData.ts
+++ b/BEVO/dashd/frontend/src/types/DashData.ts
@@ -134,6 +134,10 @@ export interface DashMessage {
     // Active driver message to overlay (from lhre/dash/message), forwarded by
     // dashd. Validated at render; absent → nothing shown.
     message?: unknown;
+    // Debug screen override from trackside (lhre/dash/screen): forces the named
+    // screen ("driving"/"park"/"shutdown"/"settings") regardless of PRNDL.
+    // Absent/null → follow PRNDL. Auto-cleared by dashd on a real gear change.
+    screenOverride?: string | null;
 }
 
 // VCU event mode enum (matches firmware VCU_DEFAULT_PARAMS + per-event override

--- a/BEVO/dashd/frontend/src/types/DashData.ts
+++ b/BEVO/dashd/frontend/src/types/DashData.ts
@@ -128,6 +128,9 @@ export interface DashMessage {
     // Website-authored park/pit-screen layout (retained lhre/dash/parkLayout).
     // Validated at render; absent → the built-in park screen is used.
     parkLayout?: unknown;
+    // Website-authored primary/driving-screen layout (retained lhre/dash/drivingLayout).
+    // Validated at render; absent → the built-in driving screen is used.
+    drivingLayout?: unknown;
     // Active driver message to overlay (from lhre/dash/message), forwarded by
     // dashd. Validated at render; absent → nothing shown.
     message?: unknown;

--- a/BEVO/dashd/main.rs
+++ b/BEVO/dashd/main.rs
@@ -282,6 +282,10 @@ struct DashMessage {
     /// None until one is sent → frontend uses its built-in park screen.
     #[serde(rename = "parkLayout", skip_serializing_if = "Option::is_none")]
     park_layout: Option<serde_json::Value>,
+    /// Website-authored primary/driving-screen layout (retained `lhre/dash/drivingLayout`).
+    /// None until one is sent → frontend uses its built-in driving screen.
+    #[serde(rename = "drivingLayout", skip_serializing_if = "Option::is_none")]
+    driving_layout: Option<serde_json::Value>,
     /// Active driver message to overlay now (from `lhre/dash/message`); None when
     /// nothing is showing or it has expired.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -424,6 +428,9 @@ struct DashState {
     /// Website-authored park/pit-screen layout (retained `lhre/dash/parkLayout`).
     /// None → frontend's built-in park screen.
     park_layout: Option<serde_json::Value>,
+    /// Website-authored primary/driving-screen layout (retained `lhre/dash/drivingLayout`).
+    /// None → frontend's built-in driving screen.
+    driving_layout: Option<serde_json::Value>,
     /// Driver-message palette the car holds (retained `lhre/dash/messages`).
     messages: Option<serde_json::Value>,
     /// Active driver message + its expiry (from `lhre/dash/message`). expiry None
@@ -596,6 +603,36 @@ fn load_park_layout() -> Option<serde_json::Value> {
     match serde_json::from_str::<serde_json::Value>(data.trim()) {
         Ok(v) => {
             println!("[DASHD] Restored park layout from {}", path);
+            Some(v)
+        }
+        Err(_) => None,
+    }
+}
+
+// Primary/driving-screen layout — same disk-cache pattern + reboot-durable path
+// as the lap-card and park layouts, own file + env override.
+const DRIVING_LAYOUT_PATH: &str = "/var/lib/bevo-dash/drivinglayout.json";
+
+fn driving_layout_path() -> String {
+    env_or_default("DASHD_DRIVING_LAYOUT_PATH", DRIVING_LAYOUT_PATH)
+}
+
+fn persist_driving_layout(raw: &str) {
+    let path = driving_layout_path();
+    if let Some(dir) = std::path::Path::new(&path).parent() {
+        let _ = std::fs::create_dir_all(dir);
+    }
+    if let Err(e) = std::fs::write(&path, raw) {
+        eprintln!("[DASHD] Failed to persist driving layout: {}", e);
+    }
+}
+
+fn load_driving_layout() -> Option<serde_json::Value> {
+    let path = driving_layout_path();
+    let data = std::fs::read_to_string(&path).ok()?;
+    match serde_json::from_str::<serde_json::Value>(data.trim()) {
+        Ok(v) => {
+            println!("[DASHD] Restored driving layout from {}", path);
             Some(v)
         }
         Err(_) => None,
@@ -915,12 +952,13 @@ fn ws_server_loop(state: Arc<Mutex<DashState>>) {
                                 let pacing = locked.pacing(Instant::now());
                                 let layout = locked.layout.clone();
                                 let park_layout = locked.park_layout.clone();
+                                let driving_layout = locked.driving_layout.clone();
                                 // Expire a timed message before forwarding it.
                                 let message = match locked.message_expiry {
                                     Some(exp) if Instant::now() >= exp => None,
                                     _ => locked.active_message.clone(),
                                 };
-                                DashMessage { seq, can, mqtt, pacing, layout, park_layout, message }
+                                DashMessage { seq, can, mqtt, pacing, layout, park_layout, driving_layout, message }
                             };
 
                             let json = match serde_json::to_string(&message) {
@@ -1091,6 +1129,28 @@ fn mqtt_subscriber_loop(state: Arc<Mutex<DashState>>) {
                             }
                             Err(e) => {
                                 eprintln!("[DASHD] MQTT bad parkLayout payload: {}", e)
+                            }
+                        }
+                        continue;
+                    }
+                    if field == "drivingLayout" {
+                        match serde_json::from_str::<serde_json::Value>(payload_str) {
+                            Ok(v) => {
+                                {
+                                    let mut locked = state.lock().unwrap();
+                                    locked.driving_layout = Some(v);
+                                }
+                                persist_driving_layout(payload_str);
+                                let _ = client.publish(
+                                    format!("{}ack/drivingLayout", MQTT_TOPIC_PREFIX),
+                                    QoS::AtMostOnce,
+                                    true,
+                                    payload_str.as_bytes().to_vec(),
+                                );
+                                println!("[DASHD] Loaded driving layout ({} bytes)", payload_str.len());
+                            }
+                            Err(e) => {
+                                eprintln!("[DASHD] MQTT bad drivingLayout payload: {}", e)
                             }
                         }
                         continue;
@@ -1401,6 +1461,7 @@ fn main() -> Result<()> {
         // Restore the last layout from disk; the retained MQTT topic refreshes it.
         layout: load_layout(),
         park_layout: load_park_layout(),
+        driving_layout: load_driving_layout(),
         messages: None,
         active_message: None,
         message_expiry: None,

--- a/BEVO/dashd/main.rs
+++ b/BEVO/dashd/main.rs
@@ -1221,6 +1221,24 @@ fn mqtt_subscriber_loop(state: Arc<Mutex<DashState>>) {
                                 );
                             }
                         }
+                        "lapCount" => {
+                            // Absolute lap-count correction from trackside (its
+                            // SELECTED completed-lap count). Adopt in EITHER
+                            // direction with NO card and no integrator reset —
+                            // this is how the dash count follows a DESELECT on
+                            // the live list (lapTrigger above is forward-only and
+                            // would ignore a backward value).
+                            let new_count = val.round().max(0.0) as u64;
+                            locked.lap_count = new_count;
+                            locked.last_offcar_trigger = Some(val);
+                            let _ = client.publish(
+                                format!("{}ack/lapCount", MQTT_TOPIC_PREFIX),
+                                QoS::AtMostOnce,
+                                true,
+                                new_count.to_string(),
+                            );
+                            println!("[DASHD] Trackside lapCount -> lap_count {}", new_count);
+                        }
                         "lapReset" => {
                             // Trackside started a new session: drop both the
                             // baseline and the running lap_count. The next

--- a/BEVO/dashd/main.rs
+++ b/BEVO/dashd/main.rs
@@ -293,6 +293,12 @@ struct DashMessage {
     /// nothing is showing or it has expired.
     #[serde(skip_serializing_if = "Option::is_none")]
     message: Option<serde_json::Value>,
+    /// Debug screen override from trackside (`lhre/dash/screen`): forces the dash
+    /// to show a named screen ("driving"/"park"/"shutdown"/"settings") regardless
+    /// of PRNDL. None = follow PRNDL normally. Cleared automatically on a real
+    /// gear transition so it can never strand the driver on the wrong screen.
+    #[serde(rename = "screenOverride", skip_serializing_if = "Option::is_none")]
+    screen_override: Option<String>,
 }
 
 /// Snapshot published to `lhre/dash/state` for the trackside link-health /
@@ -447,6 +453,13 @@ struct DashState {
     /// while a sticky (durationS=0) message is up; both cleared on replace.
     active_message: Option<serde_json::Value>,
     message_expiry: Option<Instant>,
+    /// Debug screen override from trackside (`lhre/dash/screen`). Forces the
+    /// named screen regardless of PRNDL; None = follow PRNDL. Auto-cleared on a
+    /// real gear transition (see `last_prndl`) so it can't strand the driver.
+    screen_override: Option<String>,
+    /// Last PRNDL seen by the IPC loop, for rising-edge detection of a real
+    /// gear change (which clears any active screen_override).
+    last_prndl: Option<&'static str>,
 }
 
 impl DashState {
@@ -876,8 +889,21 @@ fn ipc_reader_loop(state: Arc<Mutex<DashState>>) {
                             let mut locked = state.lock().unwrap();
                             let can_data = extract_can_data(&data, &mut locked.last_qualified_soc);
                             let power = can_data.power;
+                            let new_prndl = can_data.prndl;
                             locked.can = can_data;
                             locked.last_can_update = now;
+
+                            // A real gear change clears any trackside screen
+                            // override — the override is a debug convenience, and
+                            // the driver moving the shifter must always win so we
+                            // can't strand them on the wrong screen at speed.
+                            if let (Some(prev), Some(cur)) = (locked.last_prndl, new_prndl) {
+                                if prev != cur && locked.screen_override.is_some() {
+                                    println!("[DASHD] clearing screen override (PRNDL {} -> {})", prev, cur);
+                                    locked.screen_override = None;
+                                }
+                            }
+                            locked.last_prndl = new_prndl;
 
                             // Integrate energy for this lap: Wh += kW * dt(s) / 3.6.
                             // Regen (negative power) credits back. Budget tracks
@@ -968,7 +994,8 @@ fn ws_server_loop(state: Arc<Mutex<DashState>>) {
                                     Some(exp) if Instant::now() >= exp => None,
                                     _ => locked.active_message.clone(),
                                 };
-                                DashMessage { seq, can, mqtt, pacing, layout, park_layout, driving_layout, message }
+                                let screen_override = locked.screen_override.clone();
+                                DashMessage { seq, can, mqtt, pacing, layout, park_layout, driving_layout, message, screen_override }
                             };
 
                             let json = match serde_json::to_string(&message) {
@@ -1194,6 +1221,22 @@ fn mqtt_subscriber_loop(state: Arc<Mutex<DashState>>) {
                             }
                             Err(e) => eprintln!("[DASHD] MQTT bad message payload: {}", e),
                         }
+                        continue;
+                    }
+
+                    // Debug screen override (lhre/dash/screen): a bare string
+                    // naming the screen to force ("driving"/"park"/"shutdown"/
+                    // "settings"), or "auto"/"" to release back to PRNDL. Not
+                    // numeric — handle before the numeric parse below.
+                    if field == "screen" {
+                        let s = payload_str.trim();
+                        let mut locked = state.lock().unwrap();
+                        locked.screen_override = if s.is_empty() || s == "auto" {
+                            None
+                        } else {
+                            Some(s.to_string())
+                        };
+                        println!("[DASHD] screen override -> {:?}", locked.screen_override);
                         continue;
                     }
 
@@ -1479,6 +1522,8 @@ fn main() -> Result<()> {
         messages: None,
         active_message: None,
         message_expiry: None,
+        screen_override: None,
+        last_prndl: None,
     }));
 
     let ipc_state = Arc::clone(&state);

--- a/BEVO/dashd/main.rs
+++ b/BEVO/dashd/main.rs
@@ -214,6 +214,9 @@ struct MqttData {
     #[serde(rename = "energyDelta")]
     energy_delta: Option<f32>,
 
+    #[serde(rename = "energyDeltaStatic")]
+    energy_delta_static: Option<f32>,
+
     #[serde(rename = "lapsRemaining")]
     laps_remaining: Option<f32>,
 
@@ -323,11 +326,13 @@ struct DashStateMsg {
 struct MqttState {
     lap_delta: Option<f32>,
     energy_delta: Option<f32>,
+    energy_delta_static: Option<f32>,
     laps_remaining: Option<f32>,
     target_power: Option<f32>,
     lap_card_ms: Option<f32>,
     last_lap_delta: Instant,
     last_energy_delta: Instant,
+    last_energy_delta_static: Instant,
     last_laps_remaining: Instant,
     last_target_power: Instant,
 }
@@ -338,11 +343,13 @@ impl MqttState {
         Self {
             lap_delta: None,
             energy_delta: None,
+            energy_delta_static: None,
             laps_remaining: None,
             target_power: None,
             lap_card_ms: None,
             last_lap_delta: epoch,
             last_energy_delta: epoch,
+            last_energy_delta_static: epoch,
             last_laps_remaining: epoch,
             last_target_power: epoch,
         }
@@ -362,6 +369,9 @@ impl MqttState {
             energy_delta: self
                 .energy_delta
                 .filter(|_| now.duration_since(self.last_energy_delta) < MQTT_STALE_TIMEOUT),
+            energy_delta_static: self
+                .energy_delta_static
+                .filter(|_| now.duration_since(self.last_energy_delta_static) < MQTT_STALE_TIMEOUT),
             laps_remaining: self
                 .laps_remaining
                 .filter(|_| now.duration_since(self.last_laps_remaining) < MQTT_STALE_TIMEOUT),
@@ -1216,6 +1226,10 @@ fn mqtt_subscriber_loop(state: Arc<Mutex<DashState>>) {
                         "energyDelta" => {
                             locked.mqtt.energy_delta = Some(val);
                             locked.mqtt.last_energy_delta = now;
+                        }
+                        "energyDeltaStatic" => {
+                            locked.mqtt.energy_delta_static = Some(val);
+                            locked.mqtt.last_energy_delta_static = now;
                         }
                         "lapsRemaining" => {
                             locked.mqtt.laps_remaining = Some(val);

--- a/BEVO/dashd/main.rs
+++ b/BEVO/dashd/main.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use prost::Message;
 use rumqttc::{Client, Event, Incoming, MqttOptions, QoS};
 use serde::Serialize;
-use std::io::Read;
+use std::io::{Read, Write};
 use std::net::TcpListener;
 use std::os::unix::net::UnixStream;
 use std::sync::{Arc, Mutex};
@@ -16,6 +16,11 @@ use sensor_proto::proto::orion::OrionSensorData;
 // ---------------------------------------------------------------------------
 
 const SOCKET_PATH: &str = "/tmp/BEVO_cand.sock";
+/// cand's CAN transmit request socket — dashd relays trackside commands (the
+/// 0x029 VCU Mode Command) here; cand owns the actual CAN write.
+const CAND_TX_SOCKET_PATH: &str = "/tmp/BEVO_cand_tx.sock";
+/// CAN id of the Pi->VCU "VCU Mode Command" packet (see can_packets.csv 0x029).
+const VCU_MODE_COMMAND_ID: u32 = 0x029;
 const WS_PORT: u16 = 8001;
 const WS_SEND_HZ: u64 = 30;
 
@@ -964,6 +969,21 @@ fn ws_server_loop(state: Arc<Mutex<DashState>>) {
 }
 
 // ---------------------------------------------------------------------------
+// Relay a VCU mode command to cand's CAN TX socket. Builds the 13-byte request
+// cand::can_tx_listener_loop expects: u32 LE CAN id, u8 dlc, 8 data bytes. The
+// 0x029 packet is 8 bytes; byte0 = event_mode, bytes 1-7 reserved (left zero).
+// dashd doesn't interpret the mode — it just bridges trackside MQTT -> CAN.
+fn send_can_mode_command(event_mode: u8) -> std::io::Result<()> {
+    let mut req = [0u8; 13];
+    req[0..4].copy_from_slice(&VCU_MODE_COMMAND_ID.to_le_bytes());
+    req[4] = 8; // DLC
+    req[5] = event_mode; // data[0]; data[1..8] reserved
+    let mut stream = UnixStream::connect(CAND_TX_SOCKET_PATH)?;
+    stream.write_all(&req)?;
+    stream.flush()?;
+    Ok(())
+}
+
 // Thread 3: MQTT subscriber — receives off-car computed values
 // ---------------------------------------------------------------------------
 
@@ -1123,6 +1143,35 @@ fn mqtt_subscriber_loop(state: Arc<Mutex<DashState>>) {
                                 }
                             }
                             Err(e) => eprintln!("[DASHD] MQTT bad message payload: {}", e),
+                        }
+                        continue;
+                    }
+
+                    // VCU mode command from trackside (lhre/dash/eventMode).
+                    // Relay it to cand as the 0x029 CAN frame; dashd doesn't act
+                    // on it. The VCU re-broadcasts its active event_mode in 0x1C7,
+                    // which trackside already reads as confirmation (closed loop).
+                    if field == "eventMode" {
+                        match payload_str.trim().parse::<u8>() {
+                            Ok(mode) => match send_can_mode_command(mode) {
+                                Ok(()) => {
+                                    println!("[DASHD] relayed VCU mode command: event_mode={}", mode);
+                                    let _ = client.publish(
+                                        format!("{}ack/eventMode", MQTT_TOPIC_PREFIX),
+                                        QoS::AtMostOnce,
+                                        false,
+                                        payload_str.as_bytes().to_vec(),
+                                    );
+                                }
+                                Err(e) => eprintln!(
+                                    "[DASHD] eventMode relay to cand TX failed (is cand up?): {}",
+                                    e
+                                ),
+                            },
+                            Err(_) => eprintln!(
+                                "[DASHD] MQTT bad eventMode payload: {:?}",
+                                payload_str
+                            ),
                         }
                         continue;
                     }

--- a/BEVO/nonhermetic/assets/can.json
+++ b/BEVO/nonhermetic/assets/can.json
@@ -4794,6 +4794,31 @@
         "bytes": []
     },
     {
+        "packet_id": 41,
+        "packet_name": "VCU Mode Command",
+        "from": [
+            "Pi"
+        ],
+        "to": [
+            "VCU"
+        ],
+        "data_length": 8,
+        "frequency_ms": null,
+        "frequency": null,
+        "quantity": 1,
+        "bus": "Critical",
+        "bytes": [
+            {
+                "index": 0,
+                "start_byte": 0,
+                "name": "Event Mode",
+                "length": 1,
+                "conv_type": "uint8",
+                "precision": 1.0
+            }
+        ]
+    },
+    {
         "packet_id": 80,
         "packet_name": "HVC Charger Command",
         "from": [

--- a/VCU/firmware/Core/Src/app_freertos.c
+++ b/VCU/firmware/Core/Src/app_freertos.c
@@ -120,6 +120,7 @@ void StartControlTask(void *argument);
 static float steering_adc_to_sensor_voltage(float adc_voltage_v);
 static float steering_sensor_voltage_to_percent(float sensor_voltage_v);
 static float steering_sensor_voltage_to_angle_deg(float sensor_voltage_v);
+static const vcu_parameters_t *vcu_params_for_event_mode(uint8_t event_mode);
 
 /* USER CODE END FunctionPrototypes */
 
@@ -239,6 +240,18 @@ static float steering_sensor_voltage_to_percent(float sensor_voltage_v) {
     pct -= 1.0f;
   }
   return pct;
+}
+
+// Maps a trackside-requested event mode (1=accel, 2=skid, 3=autox, 4=endur)
+// to its params table. 0/unrecognized falls back to the firmware default.
+static const vcu_parameters_t *vcu_params_for_event_mode(uint8_t event_mode) {
+  switch (event_mode) {
+    case 1: return &acceleration_params;
+    case 2: return &skidpad_params;
+    case 3: return &autocross_params;
+    case 4: return &endurance_params;
+    default: return &SELECTED_PARAMS;
+  }
 }
 
 // SystemTask: one-time initialization (USB, logging, DFU, ADC DMA, CAN) -----
@@ -375,6 +388,18 @@ void StartControlTask(void *argument) {
 
     // Run control model
     vcu_model_step(&ctx, &in, &out, dt_ms);
+
+    // While parked, allow trackside (0x029 VCU Mode Command) to swap the
+    // active params table on the fly. Only re-init when the requested mode
+    // actually changes the active params, so this is safe to check every loop.
+    if (out.prndl_state == PRNDL_PARK) {
+      const vcu_parameters_t *requested_params =
+          vcu_params_for_event_mode(vcu_can_get_requested_event_mode());
+      if (requested_params->event_mode != s_params.event_mode) {
+        s_params = *requested_params;
+        vcu_model_init(&ctx, &s_params);
+      }
+    }
 
     vcu_can_set_model_inputs(&in);
     vcu_can_set_model_outputs(&out);

--- a/VCU/firmware/vcu/vcu_can.c
+++ b/VCU/firmware/vcu/vcu_can.c
@@ -54,6 +54,9 @@ static can_receive_message_t *inverter_voltage_mailbox_handle = NULL;
 
 static msg_inverter_faults_t inverter_faults_mailbox = {0};
 static can_receive_message_t *inverter_faults_mailbox_handle = NULL;
+
+static msg_vcu_mode_command_t vcu_mode_command_mailbox = {0};
+static can_receive_message_t *vcu_mode_command_mailbox_handle = NULL;
 // #define DUI_R2D_STATUS_TIMEOUT_MS 1000u
 
 // static bool dui_r2d_timed_out_logged = false;
@@ -328,6 +331,10 @@ void vcu_can_set_event_mode(uint8_t event_mode) {
   vcu_state_mailbox.event_mode = event_mode;
 }
 
+uint8_t vcu_can_get_requested_event_mode(void) {
+  return vcu_mode_command_mailbox.event_mode;
+}
+
 static float compute_brake_bias_pct(const vcu_outputs_t *out) {
   static float remembered_brake_bias = 0.0f;
   float total = out->bse1_psi + out->bse2_psi;
@@ -551,4 +558,12 @@ void vcu_can_add_receive_handlers(void) {
                                    inverter_faults_mailbox_handle);
   log_printf(LOG_INFO,
              "[VCU] CAN receive handler for inverter faults registered\n");
+
+  vcu_mode_command_mailbox_handle = can_get_receive_message_handle(
+      &vcu_mode_command_mailbox, VCU_MODE_COMMAND_ID,
+      (CAN_unpack_message_fn)unpack_vcu_mode_command);
+  can_rtos_register_receive_packet(&critical_bus,
+                                   vcu_mode_command_mailbox_handle);
+  log_printf(LOG_INFO,
+             "[VCU] CAN receive handler for VCU mode command registered\n");
 }

--- a/VCU/firmware/vcu/vcu_can.h
+++ b/VCU/firmware/vcu/vcu_can.h
@@ -30,6 +30,10 @@ void vcu_can_set_model_outputs(const vcu_outputs_t *out);
 void vcu_can_set_steering_angle_deg(float steering_angle_deg);
 void vcu_can_set_event_mode(uint8_t event_mode);
 
+// Latest event mode requested by trackside via the VCU Mode Command (0x029).
+// Returns 0 if no command has been received (i.e. use the firmware default).
+uint8_t vcu_can_get_requested_event_mode(void);
+
 bool is_drive_switch_pressed(void);
 
 bool hvc_tractive_ready(void);

--- a/drivers/longhorn-lib/can.json
+++ b/drivers/longhorn-lib/can.json
@@ -4794,6 +4794,185 @@
         "bytes": []
     },
     {
+        "packet_id": 41,
+        "packet_name": "VCU Mode Command",
+        "from": [
+            "Pi"
+        ],
+        "to": [
+            "VCU"
+        ],
+        "data_length": 8,
+        "frequency_ms": null,
+        "frequency": null,
+        "quantity": 1,
+        "bus": "Critical",
+        "bytes": [
+            {
+                "index": 0,
+                "start_byte": 0,
+                "name": "Event Mode",
+                "length": 1,
+                "conv_type": "uint8",
+                "precision": 1.0
+            }
+        ]
+    },
+    {
+        "packet_id": 80,
+        "packet_name": "HVC Charger Command",
+        "from": [
+            "HVC"
+        ],
+        "to": [
+            "Charger"
+        ],
+        "data_length": 7,
+        "frequency_ms": 100,
+        "frequency": 10.0,
+        "quantity": 1,
+        "bus": "Critical",
+        "bytes": [
+            {
+                "index": 0,
+                "start_byte": 0,
+                "name": "Max Charge Voltage",
+                "length": 2,
+                "conv_type": "uint16",
+                "precision": 0.01,
+                "protobuf": {
+                    "type": "float",
+                    "field": "max_charge_voltage",
+                    "proto_id": 36,
+                    "repeated": false,
+                    "field_index": null
+                }
+            },
+            {
+                "index": 1,
+                "start_byte": 2,
+                "name": "Max Charge Current",
+                "length": 2,
+                "conv_type": "uint16",
+                "precision": 0.01,
+                "protobuf": {
+                    "type": "float",
+                    "field": "max_charge_current",
+                    "proto_id": 35,
+                    "repeated": false,
+                    "field_index": null
+                }
+            },
+            {
+                "index": 2,
+                "start_byte": 4,
+                "name": "IMD LED State",
+                "length": 1,
+                "conv_type": "uint8",
+                "precision": 1.0,
+                "protobuf": {
+                    "type": "bool",
+                    "field": "imd_led",
+                    "proto_id": 17,
+                    "repeated": false,
+                    "field_index": null
+                }
+            },
+            {
+                "index": 3,
+                "start_byte": 5,
+                "name": "BMS LED State",
+                "length": 1,
+                "conv_type": "uint8",
+                "precision": 1.0,
+                "protobuf": {
+                    "type": "bool",
+                    "field": "bms_led",
+                    "proto_id": 37,
+                    "repeated": false,
+                    "field_index": null
+                }
+            },
+            {
+                "index": 4,
+                "start_byte": 6,
+                "name": "Charger Enable",
+                "length": 1,
+                "conv_type": "uint8",
+                "precision": 1.0,
+                "protobuf": {
+                    "type": "bool",
+                    "field": "charger_enable",
+                    "proto_id": 38,
+                    "repeated": false,
+                    "field_index": null
+                }
+            }
+        ]
+    },
+    {
+        "packet_id": 81,
+        "packet_name": "Charger Status",
+        "from": [
+            "Charger"
+        ],
+        "to": [
+            "HVC"
+        ],
+        "data_length": 5,
+        "frequency_ms": 100,
+        "frequency": 10.0,
+        "quantity": 1,
+        "bus": "Critical",
+        "bytes": [
+            {
+                "index": 0,
+                "start_byte": 0,
+                "name": "Actual Voltage",
+                "length": 2,
+                "conv_type": "uint16",
+                "precision": 0.01,
+                "protobuf": {
+                    "type": "float",
+                    "field": "charger_voltage",
+                    "proto_id": 15,
+                    "repeated": false,
+                    "field_index": null
+                }
+            },
+            {
+                "index": 1,
+                "start_byte": 2,
+                "name": "Actual Current",
+                "length": 2,
+                "conv_type": "uint16",
+                "precision": 0.01,
+                "protobuf": {
+                    "type": "float",
+                    "field": "charger_current",
+                    "proto_id": 14,
+                    "repeated": false,
+                    "field_index": null
+                }
+            },
+            {
+                "index": 2,
+                "start_byte": 4,
+                "name": "Charger Enabled",
+                "length": 1,
+                "conv_type": "uint8",
+                "precision": 1.0,
+                "protobuf": {
+                    "type": "bool",
+                    "field": "charger_enabled",
+                    "proto_id": 16,
+                    "repeated": false,
+                    "field_index": null
+                }
+            }
+        ]
+    },
+    {
         "packet_id": 48,
         "packet_name": "HVC Bounds Parameters",
         "from": [
@@ -4882,6 +5061,83 @@
                     "type": "float",
                     "field": "regen_energy",
                     "proto_id": 41,
+                    "repeated": false,
+                    "field_index": null
+                }
+            }
+        ]
+    },
+    {
+        "packet_id": 458,
+        "packet_name": "Torque Path",
+        "from": [
+            "VCU"
+        ],
+        "to": [
+            "Pi"
+        ],
+        "data_length": 8,
+        "frequency_ms": 10,
+        "frequency": 100.0,
+        "quantity": 1,
+        "bus": "Critical",
+        "bytes": [
+            {
+                "index": 0,
+                "start_byte": 0,
+                "name": "Torque Lookup",
+                "length": 2,
+                "conv_type": "uint16",
+                "precision": 0.1,
+                "protobuf": {
+                    "type": "float",
+                    "field": "torque_lookup",
+                    "proto_id": 42,
+                    "repeated": false,
+                    "field_index": null
+                }
+            },
+            {
+                "index": 1,
+                "start_byte": 2,
+                "name": "Torque Derated",
+                "length": 2,
+                "conv_type": "uint16",
+                "precision": 0.1,
+                "protobuf": {
+                    "type": "float",
+                    "field": "torque_derated",
+                    "proto_id": 43,
+                    "repeated": false,
+                    "field_index": null
+                }
+            },
+            {
+                "index": 2,
+                "start_byte": 4,
+                "name": "Torque Power Limited",
+                "length": 2,
+                "conv_type": "uint16",
+                "precision": 0.1,
+                "protobuf": {
+                    "type": "float",
+                    "field": "torque_power_limited",
+                    "proto_id": 44,
+                    "repeated": false,
+                    "field_index": null
+                }
+            },
+            {
+                "index": 3,
+                "start_byte": 6,
+                "name": "Torque Traction Controlled",
+                "length": 2,
+                "conv_type": "uint16",
+                "precision": 0.1,
+                "protobuf": {
+                    "type": "float",
+                    "field": "torque_traction_controlled",
+                    "proto_id": 45,
                     "repeated": false,
                     "field_index": null
                 }

--- a/drivers/longhorn-lib/can_ids.c
+++ b/drivers/longhorn-lib/can_ids.c
@@ -2665,6 +2665,113 @@ int unpack_usm_enter_bootloader(const uint8_t* rx_buf, msg_usm_enter_bootloader_
     return 0;
 }
 
+// Packet: VCU Mode Command
+int pack_vcu_mode_command(const msg_vcu_mode_command_t* msg, uint8_t* tx_buf) {
+    memset(tx_buf, 0, VCU_MODE_COMMAND_DLC);
+
+    // Pack: Event Mode
+    tx_buf[0] = (uint8_t)msg->event_mode;
+
+    return 0;
+}
+
+int unpack_vcu_mode_command(const uint8_t* rx_buf, msg_vcu_mode_command_t* msg) {
+    // Unpack: Event Mode
+    msg->event_mode = (uint8_t)rx_buf[0];
+
+    return 0;
+}
+
+// Packet: HVC Charger Command
+int pack_hvc_charger_command(const msg_hvc_charger_command_t* msg, uint8_t* tx_buf) {
+    memset(tx_buf, 0, HVC_CHARGER_COMMAND_DLC);
+
+    // Pack: Max Charge Voltage
+    uint16_t raw_max_charge_voltage = (uint16_t)(msg->max_charge_voltage / 0.01f);
+    tx_buf[0 + 0] = (uint8_t)(raw_max_charge_voltage & 0xFF);
+    tx_buf[0 + 1] = (uint8_t)((raw_max_charge_voltage >> 8) & 0xFF);
+
+    // Pack: Max Charge Current
+    uint16_t raw_max_charge_current = (uint16_t)(msg->max_charge_current / 0.01f);
+    tx_buf[2 + 0] = (uint8_t)(raw_max_charge_current & 0xFF);
+    tx_buf[2 + 1] = (uint8_t)((raw_max_charge_current >> 8) & 0xFF);
+
+    // Pack: IMD LED State
+    tx_buf[4] = (uint8_t)msg->imd_led_state;
+
+    // Pack: BMS LED State
+    tx_buf[5] = (uint8_t)msg->bms_led_state;
+
+    // Pack: Charger Enable
+    tx_buf[6] = (uint8_t)msg->charger_enable;
+
+    return 0;
+}
+
+int unpack_hvc_charger_command(const uint8_t* rx_buf, msg_hvc_charger_command_t* msg) {
+    // Unpack: Max Charge Voltage
+    uint16_t raw_max_charge_voltage = 0;
+    raw_max_charge_voltage = (uint16_t)rx_buf[0 + 0];
+    raw_max_charge_voltage |= (uint16_t)(rx_buf[0 + 1] << 8);
+    msg->max_charge_voltage = (float)raw_max_charge_voltage * 0.01f;
+
+    // Unpack: Max Charge Current
+    uint16_t raw_max_charge_current = 0;
+    raw_max_charge_current = (uint16_t)rx_buf[2 + 0];
+    raw_max_charge_current |= (uint16_t)(rx_buf[2 + 1] << 8);
+    msg->max_charge_current = (float)raw_max_charge_current * 0.01f;
+
+    // Unpack: IMD LED State
+    msg->imd_led_state = (uint8_t)rx_buf[4];
+
+    // Unpack: BMS LED State
+    msg->bms_led_state = (uint8_t)rx_buf[5];
+
+    // Unpack: Charger Enable
+    msg->charger_enable = (uint8_t)rx_buf[6];
+
+    return 0;
+}
+
+// Packet: Charger Status
+int pack_charger_status(const msg_charger_status_t* msg, uint8_t* tx_buf) {
+    memset(tx_buf, 0, CHARGER_STATUS_DLC);
+
+    // Pack: Actual Voltage
+    uint16_t raw_actual_voltage = (uint16_t)(msg->actual_voltage / 0.01f);
+    tx_buf[0 + 0] = (uint8_t)(raw_actual_voltage & 0xFF);
+    tx_buf[0 + 1] = (uint8_t)((raw_actual_voltage >> 8) & 0xFF);
+
+    // Pack: Actual Current
+    uint16_t raw_actual_current = (uint16_t)(msg->actual_current / 0.01f);
+    tx_buf[2 + 0] = (uint8_t)(raw_actual_current & 0xFF);
+    tx_buf[2 + 1] = (uint8_t)((raw_actual_current >> 8) & 0xFF);
+
+    // Pack: Charger Enabled
+    tx_buf[4] = (uint8_t)msg->charger_enabled;
+
+    return 0;
+}
+
+int unpack_charger_status(const uint8_t* rx_buf, msg_charger_status_t* msg) {
+    // Unpack: Actual Voltage
+    uint16_t raw_actual_voltage = 0;
+    raw_actual_voltage = (uint16_t)rx_buf[0 + 0];
+    raw_actual_voltage |= (uint16_t)(rx_buf[0 + 1] << 8);
+    msg->actual_voltage = (float)raw_actual_voltage * 0.01f;
+
+    // Unpack: Actual Current
+    uint16_t raw_actual_current = 0;
+    raw_actual_current = (uint16_t)rx_buf[2 + 0];
+    raw_actual_current |= (uint16_t)(rx_buf[2 + 1] << 8);
+    msg->actual_current = (float)raw_actual_current * 0.01f;
+
+    // Unpack: Charger Enabled
+    msg->charger_enabled = (uint8_t)rx_buf[4];
+
+    return 0;
+}
+
 // Packet: HVC Bounds Parameters
 int pack_hvc_bounds_parameters(const msg_hvc_bounds_parameters_t* msg, uint8_t* tx_buf) {
     memset(tx_buf, 0, HVC_BOUNDS_PARAMETERS_DLC);

--- a/drivers/longhorn-lib/can_ids.h
+++ b/drivers/longhorn-lib/can_ids.h
@@ -1986,6 +1986,90 @@ int pack_usm_enter_bootloader(const msg_usm_enter_bootloader_t* msg, uint8_t* tx
 int unpack_usm_enter_bootloader(const uint8_t* rx_buf, msg_usm_enter_bootloader_t* msg);
 
 // ==========================================================================
+// Packet: VCU Mode Command (41)
+// ==========================================================================
+// From: Pi
+// To:   VCU
+#define VCU_MODE_COMMAND_ID 41
+#define VCU_MODE_COMMAND_DLC 8
+#define VCU_MODE_COMMAND_FREQ 0
+#define VCU_MODE_COMMAND_TIMEOUT_MS 0
+
+typedef struct {
+    uint8_t event_mode;
+} msg_vcu_mode_command_t;
+
+// Signal: Event Mode
+#define VCU_MODE_COMMAND_EVENT_MODE_PREC 1.0f
+
+int pack_vcu_mode_command(const msg_vcu_mode_command_t* msg, uint8_t* tx_buf);
+int unpack_vcu_mode_command(const uint8_t* rx_buf, msg_vcu_mode_command_t* msg);
+
+// ==========================================================================
+// Packet: HVC Charger Command (80)
+// ==========================================================================
+// From: HVC
+// To:   Charger
+#define HVC_CHARGER_COMMAND_ID 80
+#define HVC_CHARGER_COMMAND_DLC 7
+#define HVC_CHARGER_COMMAND_FREQ 100
+#define HVC_CHARGER_COMMAND_TIMEOUT_MS 200
+
+typedef struct {
+    float max_charge_voltage;
+    float max_charge_current;
+    uint8_t imd_led_state;
+    uint8_t bms_led_state;
+    uint8_t charger_enable;
+} msg_hvc_charger_command_t;
+
+// Signal: Max Charge Voltage
+#define HVC_CHARGER_COMMAND_MAX_CHARGE_VOLTAGE_PREC 0.01f
+
+// Signal: Max Charge Current
+#define HVC_CHARGER_COMMAND_MAX_CHARGE_CURRENT_PREC 0.01f
+
+// Signal: IMD LED State
+#define HVC_CHARGER_COMMAND_IMD_LED_STATE_PREC 1.0f
+
+// Signal: BMS LED State
+#define HVC_CHARGER_COMMAND_BMS_LED_STATE_PREC 1.0f
+
+// Signal: Charger Enable
+#define HVC_CHARGER_COMMAND_CHARGER_ENABLE_PREC 1.0f
+
+int pack_hvc_charger_command(const msg_hvc_charger_command_t* msg, uint8_t* tx_buf);
+int unpack_hvc_charger_command(const uint8_t* rx_buf, msg_hvc_charger_command_t* msg);
+
+// ==========================================================================
+// Packet: Charger Status (81)
+// ==========================================================================
+// From: Charger
+// To:   HVC
+#define CHARGER_STATUS_ID 81
+#define CHARGER_STATUS_DLC 5
+#define CHARGER_STATUS_FREQ 100
+#define CHARGER_STATUS_TIMEOUT_MS 200
+
+typedef struct {
+    float actual_voltage;
+    float actual_current;
+    uint8_t charger_enabled;
+} msg_charger_status_t;
+
+// Signal: Actual Voltage
+#define CHARGER_STATUS_ACTUAL_VOLTAGE_PREC 0.01f
+
+// Signal: Actual Current
+#define CHARGER_STATUS_ACTUAL_CURRENT_PREC 0.01f
+
+// Signal: Charger Enabled
+#define CHARGER_STATUS_CHARGER_ENABLED_PREC 1.0f
+
+int pack_charger_status(const msg_charger_status_t* msg, uint8_t* tx_buf);
+int unpack_charger_status(const uint8_t* rx_buf, msg_charger_status_t* msg);
+
+// ==========================================================================
 // Packet: HVC Bounds Parameters (48)
 // ==========================================================================
 // From: Pi
@@ -2052,8 +2136,8 @@ int unpack_energy_estimate(const uint8_t* rx_buf, msg_energy_estimate_t* msg);
 // To:   Pi
 #define TORQUE_PATH_ID 458
 #define TORQUE_PATH_DLC 8
-#define TORQUE_PATH_FREQ 100
-#define TORQUE_PATH_TIMEOUT_MS 200
+#define TORQUE_PATH_FREQ 10
+#define TORQUE_PATH_TIMEOUT_MS 20
 
 typedef struct {
     float torque_lookup;

--- a/drivers/longhorn-lib/config/can_packets.csv
+++ b/drivers/longhorn-lib/config/can_packets.csv
@@ -64,6 +64,7 @@ CAN ID,CAN ID Binary,From,To,Packet Info,Frequency (Hz),Data Length Code (DLC),Q
 0x026,100011,Pi,CSM,CSM Enter Bootloader,NA,1,1,Enable,unused,unused,unused,unused,unused,unused,unused,Critical,,
 0x027,100100,Pi,HVC,HVC Enter Bootloader,NA,1,1,Enable,unused,unused,unused,unused,unused,unused,unused,Critical,,
 0x028,100101,Pi,USM,USM Enter Bootloader,NA,1,1,Enable,unused,unused,unused,unused,unused,unused,unused,Critical,,
+0x029,101001,Pi,VCU,VCU Mode Command,NA,8,1,Event Mode (uint8),unused,unused,unused,unused,unused,unused,unused,Critical,Runtime VCU params-table select; byte0=event_mode (1=accel 2=skid 3=autox 4=endur); bytes1-7 reserved for extensibility,
 0x050,1010000,HVC,Charger,HVC Charger Command,10,7,1,"Max Charge Voltage (uint16, 0.01V); max_charge_voltage (float) #36",,"Max Charge Current (uint16, 0.01A); max_charge_current (float) #35",,"IMD LED State (uint8, bool); imd_led (bool) #17","BMS LED State (uint8, bool); bms_led (bool) #37","Charger Enable (uint8, bool); charger_enable (bool) #38",unused,Critical,,
 0x051,1010001,Charger,HVC,Charger Status,10,5,1,"Actual Voltage (uint16, 0.01V); charger_voltage (float) #15",,"Actual Current (uint16, 0.01A); charger_current (float) #14",,"Charger Enabled (uint8, bool); charger_enabled (bool) #16",unused,unused,unused,Critical,,
 0x030,110000,Pi,HVC,HVC Bounds Parameters,NA,,,,,,,,,,,,,

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
@@ -660,6 +660,14 @@ function App() {
   // + = banked margin vs the even split; − = over budget, must conserve.
   const budgetVsTargetWh = dynamicLapBudgetWh != null && targetEnergyPerLapWh != null
     ? dynamicLapBudgetWh - targetEnergyPerLapWh : null;
+  // --- per-lap strategy deltas published to the car dash (mqtt.lapDelta /
+  // energyDelta / energyDeltaStatic). All from the last COMPLETED lap vs the best
+  // lap / per-lap energy budgets. Null (→ stops publishing, dash shows nothing
+  // rather than a bogus 0) until there's a completed lap + a plan.
+  const lastLap = liveState.laps.length ? liveState.laps[liveState.laps.length - 1] : null;
+  const lapDeltaS = lastLap && bestLap ? (lastLap.durationMs - bestLap.durationMs) / 1000 : null;
+  const energyDeltaDynWh = lastLap && dynamicLapBudgetWh != null ? lastLap.energyWh - dynamicLapBudgetWh : null;
+  const energyDeltaStaticWh = lastLap && targetEnergyPerLapWh != null ? lastLap.energyWh - targetEnergyPerLapWh : null;
   // Auto-derive the dash target power from the energy plan: the live Wh/lap
   // budget ÷ the rolling average lap time is the power rate that spends the
   // budget evenly. A manual override (dashPowerMode='manual') wins when set.
@@ -903,6 +911,16 @@ function App() {
     if (isMirror || dashSignals.status !== "connected") return;
     if (dynamicLapBudgetWh != null) dashSignals.publishLapBudget(Math.round(dynamicLapBudgetWh));
   }, [dynamicLapBudgetWh, isMirror, dashSignals.status, dashSignals.publishLapBudget]);
+
+  // Push the per-lap strategy deltas to the car dash (leader only). Each rides the
+  // dashSignals keepalive; passing null stops it (dashd nulls it after ~5 s).
+  useEffect(() => {
+    if (isMirror || dashSignals.status !== "connected") return;
+    dashSignals.publishLapDelta(lapDeltaS);
+    dashSignals.publishEnergyDelta(energyDeltaDynWh);
+    dashSignals.publishEnergyDeltaStatic(energyDeltaStaticWh);
+    dashSignals.publishLapsRemaining(lapsRemainingPlan);
+  }, [lapDeltaS, energyDeltaDynWh, energyDeltaStaticWh, lapsRemainingPlan, isMirror, dashSignals.status, dashSignals.publishLapDelta, dashSignals.publishEnergyDelta, dashSignals.publishEnergyDeltaStatic, dashSignals.publishLapsRemaining]);
 
   // Push the active driver-message set to the car (retained) whenever it changes
   // or the link (re)connects, so the dash holds the current quick-send palette

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
@@ -2,7 +2,7 @@
 import './trackside.css';
 
 import { useEffect, useMemo, useRef, useState, type ChangeEvent, type Dispatch, type MouseEvent, type ReactNode, type SetStateAction } from "react";
-import { Activity, AlertTriangle, ArrowDown, ArrowUp, CalendarDays, ChevronLeft, ChevronRight, Disc3, Download, FileText, Flag, Gauge, GraduationCap, HelpCircle, MapPinned, Minus, MonitorCog, Moon, NotebookText, Plus, Power, Radio, RefreshCcw, Save, Scissors, SlidersHorizontal, Sun, Target, Thermometer, Timer, Trash2, Upload, Users, WifiOff, X, Zap } from "lucide-react";
+import { Activity, AlertTriangle, ArrowDown, ArrowUp, CalendarDays, ChevronLeft, ChevronRight, Crosshair, Disc3, Download, FileText, Flag, Gauge, GraduationCap, HelpCircle, MapPinned, Minus, MonitorCog, Moon, NotebookText, Plus, Power, Radio, RefreshCcw, Save, Scissors, SlidersHorizontal, Sun, Target, Thermometer, Timer, Trash2, Upload, Users, WifiOff, X, Zap } from "lucide-react";
 import { api } from "@/lib/trackside/api";
 import { useCarStatus, CAR_STATE_META, humanizeReason, type CarState, type CarStatusFeed } from "@/lib/trackside/useCarStatus";
 import { EVENT_TYPES, upsertSession, patchSession, syncRegistryWithServer, type TracksideSessionInfo } from "@/lib/trackside/sessionRegistry";
@@ -3611,6 +3611,7 @@ function App() {
                   center={builderCenter}
                   onCenter={setBuilderCenter}
                   targetSpanM={selectedTrackView?.spanM}
+                  follow
                   gpsUnavailable={filteredLiveState.lastSample != null && !filteredLiveState.samples.some(hasGps)}
                 />
               </Panel>
@@ -5682,6 +5683,7 @@ function TrackBuilderMap({
   onCenter,
   targetSpanM,
   gpsUnavailable = false,
+  follow = false,
 }: {
   points: GpsPoint[];
   liveSample: LiveSample | null;
@@ -5692,11 +5694,19 @@ function TrackBuilderMap({
   onCenter: (center: { lat: number; lon: number }) => void;
   targetSpanM?: number;
   gpsUnavailable?: boolean;
+  // When true, the viewport auto-centers on the live car position (liveSample)
+  // and stays locked on it as it moves. Panning disengages follow; the recenter
+  // button re-engages it. Off for the track-builder usage (manual center).
+  follow?: boolean;
 }) {
   const [drawStart, setDrawStart] = useState<{ x: number; y: number } | null>(null);
   const [drawEnd, setDrawEnd] = useState<{ x: number; y: number } | null>(null);
   const [panStart, setPanStart] = useState<{ x: number; y: number; cx: number; cy: number } | null>(null);
   const [spanM, setSpanM] = useState(520);
+  // Follow-the-car: when `follow` is on, the viewport tracks the live position.
+  // `following` is the live toggle — panning turns it off, the recenter button
+  // turns it back on. Defaults on so the map opens centered on the car.
+  const [following, setFollowing] = useState(true);
   const width = 920;
   const height = 620;
   const pad = 0;
@@ -5704,7 +5714,13 @@ function TrackBuilderMap({
     if (targetSpanM == null) return;
     setSpanM(Math.max(80, Math.min(8000, targetSpanM)));
   }, [targetSpanM]);
-  const projectedCenter = project(center.lat, center.lon);
+  // The car's current position, when follow is enabled and we have a fix.
+  const followPoint = follow && liveSample && liveSample.lat != null && liveSample.lon != null
+    ? { lat: liveSample.lat, lon: liveSample.lon }
+    : null;
+  // Viewport center: lock onto the car while following, else the manual center.
+  const viewCenter = followPoint && following ? followPoint : center;
+  const projectedCenter = project(viewCenter.lat, viewCenter.lon);
   const bounds = mapBoundsFromCenter(projectedCenter.mx, projectedCenter.my, width, height, spanM, pad);
   const tiles = satelliteTiles(bounds);
   const line = points.length >= 2
@@ -5754,6 +5770,12 @@ function TrackBuilderMap({
           return;
         }
         setPanStart({ ...start, cx: projectedCenter.mx, cy: projectedCenter.my });
+        // Grabbing to pan = manual control: hand the current (car) center to the
+        // parent so the drag continues from here, then stop following.
+        if (following && followPoint) {
+          onCenter(followPoint);
+          setFollowing(false);
+        }
       }}
       onMouseMove={(event) => {
         const current = pointer(event);
@@ -5819,6 +5841,18 @@ function TrackBuilderMap({
       <text className="mapCredit" x={width - 10} y={height - 10} textAnchor="end">Esri World Imagery</text>
     </svg>
       <div className="mapZoomBtns">
+        {follow ? (
+          <button
+            type="button"
+            aria-label="Center on car"
+            title={followPoint ? (following ? "Following car — drag to look around" : "Recenter on car") : "Waiting for GPS fix"}
+            className={following && followPoint ? "follow active" : "follow"}
+            disabled={!followPoint}
+            onClick={() => setFollowing(true)}
+          >
+            <Crosshair size={16} />
+          </button>
+        ) : null}
         <button type="button" aria-label="Zoom in" title="Zoom in" onClick={() => zoomBy(1 / 1.3)}><Plus size={16} /></button>
         <button type="button" aria-label="Zoom out" title="Zoom out" onClick={() => zoomBy(1.3)}><Minus size={16} /></button>
       </div>

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
@@ -1344,8 +1344,12 @@ function App() {
           .map((segment, index) => ({ ...segment, label: `Session ${index + 1}` }));
         setSegments(nextSegments);
         setSelectedSegments(new Set(nextSegments.map((segment) => segment.id)));
-        setPreviewSelectedSegments(new Set(nextSegments[0] ? [nextSegments[0].id] : []));
-        setLastPreviewSegmentId(nextSegments[0]?.id ?? "");
+        // Don't auto-preview the first session: that pulled its GPS into the
+        // shared `gps` state and made the Track Builder map open non-empty with
+        // a trace nobody picked. Start with no preview — the user clicks a
+        // session (Analysis) or checks a reference (Builder) to load a trace.
+        setPreviewSelectedSegments(new Set());
+        setLastPreviewSegmentId("");
         setSessionMetadata((prev) => {
           const next = { ...prev };
           nextSegments.forEach((segment) => {

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
@@ -2,7 +2,7 @@
 import './trackside.css';
 
 import { useEffect, useMemo, useRef, useState, type ChangeEvent, type Dispatch, type MouseEvent, type ReactNode, type SetStateAction } from "react";
-import { Activity, AlertTriangle, ArrowDown, ArrowUp, CalendarDays, ChevronLeft, ChevronRight, Disc3, Download, FileText, Flag, Gauge, GraduationCap, HelpCircle, MapPinned, Moon, NotebookText, Plus, Power, Radio, RefreshCcw, Save, Scissors, SlidersHorizontal, Sun, Target, Thermometer, Timer, Trash2, Upload, Users, WifiOff, X, Zap } from "lucide-react";
+import { Activity, AlertTriangle, ArrowDown, ArrowUp, CalendarDays, ChevronLeft, ChevronRight, Disc3, Download, FileText, Flag, Gauge, GraduationCap, HelpCircle, MapPinned, MonitorCog, Moon, NotebookText, Plus, Power, Radio, RefreshCcw, Save, Scissors, SlidersHorizontal, Sun, Target, Thermometer, Timer, Trash2, Upload, Users, WifiOff, X, Zap } from "lucide-react";
 import { api } from "@/lib/trackside/api";
 import { useCarStatus, CAR_STATE_META, humanizeReason, type CarState, type CarStatusFeed } from "@/lib/trackside/useCarStatus";
 import { EVENT_TYPES, upsertSession, patchSession, syncRegistryWithServer, type TracksideSessionInfo } from "@/lib/trackside/sessionRegistry";
@@ -544,6 +544,10 @@ function App() {
   const [dashPowerMode, setDashPowerMode] = useState<"auto" | "manual">(() => (localStorage.getItem("dash-power-mode") === "manual" ? "manual" : "auto"));
   const [dashAutoLap, setDashAutoLap] = useState(() => localStorage.getItem("dash-auto-lap") === "1");
   const [dashGatePushed, setDashGatePushed] = useState(false);
+  // Debug screen override the strategist is forcing on the dash (null = auto /
+  // follow PRNDL). Not persisted — it's a transient bench/pit aid, and the car
+  // clears it on a real gear change anyway, so it shouldn't survive a reload.
+  const [dashScreenOverride, setDashScreenOverride] = useState<string | null>(null);
   // How long the on-car full-screen lap card stays up after a lap (seconds).
   const [lapCardDurationS, setLapCardDurationS] = useState(() => {
     const v = Number(localStorage.getItem("dash-lap-card-duration-s"));
@@ -4079,6 +4083,63 @@ function App() {
               Lay out what the driver sees on each lap card, then send it to the car (used until replaced).
               The lap card auto-clears after the duration above.
             </p>
+          </Panel>
+
+          <Panel title="Dash Screen — debug override" icon={<MonitorCog size={18} />}>
+            <p style={{ margin: "0 0 8px", opacity: 0.75, fontSize: "0.85rem" }}>
+              Force the driver dash onto a specific screen without shifting the car into gear —
+              for bench checks and pit demos. The car snaps back to normal PRNDL routing the
+              moment the driver actually shifts, and a dash reboot drops the override too.
+            </p>
+            {(() => {
+              const connected = !isMirror && dashSignals.status === "connected";
+              const SCREENS: { id: string; label: string }[] = [
+                { id: "driving", label: "Driving" },
+                { id: "park", label: "Park / Pit" },
+                { id: "shutdown", label: "Shutdown" },
+                { id: "settings", label: "Settings" },
+              ];
+              const setOverride = (id: string | null) => {
+                if (!connected) return;
+                dashSignals.publishScreen(id);
+                setDashScreenOverride(id);
+              };
+              return (
+                <>
+                  <div className="screenOverrideButtons">
+                    {SCREENS.map((s) => (
+                      <button
+                        key={s.id}
+                        className={dashScreenOverride === s.id ? "tool active" : "tool"}
+                        disabled={!connected}
+                        onClick={() => setOverride(s.id)}
+                      >
+                        {s.label}
+                      </button>
+                    ))}
+                  </div>
+                  <div className="gateButtons" style={{ marginTop: 8 }}>
+                    <button
+                      className="primary"
+                      disabled={!connected || dashScreenOverride === null}
+                      onClick={() => setOverride(null)}
+                    >
+                      <Radio size={15} /> Release to auto (PRNDL)
+                    </button>
+                    <span style={{ alignSelf: "center", opacity: 0.8, fontSize: "0.85rem" }}>
+                      {dashScreenOverride
+                        ? `Forcing: ${dashScreenOverride}`
+                        : "Following PRNDL"}
+                    </span>
+                  </div>
+                  {!connected ? (
+                    <p style={{ marginTop: 6, opacity: 0.7, fontSize: "0.8rem" }}>
+                      Connect to the dash first (Dash tab → Connect to dash).
+                    </p>
+                  ) : null}
+                </>
+              );
+            })()}
           </Panel>
 
           <Panel title="Start/Finish — on-car laps" icon={<MapPinned size={18} />}>

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
@@ -575,6 +575,10 @@ function App() {
   const [msgSendStatus, setMsgSendStatus] = useState("");
   const [dashNow, setDashNow] = useState(0); // 1 Hz tick for link-health "age" displays
   const dashLastLapCountRef = useRef(0);
+  // Set by markLap so the dash-count sync effect fires a lap CARD for the next
+  // newly-counted lap even when GPS auto-card (dashAutoLap) is off — a manual
+  // "Log Lap" is an explicit request to show the card.
+  const dashCardForceRef = useRef(false);
   const lastRegistryPatchRef = useRef(0);
   // Multi-client sync: one leader owns the session, others mirror it read-only.
   const presence = usePresence(true);
@@ -1039,13 +1043,29 @@ function App() {
 
   // Auto-fire a dash lap card whenever the trackside lap detector completes a
   // lap — optional, off by default so the thread's "manual for now" still holds.
+  // Keep the dash lap count in sync with the SELECTED (counted) laps — the same
+  // source as lapsCompletedPlan — in BOTH directions:
+  //   • count up (new counted lap)   -> fire the card via lapTrigger if auto-card
+  //     is on OR a manual Log Lap requested it; otherwise just sync the number.
+  //   • count down (a lap deselected) -> publishLapCount pulls the dash count
+  //     down with NO card (lapTrigger is forward-only by design).
+  // So deselecting a double-count / driver-change lap updates the driver dash too.
   useEffect(() => {
-    const count = liveState.laps.length;
-    if (count > dashLastLapCountRef.current) {
-      if (!isMirror && dashAutoLap && dashSignals.status === "connected") dashSignals.sendLap();
-      dashLastLapCountRef.current = count;
+    if (isMirror || dashSignals.status !== "connected") return;
+    const n = selectedLaps.length;
+    const prev = dashLastLapCountRef.current;
+    if (n === prev) return;
+    dashLastLapCountRef.current = n;
+    if (n > prev) {
+      const wantCard = dashAutoLap || dashCardForceRef.current;
+      dashCardForceRef.current = false;
+      if (wantCard) dashSignals.sendLap(n);
+      else dashSignals.publishLapCount(n); // count up, no card
+    } else {
+      dashCardForceRef.current = false;
+      dashSignals.publishLapCount(n); // deselect: pull the dash count down, no card
     }
-  }, [liveState.laps.length, dashAutoLap, dashSignals.status, dashSignals.sendLap, isMirror]);
+  }, [selectedLaps.length, dashAutoLap, dashSignals.status, dashSignals.sendLap, dashSignals.publishLapCount, isMirror]);
 
   // Drain: re-publish the website's lap count whenever the car's mirror shows
   // fewer laps than we've logged. Catches both the dashd-restart and
@@ -1059,12 +1079,12 @@ function App() {
     if (dashSignals.status !== "connected") return;
     const carLapCount = dashSignals.dashState?.lapCount ?? null;
     if (carLapCount == null) return; // no mirror yet — nothing to compare against
-    const websiteLapCount = liveState.laps.length;
+    const websiteLapCount = selectedLaps.length;
     if (websiteLapCount > carLapCount) {
       dashSignals.republishLap(websiteLapCount);
     }
   }, [
-    liveState.laps.length,
+    selectedLaps.length,
     dashSignals.status,
     dashSignals.dashState?.lapCount,
     dashSignals.republishLap,
@@ -2375,14 +2395,11 @@ function App() {
     triggerManualLap();
     const after = liveStateRef.current.laps.length;
     const lapClosed = after > beforeLaps;
-    // On a completed lap, always fire the car's lap card. sendLap advances the
-    // lap counter in lockstep with the Live tab even if the publish is dropped
-    // (link mid-handshake), and the auto-connect keeps the uplink up — so both
-    // lap buttons reliably log to the Live tab AND reach the car.
-    // Send the website's authoritative lap count to the car so dashd adopts it
-    // (rather than running its own +1 counter that drifted from trackside).
-    if (lapClosed) dashSignals.sendLap(after);
-    dashLastLapCountRef.current = after;
+    // On a completed lap, request the car's lap card. The actual lapTrigger is
+    // sent by the dash-count sync effect when the newly-logged lap shows up in
+    // the SELECTED count — so the card fires at the corrected lap number, and a
+    // manual Log Lap always cards even if GPS auto-card is off.
+    if (lapClosed) dashCardForceRef.current = true;
     // Visible feedback so the user knows whether this click STARTED a lap (no
     // dash card yet — by design, the card represents 'lap COMPLETE') or CLOSED
     // a lap (dash card fires). Earlier this was silent, which made the two

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
@@ -644,12 +644,22 @@ function App() {
     [torqueParamSetId],
   );
   const targetEnergyPerLapWh = targetLaps > 0 && targetEnergyKwh > 0 ? (targetEnergyKwh * 1000) / targetLaps : null;
+  // Laps the strategist counts as REAL completed laps = the checkbox selection in
+  // the live list. Deselecting a double-counted trigger or a driver-change lap
+  // drops the completed count (and raises laps-remaining), so the plan/budget
+  // aren't offset by them. Every lap is auto-selected on completion, so the
+  // default count equals the raw lap count until something is deselected.
+  const selectedLaps = useMemo(() => liveState.laps.filter((lap) => selectedLapIds.has(lap.id)), [liveState.laps, selectedLapIds]);
   // --- dynamic per-lap energy budget (Wh), recomputed each completed lap ---
+  // energyUsedWh stays the ACTUAL total over ALL laps: a deselected lap's energy
+  // was still physically consumed, and a double-count splits one real lap's
+  // energy across two records (total conserved). So only the COUNT follows the
+  // selection — the energy figure must not.
   const energyUsedWh = useMemo(
     () => liveState.laps.reduce((sum, lap) => sum + (lap.energyWh || 0), 0),
     [liveState.laps],
   );
-  const lapsCompletedPlan = liveState.laps.length;
+  const lapsCompletedPlan = selectedLaps.length;
   const totalBudgetWh = targetEnergyKwh > 0 ? targetEnergyKwh * 1000 : null;
   const remainingBudgetWh = totalBudgetWh != null ? totalBudgetWh - energyUsedWh : null;
   const lapsRemainingPlan = targetLaps > 0 ? Math.max(0, targetLaps - lapsCompletedPlan) : null;
@@ -684,7 +694,6 @@ function App() {
       setSoeCutoffCellV(normalizeSoeCutoffCellV(p.soeCutoffCellV));
     }
   });
-  const selectedLaps = useMemo(() => liveState.laps.filter((lap) => selectedLapIds.has(lap.id)), [liveState.laps, selectedLapIds]);
   const lapAverages = useMemo(() => {
     if (!selectedLaps.length) {
       return {
@@ -701,11 +710,11 @@ function App() {
     const avgEnergyInWh = selectedLaps.reduce((sum, lap) => sum + lapEnergyInWh(lap), 0) / selectedLaps.length;
     return { count: selectedLaps.length, avgMs, avgEnergyWh, avgEnergyOutWh, avgEnergyInWh };
   }, [selectedLaps]);
-  // Hero "Lap" tile reads COMPLETED laps, not click count. A lap is counted
-  // when its end-of-lap click closes it (or when GPS auto-detect crosses S/F).
-  // The lap currently in progress is implied by the running timer above, not
-  // by the counter — so 4/22 means "4 done, on the 5th".
-  const currentLapNumber = liveState.laps.length;
+  // Hero "Lap" tile reads SELECTED completed laps (same source as the plan's
+  // lapsCompletedPlan), so deselecting a double-count / driver-change lap in the
+  // live list updates "4/22" to the real count. The lap in progress is implied
+  // by the running timer above, not the counter — so 4/22 means "4 done, on 5th".
+  const currentLapNumber = selectedLaps.length;
   const liveSectorCount = sessionFromFile && hasStartFinish && splitGates.length ? splitGates.length + 1 : 0;
   const liveLapElapsedMs = liveState.lastSample && liveState.lapStartMs ? Math.max(0, liveState.lastSample.t - liveState.lapStartMs) : 0;
   // Wall-clock ticker for the manual recording timer (runs only while recording).
@@ -3456,7 +3465,13 @@ function App() {
                 running={liveState.running}
               />
               </div>
-              <Panel title="Live Laps" icon={<Timer size={18} />}>
+              <Panel
+                title="Live Laps"
+                icon={<Timer size={18} />}
+                headerRight={liveState.laps.length !== selectedLaps.length
+                  ? <><strong>{selectedLaps.length}</strong>/{liveState.laps.length} counted</>
+                  : undefined}
+              >
                 <LiveLapTable
                   laps={liveState.laps}
                   bestLap={bestLap}
@@ -5086,7 +5101,7 @@ function LiveLapTable({
         <table className="lapTable">
           <thead>
             <tr>
-              <th aria-label="Include in average" />
+              <th aria-label="Count this lap (completed total + average); deselect double-counts / driver-change laps" title="Counts toward completed laps & the average. Deselect double-counts or driver-change laps to correct the lap count." />
               <th>Lap</th>
               <th>Time</th>
               {Array.from({ length: columns }, (_sector, index) => <th key={`sector-head-${index}`}>S{index + 1}</th>)}
@@ -5107,7 +5122,8 @@ function LiveLapTable({
                       type="checkbox"
                       checked={selected}
                       onChange={() => onToggleLap(lap.id)}
-                      aria-label={`Include ${lap.label} in average`}
+                      aria-label={`Count ${lap.label} toward completed laps and the average`}
+                      title={`Count ${lap.label} toward completed laps & the average — deselect a double-count or driver-change lap`}
                     />
                   </td>
                   <td className={bestLap?.id === lap.id ? "purpleText" : ""}>

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
@@ -543,6 +543,9 @@ function App() {
   // Power-budget mode: 'auto' derives kW from the energy plan; 'manual' uses the slider.
   const [dashPowerMode, setDashPowerMode] = useState<"auto" | "manual">(() => (localStorage.getItem("dash-power-mode") === "manual" ? "manual" : "auto"));
   const [dashAutoLap, setDashAutoLap] = useState(() => localStorage.getItem("dash-auto-lap") === "1");
+  // Selected VCU params table to command (event_mode); persisted for convenience.
+  const [vcuMode, setVcuMode] = useState<number>(() => Number(localStorage.getItem("dash-vcu-mode") || 4));
+  const [vcuModeStatus, setVcuModeStatus] = useState("");
   const [dashGatePushed, setDashGatePushed] = useState(false);
   // How long the on-car full-screen lap card stays up after a lap (seconds).
   const [lapCardDurationS, setLapCardDurationS] = useState(() => {
@@ -4007,6 +4010,58 @@ function App() {
                 : " Manual override — switch to Auto to track the energy plan."}
               {" "}Sent live + republished ~1 Hz so it never goes stale.
             </p>
+          </Panel>
+
+          <Panel title="VCU Mode" icon={<SlidersHorizontal size={18} />}>
+            <p style={{ margin: "0 0 8px", opacity: 0.75, fontSize: "0.85rem" }}>
+              Select the VCU params table at runtime (no re-flash). Relayed to the car as the
+              0x029 CAN command; the VCU applies it (its firmware gates the swap to a safe
+              state) and re-broadcasts its active mode for confirmation.
+            </p>
+            {(() => {
+              const connected = !isMirror && dashSignals.status === "connected";
+              const MODES: { v: number; label: string }[] = [
+                { v: 1, label: "Acceleration" },
+                { v: 2, label: "Skidpad" },
+                { v: 3, label: "Autocross" },
+                { v: 4, label: "Endurance" },
+              ];
+              return (
+                <>
+                  <div className="gateButtons">
+                    <select
+                      value={vcuMode}
+                      disabled={!connected}
+                      onChange={(e) => {
+                        const v = Number(e.target.value);
+                        setVcuMode(v);
+                        localStorage.setItem("dash-vcu-mode", String(v));
+                      }}
+                    >
+                      {MODES.map((m) => <option key={m.v} value={m.v}>{m.v} · {m.label}</option>)}
+                    </select>
+                    <button
+                      className="primary"
+                      disabled={!connected}
+                      onClick={() => {
+                        dashSignals.publishEventMode(vcuMode);
+                        const lbl = MODES.find((m) => m.v === vcuMode)?.label ?? String(vcuMode);
+                        setVcuModeStatus(`Sent mode ${vcuMode} (${lbl}) to VCU ✓`);
+                        window.setTimeout(() => setVcuModeStatus(""), 4000);
+                      }}
+                    >
+                      <Radio size={15} /> Send to VCU
+                    </button>
+                  </div>
+                  {vcuModeStatus ? <span className="goodText">{vcuModeStatus}</span> : null}
+                  {!connected ? (
+                    <p style={{ marginTop: 6, opacity: 0.7, fontSize: "0.8rem" }}>
+                      Connect to the dash first (Dash tab → Connect to dash).
+                    </p>
+                  ) : null}
+                </>
+              );
+            })()}
           </Panel>
 
           <Panel title="Lap Control" icon={<Flag size={18} />}>

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
@@ -1344,12 +1344,8 @@ function App() {
           .map((segment, index) => ({ ...segment, label: `Session ${index + 1}` }));
         setSegments(nextSegments);
         setSelectedSegments(new Set(nextSegments.map((segment) => segment.id)));
-        // Don't auto-preview the first session: that pulled its GPS into the
-        // shared `gps` state and made the Track Builder map open non-empty with
-        // a trace nobody picked. Start with no preview — the user clicks a
-        // session (Analysis) or checks a reference (Builder) to load a trace.
-        setPreviewSelectedSegments(new Set());
-        setLastPreviewSegmentId("");
+        setPreviewSelectedSegments(new Set(nextSegments[0] ? [nextSegments[0].id] : []));
+        setLastPreviewSegmentId(nextSegments[0]?.id ?? "");
         setSessionMetadata((prev) => {
           const next = { ...prev };
           nextSegments.forEach((segment) => {

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
@@ -3543,25 +3543,6 @@ function App() {
               <TractionControlPanel sample={filteredLiveState.lastSample} />
             </div>
             <div className="liveMainColumn">
-              {/* Live Position hidden until chudpi/GPS is reliable. The RadioLion
-                  receiver's draw browns out the chudpi rail, so no fix reaches
-                  the website. Re-enable this Panel block once chudpi power is
-                  fixed. */}
-              {/*
-              <Panel title="Live Position" icon={<MapPinned size={18} />} className="liveMapPanel">
-                <TrackBuilderMap
-                  points={filteredLiveState.samples.filter(hasGps).map((sample) => ({ t: sample.t, lat: sample.lat ?? 0, lon: sample.lon ?? 0 }))}
-                  liveSample={filteredLiveState.lastSample}
-                  gates={track.gates}
-                  drawMode={null}
-                  onDrawGate={handleDrawGate}
-                  center={builderCenter}
-                  onCenter={setBuilderCenter}
-                  targetSpanM={selectedTrackView?.spanM}
-                  gpsUnavailable={filteredLiveState.lastSample != null && !filteredLiveState.samples.some(hasGps)}
-                />
-              </Panel>
-              */}
               <Panel title="Energy Window" icon={<Zap size={18} />}>
                 <EnergyWindowChart
                   state={filteredLiveState}
@@ -3585,6 +3566,22 @@ function App() {
                   link. */}
               <DriverControlsPanel sample={filteredLiveState.lastSample} torqueParamSet={torqueParamSet} />
               <TempsStatusPanel sample={filteredLiveState.lastSample} />
+              {/* Live Position — re-enabled now that chudpi/GPS is reliable. Kept
+                  last in the column so it's available but out of the way; it
+                  self-indicates (gpsUnavailable) if a session has no fix. */}
+              <Panel title="Live Position" icon={<MapPinned size={18} />} className="liveMapPanel">
+                <TrackBuilderMap
+                  points={filteredLiveState.samples.filter(hasGps).map((sample) => ({ t: sample.t, lat: sample.lat ?? 0, lon: sample.lon ?? 0 }))}
+                  liveSample={filteredLiveState.lastSample}
+                  gates={track.gates}
+                  drawMode={null}
+                  onDrawGate={handleDrawGate}
+                  center={builderCenter}
+                  onCenter={setBuilderCenter}
+                  targetSpanM={selectedTrackView?.spanM}
+                  gpsUnavailable={filteredLiveState.lastSample != null && !filteredLiveState.samples.some(hasGps)}
+                />
+              </Panel>
             </div>
             <div className="rightRail">
               {/* Energy Strategy widget hidden for now — revisit later.

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
@@ -544,7 +544,12 @@ function App() {
   const [dashPowerMode, setDashPowerMode] = useState<"auto" | "manual">(() => (localStorage.getItem("dash-power-mode") === "manual" ? "manual" : "auto"));
   const [dashAutoLap, setDashAutoLap] = useState(() => localStorage.getItem("dash-auto-lap") === "1");
   // Selected VCU params table to command (event_mode); persisted for convenience.
-  const [vcuMode, setVcuMode] = useState<number>(() => Number(localStorage.getItem("dash-vcu-mode") || 4));
+  // Validate against the known modes so a corrupted/empty value (NaN, 0, 5…)
+  // can't preselect an invalid mode — fall back to 4 (Endurance).
+  const [vcuMode, setVcuMode] = useState<number>(() => {
+    const parsed = Number(localStorage.getItem("dash-vcu-mode"));
+    return [1, 2, 3, 4].includes(parsed) ? parsed : 4;
+  });
   const [vcuModeStatus, setVcuModeStatus] = useState("");
   const [dashGatePushed, setDashGatePushed] = useState(false);
   // How long the on-car full-screen lap card stays up after a lap (seconds).

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
@@ -1798,6 +1798,11 @@ function App() {
       patchSession(sessionInfo.id, { endedAt: Date.now(), laps: liveStateRef.current.laps.length });
       setSessionInfo(null);
     }
+    // Reset the car's lap_count + baseline too, so the driver dash starts the
+    // re-armed session at Lap 0 instead of holding the prior high water mark —
+    // symmetric with Stop Event (stopEventAndDownload). Without this, Reset
+    // cleared the trackside laps but left the dash showing the old count.
+    if (dashSignals.status === "connected") dashSignals.resetLapCounter();
     markLiveSessionEnded();
     clearLiveSessionState();
     // The manual Start button is gone, so a reset re-arms the auto feed; the

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
@@ -3332,15 +3332,11 @@ function App() {
               <div className="heroMetricRow">
                 <Metric label="Best" value={bestLap ? formatLapTime(bestLap.durationMs) : "--"} tone="purple" />
                 <Metric label="Lap" value={`${currentLapNumber} / ${targetLaps > 0 ? targetLaps : "—"}`} />
-                <Metric label="Energy" value={`${liveState.totalEnergyOutWh.toFixed(1)} Wh`} />
+                <Metric label="Energy" value={`${liveState.totalEnergyWh.toFixed(1)} Wh`} />
               </div>
               {/* Tier 2 — compact inline strip, smaller because they're checked
                   every few seconds, not every second. */}
               <div className="heroMetricStrip">
-                <span className="heroMetricInline">
-                  <small>Regen In</small>
-                  <b className={liveState.totalEnergyInWh > 0 ? "goodText" : ""}>{liveState.totalEnergyInWh.toFixed(1)} Wh</b>
-                </span>
                 <span className="heroMetricInline">
                   <small>Torque</small>
                   <b className={liveTorqueNm != null && liveTorqueNm < 0 ? "goodText" : ""}>
@@ -4643,8 +4639,6 @@ function EnergyStrategyPanel({
 }) {
   const sample = state.lastSample;
   const signedPowerKw = signedVcuPowerKwFor(state.previousSample, sample);
-  const drivePowerKw = signedPowerKw == null ? null : Math.max(0, signedPowerKw);
-  const regenPowerKw = signedPowerKw == null ? null : Math.max(0, -signedPowerKw);
   const pack = packStatus(state.samples, soeCutoffCellV, sample);
   const targetWh = targetEnergyKwh > 0 ? targetEnergyKwh * 1000 : null;
   const vcuUsedWh = state.totalEnergyWh;
@@ -4681,15 +4675,9 @@ function EnergyStrategyPanel({
           <Metric label="SOE Remaining" value={soeRemainingWh == null ? "--" : formatKwhFromWh(soeRemainingWh)} />
           <Metric label="Net Used (VCU)" value={formatKwhFromWh(vcuUsedWh)} />
           <Metric label="Net / Lap" value={targetEnergyPerLapWh == null ? "--" : `${targetEnergyPerLapWh.toFixed(0)} Wh`} />
-          <Metric label="Drive (VCU)" value={formatKwhFromWh(state.totalEnergyOutWh)} />
-          <Metric label="Regen (VCU)" value={formatKwhFromWh(state.totalEnergyInWh)} />
-          <Metric label="Drive Power" value={drivePowerKw == null ? "--" : `${drivePowerKw.toFixed(2)} kW`} />
-          <Metric label="Regen Power" value={regenPowerKw == null ? "--" : `${regenPowerKw.toFixed(2)} kW`} />
+          <Metric label="Power" value={signedPowerKw == null ? "--" : `${signedPowerKw.toFixed(2)} kW`} tone={signedPowerKw != null && signedPowerKw < 0 ? "good" : ""} />
           <Metric label="Lap Net" value={`${state.lapEnergyWh.toFixed(1)} Wh`} />
-          <Metric label="Lap Drive" value={`${state.lapEnergyOutWh.toFixed(1)} Wh`} />
-          <Metric label="Lap Regen" value={`${state.lapEnergyInWh.toFixed(1)} Wh`} />
           <Metric label="Avg Net Lap" value={averages.avgEnergyWh == null ? "--" : `${averages.avgEnergyWh.toFixed(1)} Wh`} />
-          <Metric label="Avg Regen" value={averages.avgEnergyInWh == null ? "--" : `${averages.avgEnergyInWh.toFixed(1)} Wh`} />
         </div>
         <small className="muted">
           {selectedAvgDelta != null
@@ -4894,18 +4882,11 @@ function EnergyWindowChart({
   const plotH = height - padTop - padBottom;
   const lastT = state.lastSample?.t ?? Date.now();
   const startT = lastT - windowS * 1000;
-  const maxEnergy = Math.max(1, ...trace.flatMap((point) => [point.energyOutWh, point.energyInWh, Math.max(0, point.energyWh)]));
-  const outPoints = trace
+  const maxEnergy = Math.max(1, ...trace.map((point) => Math.max(0, point.energyWh)));
+  const netPoints = trace
     .map((point) => {
       const x = padLeft + Math.max(0, Math.min(1, (point.t - startT) / (windowS * 1000))) * plotW;
-      const y = padTop + (1 - Math.max(0, Math.min(1, point.energyOutWh / maxEnergy))) * plotH;
-      return `${x.toFixed(1)},${y.toFixed(1)}`;
-    })
-    .join(" ");
-  const inPoints = trace
-    .map((point) => {
-      const x = padLeft + Math.max(0, Math.min(1, (point.t - startT) / (windowS * 1000))) * plotW;
-      const y = padTop + (1 - Math.max(0, Math.min(1, point.energyInWh / maxEnergy))) * plotH;
+      const y = padTop + (1 - Math.max(0, Math.min(1, point.energyWh / maxEnergy))) * plotH;
       return `${x.toFixed(1)},${y.toFixed(1)}`;
     })
     .join(" ");
@@ -4915,9 +4896,7 @@ function EnergyWindowChart({
   return (
     <div className="energyWindow">
       <div className="energyToolbar">
-        <Metric label="Window Out" value={`${(latest?.energyOutWh ?? 0).toFixed(1)} Wh`} />
-        <Metric label="Regen In" value={`${(latest?.energyInWh ?? 0).toFixed(1)} Wh`} tone="good" />
-        <Metric label="Net" value={`${latestEnergy.toFixed(1)} Wh`} />
+        <Metric label="Energy" value={`${latestEnergy.toFixed(1)} Wh`} />
         <label>
           <span>Window</span>
           <select value={windowS} onChange={(event) => onWindowS(Number(event.target.value))}>
@@ -4937,8 +4916,7 @@ function EnergyWindowChart({
         <text x={width - padRight - 28} y={height - 7}>now</text>
         <text x={6} y={padTop + 10}>{maxEnergy.toFixed(1)} Wh</text>
         <text x={10} y={height - padBottom}>0 Wh</text>
-        {outPoints ? <polyline className="energyOutLine" points={outPoints} /> : null}
-        {inPoints ? <polyline className="energyInLine" points={inPoints} /> : null}
+        {netPoints ? <polyline className="energyNetLine" points={netPoints} /> : null}
         {lapBreaks.map((lap) => {
           const x = padLeft + Math.max(0, Math.min(1, (lap.endMs - startT) / (windowS * 1000))) * plotW;
           return (
@@ -5005,8 +4983,6 @@ function LiveDataPanel({ state }: { state: LiveSessionState }) {
   const energyV = energyVoltageFor(sample);
   const dcBusCurrent = dcBusCurrentFor(sample);
   const signedPowerKw = signedVcuPowerKwFor(state.previousSample, sample);
-  const drivePowerKw = signedPowerKw == null ? null : Math.max(0, signedPowerKw);
-  const regenPowerKw = signedPowerKw == null ? null : Math.max(0, -signedPowerKw);
   const motorRpm = firstLiveValue(values, ["controls_motor_speed", "motor_speed", "dynamics_inverter_rpm", "inverter_rpm"]);
   const rawApps = rawAppsTravelDetails(values);
   const rawRows = [...rawAppsLiveRows(rawApps), ...topLiveValues(values)];
@@ -5015,8 +4991,7 @@ function LiveDataPanel({ state }: { state: LiveSessionState }) {
       <div className="liveDataGrid">
         <Metric label="Samples" value={state.samples.length.toLocaleString()} />
         <Metric label="Last Sample" value={sample ? formatTime(sample.t) : "--"} />
-        <Metric label="Drive Power" value={drivePowerKw == null ? "--" : `${drivePowerKw.toFixed(2)} kW`} />
-        <Metric label="Regen Power" value={regenPowerKw == null ? "--" : `${regenPowerKw.toFixed(2)} kW`} tone="good" />
+        <Metric label="Power" value={signedPowerKw == null ? "--" : `${signedPowerKw.toFixed(2)} kW`} tone={signedPowerKw != null && signedPowerKw < 0 ? "good" : ""} />
         <Metric label={dcBusV == null && energyV != null ? "Est V / I" : "DC Bus"} value={energyV == null || dcBusCurrent == null ? "--" : `${energyV.toFixed(1)} V / ${dcBusCurrent.toFixed(1)} A`} />
         <Metric label="Power Src" value="VCU 0x1C9" />
         <Metric label="Motor RPM" value={motorRpm == null ? "--" : `${Math.round(motorRpm).toLocaleString()} rpm`} />
@@ -5090,7 +5065,7 @@ function LiveLapTable({
   };
 }) {
   const columns = sectorCount;
-  const totalCols = 3 + columns + 3 + (targetEnergyPerLapWh != null ? 1 : 0) + 1; // +1 = Notes
+  const totalCols = 3 + columns + 1 + (targetEnergyPerLapWh != null ? 1 : 0) + 1; // energy col (Net) + optional Δ + Notes
   const currentTargetEnergyWh = currentLapEnergyWh;
   const averageTargetEnergyWh = averages.avgEnergyWh;
   const tableWrapRef = useRef<HTMLDivElement | null>(null);
@@ -5115,10 +5090,8 @@ function LiveLapTable({
               <th>Lap</th>
               <th>Time</th>
               {Array.from({ length: columns }, (_sector, index) => <th key={`sector-head-${index}`}>S{index + 1}</th>)}
-              <th>Drive</th>
-              <th>Regen</th>
-              <th>Net</th>
-              {targetEnergyPerLapWh != null ? <th>Δ Net</th> : null}
+              <th>Energy</th>
+              {targetEnergyPerLapWh != null ? <th>Δ Energy</th> : null}
               <th>Notes</th>
             </tr>
           </thead>
@@ -5166,8 +5139,6 @@ function LiveLapTable({
                     </td>
                     );
                   })}
-                  <td>{lapEnergyOutWh(lap).toFixed(1)} Wh</td>
-                  <td className="goodText">{lapEnergyInWh(lap).toFixed(1)} Wh</td>
                   <td>{lap.energyWh.toFixed(1)} Wh</td>
                   {targetEnergyPerLapWh != null ? <td className={delta != null && delta > 0 ? "deltaOver" : "deltaUnder"}>{delta == null ? "--" : formatEnergyDelta(delta)}</td> : null}
                   <td>
@@ -5200,8 +5171,6 @@ function LiveLapTable({
                 {Array.from({ length: columns }, (_unused, index) => (
                   <td key={`current-sector-${index}`}>{currentSectors[index] == null ? "--" : formatLapTime(currentSectors[index])}</td>
                 ))}
-                <td>{currentLapEnergyOutWh.toFixed(1)} Wh</td>
-                <td className="goodText">{currentLapEnergyInWh.toFixed(1)} Wh</td>
                 <td>{currentLapEnergyWh.toFixed(1)} Wh</td>
                 {targetEnergyPerLapWh != null ? <td>{formatEnergyDelta(currentTargetEnergyWh - targetEnergyPerLapWh)}</td> : null}
                 <td />
@@ -5215,8 +5184,6 @@ function LiveLapTable({
                 <td>Avg ({averages.count})</td>
                 <td>{averages.avgMs == null ? "--" : formatLapTime(averages.avgMs)}</td>
                 {Array.from({ length: columns }, (_unused, index) => <td key={`avg-sector-${index}`} />)}
-                <td>{averages.avgEnergyOutWh == null ? "--" : `${averages.avgEnergyOutWh.toFixed(1)} Wh`}</td>
-                <td className="goodText">{averages.avgEnergyInWh == null ? "--" : `${averages.avgEnergyInWh.toFixed(1)} Wh`}</td>
                 <td>{averages.avgEnergyWh == null ? "--" : `${averages.avgEnergyWh.toFixed(1)} Wh`}</td>
                 {targetEnergyPerLapWh != null ? (
                   <td>{averageTargetEnergyWh == null ? "--" : formatEnergyDelta(averageTargetEnergyWh - targetEnergyPerLapWh)}</td>
@@ -5235,9 +5202,7 @@ function LiveLapTable({
           </div>
           <div className="lapMiniGrid">
             <Metric label="Time" value={lastLap == null ? "--" : formatLapTime(lastLap.durationMs)} />
-            <Metric label="Net" value={lastLap == null ? "--" : `${lastLap.energyWh.toFixed(1)} Wh`} />
-            <Metric label="Drive" value={lastLap == null ? "--" : `${lapEnergyOutWh(lastLap).toFixed(1)} Wh`} />
-            <Metric label="Regen" value={lastLap == null ? "--" : `${lapEnergyInWh(lastLap).toFixed(1)} Wh`} />
+            <Metric label="Energy" value={lastLap == null ? "--" : `${lastLap.energyWh.toFixed(1)} Wh`} />
             <Metric label="Target Δ" value={lastLapDeltaWh == null ? "--" : formatEnergyDelta(lastLapDeltaWh)} />
           </div>
         </div>
@@ -5248,9 +5213,7 @@ function LiveLapTable({
           </div>
           <div className="lapMiniGrid">
             <Metric label="Time" value={averages.avgMs == null ? "--" : formatLapTime(averages.avgMs)} />
-            <Metric label="Net" value={averages.avgEnergyWh == null ? "--" : `${averages.avgEnergyWh.toFixed(1)} Wh`} />
-            <Metric label="Drive" value={averages.avgEnergyOutWh == null ? "--" : `${averages.avgEnergyOutWh.toFixed(1)} Wh`} />
-            <Metric label="Regen" value={averages.avgEnergyInWh == null ? "--" : `${averages.avgEnergyInWh.toFixed(1)} Wh`} />
+            <Metric label="Energy" value={averages.avgEnergyWh == null ? "--" : `${averages.avgEnergyWh.toFixed(1)} Wh`} />
             <Metric label="Target Δ" value={averageDeltaWh == null ? "--" : formatEnergyDelta(averageDeltaWh)} />
           </div>
         </div>

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
@@ -1840,9 +1840,12 @@ function App() {
   function sendDashLayout(screenId: string, layout: LapCardLayout) {
     if (isMirrorRef.current) { setLayoutSendStatus("Read-only mirror — only the session leader can push to the car."); return; }
     if (dashSignals.status !== "connected") { setLayoutSendStatus("Connect to the dash first (Dash tab → Connect to dash)."); return; }
-    // Route to the screen's retained topic: park → parkLayout, else the lap card.
-    const ok = screenId === "park" ? dashSignals.publishParkLayout(layout) : dashSignals.publishLayout(layout);
-    const where = screenId === "park" ? "park screen" : "lap card";
+    // Route to the screen's retained topic: park → parkLayout, driving →
+    // drivingLayout, else the lap card.
+    const ok = screenId === "park" ? dashSignals.publishParkLayout(layout)
+      : screenId === "driving" ? dashSignals.publishDrivingLayout(layout)
+      : dashSignals.publishLayout(layout);
+    const where = screenId === "park" ? "park screen" : screenId === "driving" ? "driving screen" : "lap card";
     setLayoutSendStatus(ok ? `Sent “${layout.name}” to the ${where} ✓ (retained — used until replaced)` : "Publish failed — check the dash link.");
     window.setTimeout(() => setLayoutSendStatus(""), 5000);
   }

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
@@ -2,7 +2,7 @@
 import './trackside.css';
 
 import { useEffect, useMemo, useRef, useState, type ChangeEvent, type Dispatch, type MouseEvent, type ReactNode, type SetStateAction } from "react";
-import { Activity, AlertTriangle, ArrowDown, ArrowUp, CalendarDays, ChevronLeft, ChevronRight, Disc3, Download, FileText, Flag, Gauge, GraduationCap, HelpCircle, MapPinned, MonitorCog, Moon, NotebookText, Plus, Power, Radio, RefreshCcw, Save, Scissors, SlidersHorizontal, Sun, Target, Thermometer, Timer, Trash2, Upload, Users, WifiOff, X, Zap } from "lucide-react";
+import { Activity, AlertTriangle, ArrowDown, ArrowUp, CalendarDays, ChevronLeft, ChevronRight, Disc3, Download, FileText, Flag, Gauge, GraduationCap, HelpCircle, MapPinned, Minus, MonitorCog, Moon, NotebookText, Plus, Power, Radio, RefreshCcw, Save, Scissors, SlidersHorizontal, Sun, Target, Thermometer, Timer, Trash2, Upload, Users, WifiOff, X, Zap } from "lucide-react";
 import { api } from "@/lib/trackside/api";
 import { useCarStatus, CAR_STATE_META, humanizeReason, type CarState, type CarStatusFeed } from "@/lib/trackside/useCarStatus";
 import { EVENT_TYPES, upsertSession, patchSession, syncRegistryWithServer, type TracksideSessionInfo } from "@/lib/trackside/sessionRegistry";
@@ -751,6 +751,9 @@ function App() {
     return () => window.clearInterval(id);
   }, []);
   const dataAgeMs = lastDataAtMs == null ? null : Math.max(0, liveNowMs - lastDataAtMs);
+  // Last GPS coordinate we saw + when it last changed, for the Live Position
+  // readout's freshness (see gpsFixAgeMs).
+  const lastGpsFixRef = useRef<{ lat: number; lon: number; at: number } | null>(null);
   // Time spent trying to get telemetry since the feed started — used to escalate
   // 'waiting' to a hard 'down' after a grace period so a car-off page-load
   // doesn't sit on yellow forever just because the broker is reachable.
@@ -802,6 +805,21 @@ function App() {
     : liveHasGpsFix
       ? { dot: "live", label: sfGateDefined ? "GPS · auto-lap armed" : "GPS fix" }
       : { dot: "dead", label: "No GPS fix" };
+
+  // Raw lat/lon readout for the Live Position panel. We track when the coordinate
+  // last CHANGED (not just when a sample arrived) so a stuck/frozen fix reads as
+  // stale even while telemetry keeps flowing — that's the case the strategist
+  // wants to catch. `liveNowMs` ticks at 1 Hz to keep the age live.
+  const curGpsFix = liveHasGpsFix
+    ? { lat: liveState.lastSample!.lat as number, lon: liveState.lastSample!.lon as number }
+    : null;
+  if (curGpsFix) {
+    const prev = lastGpsFixRef.current;
+    if (!prev || prev.lat !== curGpsFix.lat || prev.lon !== curGpsFix.lon) {
+      lastGpsFixRef.current = { ...curGpsFix, at: liveNowMs };
+    }
+  }
+  const gpsFixAgeMs = lastGpsFixRef.current == null ? null : Math.max(0, liveNowMs - lastGpsFixRef.current.at);
 
   // Authoritative car state from the central classifier (PR #282), if reachable.
   const carStatus = useCarStatus(source, liveState.running);
@@ -3570,6 +3588,20 @@ function App() {
                   last in the column so it's available but out of the way; it
                   self-indicates (gpsUnavailable) if a session has no fix. */}
               <Panel title="Live Position" icon={<MapPinned size={18} />} className="liveMapPanel">
+                <div className="gpsReadout">
+                  <span className={`gpsDot ${liveHasGpsFix && dataAgeMs != null && dataAgeMs < 3000 ? "live" : liveHasGpsFix ? "stale" : "dead"}`} />
+                  <span className="gpsCoord">LAT <strong>{curGpsFix ? curGpsFix.lat.toFixed(6) : "—"}</strong></span>
+                  <span className="gpsCoord">LON <strong>{curGpsFix ? curGpsFix.lon.toFixed(6) : "—"}</strong></span>
+                  <span className="gpsAge">
+                    {curGpsFix == null
+                      ? "no fix"
+                      : gpsFixAgeMs == null
+                        ? "—"
+                        : gpsFixAgeMs < 2000
+                          ? "updating"
+                          : `unchanged ${(gpsFixAgeMs / 1000).toFixed(0)}s`}
+                  </span>
+                </div>
                 <TrackBuilderMap
                   points={filteredLiveState.samples.filter(hasGps).map((sample) => ({ t: sample.t, lat: sample.lat ?? 0, lon: sample.lon ?? 0 }))}
                   liveSample={filteredLiveState.lastSample}
@@ -5704,14 +5736,16 @@ function TrackBuilderMap({
       lon2: b.lon,
     });
   };
+  // Zoom via explicit buttons rather than the scroll wheel. React's wheel
+  // listener is passive, so an onWheel preventDefault() couldn't stop the page
+  // from also scrolling — zooming the map hijacked the whole page. Buttons keep
+  // pan-by-drag intact without fighting the page scroll. Smaller spanM = closer.
+  const zoomBy = (factor: number) => setSpanM((current) => Math.max(80, Math.min(8000, current * factor)));
   return (
+    <div className="mapWrap">
     <svg
       className={drawMode ? "map builderMap drawing" : "map builderMap"}
       viewBox={`0 0 ${width} ${height}`}
-      onWheel={(event) => {
-        event.preventDefault();
-        setSpanM((current) => nextMapSpan(current, event.deltaY));
-      }}
       onMouseDown={(event) => {
         const start = pointer(event);
         if (drawMode) {
@@ -5784,6 +5818,11 @@ function TrackBuilderMap({
       ) : null}
       <text className="mapCredit" x={width - 10} y={height - 10} textAnchor="end">Esri World Imagery</text>
     </svg>
+      <div className="mapZoomBtns">
+        <button type="button" aria-label="Zoom in" title="Zoom in" onClick={() => zoomBy(1 / 1.3)}><Plus size={16} /></button>
+        <button type="button" aria-label="Zoom out" title="Zoom out" onClick={() => zoomBy(1.3)}><Minus size={16} /></button>
+      </div>
+    </div>
   );
 }
 
@@ -6078,11 +6117,6 @@ function distanceMeters(lat1: number, lon1: number, lat2: number, lon2: number) 
   return radius * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
 }
 
-function nextMapSpan(currentSpanM: number, deltaY: number) {
-  const boundedDelta = Math.max(-120, Math.min(120, deltaY));
-  const zoomFactor = Math.exp(boundedDelta * 0.0007);
-  return Math.max(80, Math.min(8000, currentSpanM * zoomFactor));
-}
 
 function sampleCrossesGate(previous: LiveSample, current: LiveSample, gate: GateLine) {
   if (!hasGps(previous) || !hasGps(current)) return false;

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
@@ -132,6 +132,9 @@ type LiveLap = {
   distanceM: number;
   avgSpeedMps: number | null;
   samples: LiveSample[];
+  /** Peak battery (max-cell) temp °C reached during this lap, captured at close
+   *  from the lap's samples. Drives the battery thermal-projection trend. */
+  maxCellTempC?: number;
   notes?: string; // per-lap note (synced to the classifier DB)
 };
 type LiveSessionState = {
@@ -513,6 +516,13 @@ function App() {
   const [recordingBusy, setRecordingBusy] = useState(false);
   const [energyWindowS, setEnergyWindowS] = useState(60);
   const [targetLaps, setTargetLaps] = useState(() => Number(localStorage.getItem("motec-target-laps") || 0));
+  // Battery max-cell-temp limit (°C) for the thermal projection — the line the
+  // projection colors against. Configurable trackside (the team is still dialing
+  // it in); persisted. Default 60 °C (the design target from PTN thermals).
+  const [batteryTempLimitC, setBatteryTempLimitC] = useState(() => {
+    const v = Number(localStorage.getItem("battery-temp-limit-c"));
+    return Number.isFinite(v) && v > 0 ? v : 60;
+  });
   const [targetEnergyKwh, setTargetEnergyKwh] = useState(() => Number(localStorage.getItem("motec-target-energy-kwh") || PACK_ENERGY_KWH));
   const [soeCutoffCellV, setSoeCutoffCellV] = useState(loadSoeCutoffCellV);
   const [selectedLapIds, setSelectedLapIds] = useState<Set<string>>(() => new Set());
@@ -667,6 +677,29 @@ function App() {
   const totalBudgetWh = targetEnergyKwh > 0 ? targetEnergyKwh * 1000 : null;
   const remainingBudgetWh = totalBudgetWh != null ? totalBudgetWh - energyUsedWh : null;
   const lapsRemainingPlan = targetLaps > 0 ? Math.max(0, targetLaps - lapsCompletedPlan) : null;
+
+  // --- battery thermal projection (computa's 80/20 recent-lap trend) ---------
+  // Per-lap PEAK battery temp from SELECTED laps; project to the finish with a
+  // conservative deg/lap slope: max(median(last 3 deltas), last delta), clamped
+  // >= 0 so it catches the end-of-run ramp and biases hot. Frontend-only.
+  const batteryThermalProjection = useMemo(() => {
+    const lapTemps = selectedLaps
+      .map((lap) => lap.maxCellTempC)
+      .filter((t): t is number => t != null && Number.isFinite(t));
+    const currentTemp = maxCellTempFor(filteredLiveState.lastSample);
+    if (lapTemps.length < 2 || currentTemp == null) {
+      return { ready: false as const, lapTemps, currentTemp };
+    }
+    const deltas: number[] = [];
+    for (let i = 1; i < lapTemps.length; i++) deltas.push(lapTemps[i] - lapTemps[i - 1]);
+    const recent = deltas.slice(-3);
+    const slopeDegPerLap = Math.max(0, Math.max(medianOf(recent), deltas[deltas.length - 1]));
+    const projectedFinishTemp = lapsRemainingPlan != null
+      ? currentTemp + slopeDegPerLap * lapsRemainingPlan
+      : null;
+    return { ready: true as const, lapTemps, currentTemp, slopeDegPerLap, projectedFinishTemp };
+  }, [selectedLaps, filteredLiveState.lastSample, lapsRemainingPlan]);
+
   // Headline budget: how much you can spend on EACH remaining lap from here.
   // Over-use shrinks remaining Wh → this drops; under-use grows it → this rises.
   const dynamicLapBudgetWh = remainingBudgetWh != null && lapsRemainingPlan != null && lapsRemainingPlan > 0
@@ -2239,6 +2272,7 @@ function App() {
             distanceM: lapDistanceM,
             avgSpeedMps: durationMs > 0 && lapDistanceM > 0 ? lapDistanceM / (durationMs / 1000) : null,
             samples: [],
+            maxCellTempC: lapMaxCellTempC(lapSamples),
           };
           laps.push(completedLap);
         }
@@ -2357,6 +2391,7 @@ function App() {
       distanceM: current.lapDistanceM,
       avgSpeedMps: durationMs > 0 && current.lapDistanceM > 0 ? current.lapDistanceM / (durationMs / 1000) : null,
       samples: [],
+      maxCellTempC: lapMaxCellTempC(current.lapSamples),
     };
     laps.push(completedLap);
     const nextState = {
@@ -3574,6 +3609,14 @@ function App() {
                   windowS={energyWindowS}
                 />
               </Panel>
+              <BatteryThermalProjectionPanel
+                projection={batteryThermalProjection}
+                targetLaps={targetLaps}
+                lapsCompleted={lapsCompletedPlan}
+                limitC={batteryTempLimitC}
+                onLimitC={(v) => { setBatteryTempLimitC(v); localStorage.setItem("battery-temp-limit-c", String(v)); }}
+                isMirror={isMirror}
+              />
               <Panel title="Vitals Window" icon={<Gauge size={18} />}>
                 <VitalsWindowChart state={filteredLiveState} windowS={energyWindowS} />
               </Panel>
@@ -4546,6 +4589,88 @@ function TractionControlPanel({ sample }: { sample: LiveSample | null }) {
         <Metric label="Final (TC)" value={fmtNm(finalTq)} tone={tcActive ? "" : "good"} />
       </div>
       <small className="muted">VCU torque path: lookup → derated → power-limited → traction-controlled.</small>
+    </Panel>
+  );
+}
+
+// Battery thermal projection — computa's 80/20 recent-lap trend (NOT a thermal
+// model). Plots per-lap PEAK battery temp vs lap, then a dashed projection from
+// the current temp to the finish at the recent deg/lap slope, against a limit
+// line. Battery only. "Color by margin to limit, not confidence."
+function BatteryThermalProjectionPanel({
+  projection, targetLaps, lapsCompleted, limitC, onLimitC, isMirror,
+}: {
+  projection: { ready: boolean; lapTemps: number[]; currentTemp: number | null; slopeDegPerLap?: number; projectedFinishTemp?: number | null };
+  targetLaps: number;
+  lapsCompleted: number;
+  limitC: number;
+  onLimitC: (v: number) => void;
+  isMirror: boolean;
+}) {
+  const width = 900, height = 180, padLeft = 52, padRight = 16, padTop = 16, padBottom = 28;
+  const plotW = width - padLeft - padRight;
+  const plotH = height - padTop - padBottom;
+  const { ready, lapTemps, currentTemp } = projection;
+  const proj = ready ? projection.projectedFinishTemp ?? null : null;
+  const slope = ready ? projection.slopeDegPerLap ?? 0 : 0;
+  const fmt1 = (v: number | null | undefined) => (v == null ? "--" : v.toFixed(1));
+  const overLimit = proj != null && proj >= limitC;
+  const nearLimit = proj != null && proj >= limitC - 5;
+  const projColor = overLimit ? "#ff4d4f" : nearLimit ? "#FFD700" : "var(--fresh)";
+
+  const limitInput = (
+    <label>
+      <span>Limit °C</span>
+      <input
+        type="number" min={20} max={120} step={1} value={limitC} disabled={isMirror}
+        onChange={(e) => onLimitC(Math.max(20, Math.min(120, Number(e.target.value) || 60)))}
+      />
+    </label>
+  );
+
+  if (!ready || currentTemp == null) {
+    return (
+      <Panel title="Battery Thermal Projection" icon={<Thermometer size={18} />}
+        headerRight={<span style={{ opacity: 0.7 }}>collecting…</span>}>
+        <div className="energyToolbar">{limitInput}</div>
+        <small className="muted">Collecting — need 2+ completed (selected) laps with battery temp to project.</small>
+      </Panel>
+    );
+  }
+
+  const xMax = Math.max(targetLaps || 0, lapsCompleted, lapTemps.length, 1);
+  const xOf = (lap: number) => padLeft + (lap / xMax) * plotW;
+  const ys = [...lapTemps, limitC, currentTemp];
+  if (proj != null) ys.push(proj);
+  const yLo = Math.min(...ys) - 3;
+  const yHi = Math.max(...ys) + 3;
+  const yOf = (t: number) => padTop + (1 - (t - yLo) / Math.max(1, yHi - yLo)) * plotH;
+  const histPts = lapTemps.map((t, i) => `${xOf(i + 1).toFixed(1)},${yOf(t).toFixed(1)}`).join(" ");
+
+  return (
+    <Panel title="Battery Thermal Projection" icon={<Thermometer size={18} />}
+      headerRight={<span style={{ color: projColor }}><strong>{fmt1(currentTemp)}</strong>°C now → <strong>{fmt1(proj)}</strong>°C @ finish</span>}>
+      <div className="energyToolbar">
+        <Metric label="Now" value={`${fmt1(currentTemp)} °C`} />
+        <Metric label="@ Finish" value={proj == null ? "--" : `${fmt1(proj)} °C`} />
+        <Metric label="Trend" value={`+${fmt1(slope)} °C/lap`} />
+        {limitInput}
+      </div>
+      <svg className="energyChart" viewBox={`0 0 ${width} ${height}`} role="img" aria-label="Battery temperature projected to finish">
+        <rect x={padLeft} y={padTop} width={plotW} height={plotH} rx="6" />
+        <line className="thermalLimitLine" x1={padLeft} x2={width - padRight} y1={yOf(limitC)} y2={yOf(limitC)} />
+        <text x={width - padRight} y={yOf(limitC) - 4} textAnchor="end">limit {limitC}°C</text>
+        {histPts ? <polyline className="energyNetLine" points={histPts} /> : null}
+        {proj != null && targetLaps > 0 ? (
+          <line className="thermalProjLine" x1={xOf(lapsCompleted)} y1={yOf(currentTemp)} x2={xOf(targetLaps)} y2={yOf(proj)} style={{ stroke: projColor }} />
+        ) : null}
+        <circle className="thermalNowDot" cx={xOf(lapsCompleted)} cy={yOf(currentTemp)} r="4" />
+        <text x={padLeft} y={height - 8}>lap 0</text>
+        <text x={width - padRight - 36} y={height - 8}>{targetLaps > 0 ? `lap ${targetLaps}` : "now"}</text>
+        <text x={8} y={padTop + 10}>{yHi.toFixed(0)}°C</text>
+        <text x={8} y={height - padBottom}>{yLo.toFixed(0)}°C</text>
+      </svg>
+      <small className="muted">Linear recent-lap trend — projects current battery temp by deg/lap to the finish (selected laps, biased hot). Not a thermal model.</small>
     </Panel>
   );
 }
@@ -6674,6 +6799,24 @@ function maxCellTempFor(sample: LiveSample | null) {
     firstLiveValue(sample.values, ["cell_bottom_temp", "thermal_cell_bottom_temp"]),
   ].map(validTemp).filter((value): value is number => value != null && value > 0);
   return candidates.length ? Math.max(...candidates) : null;
+}
+
+// Peak battery (max-cell) temp °C over a lap's samples — captured at lap close
+// as the lap's representative battery temp for the thermal-projection trend.
+function lapMaxCellTempC(samples: LiveSample[]): number | undefined {
+  let max: number | null = null;
+  for (const s of samples) {
+    const t = maxCellTempFor(s);
+    if (t != null && (max == null || t > max)) max = t;
+  }
+  return max ?? undefined;
+}
+
+function medianOf(values: number[]): number {
+  if (!values.length) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
 }
 
 function packVoltageFor(sample: LiveSample | null) {

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
@@ -523,6 +523,9 @@ function App() {
     const v = Number(localStorage.getItem("battery-temp-limit-c"));
     return Number.isFinite(v) && v > 0 ? v : 60;
   });
+  // Diagnostics & charts (Live Data, energy/temp windows, non-battery temps) are
+  // collapsed by default so the glance panels fit without scrolling. Persisted.
+  const [showDiagnostics, setShowDiagnostics] = useState(() => localStorage.getItem("live-show-diagnostics") === "1");
   const [targetEnergyKwh, setTargetEnergyKwh] = useState(() => Number(localStorage.getItem("motec-target-energy-kwh") || PACK_ENERGY_KWH));
   const [soeCutoffCellV, setSoeCutoffCellV] = useState(loadSoeCutoffCellV);
   const [selectedLapIds, setSelectedLapIds] = useState<Set<string>>(() => new Set());
@@ -652,6 +655,8 @@ function App() {
     samples: filteredLiveSamples,
   }), [liveState, filteredLiveLastSample, filteredLiveSamples]);
   const bestLap = useMemo(() => liveState.laps.reduce<LiveLap | null>((best, lap) => (!best || lap.durationMs < best.durationMs ? lap : best), null), [liveState.laps]);
+  // Most recently completed lap — drives the hero "Last lap" (net + time) tile.
+  const lastLap = liveState.laps.length ? liveState.laps[liveState.laps.length - 1] : null;
   const bestSectors = useMemo(() => bestSectorTimes(liveState.laps), [liveState.laps]);
   const torqueParamSet = useMemo(
     () => VCU_TORQUE_PARAM_SETS.find((item) => item.id === torqueParamSetId) ?? VCU_TORQUE_PARAM_SETS[0],
@@ -3391,9 +3396,16 @@ function App() {
             <div className="liveHeroStats">
               {/* Tier 1 race-state metrics — biggest, glanced every second. */}
               <div className="heroMetricRow">
+                <div className="heroLapBig">
+                  <small>LAP</small>
+                  <strong>{currentLapNumber}<span className="heroLapTarget"> / {targetLaps > 0 ? targetLaps : "—"}</span></strong>
+                </div>
+                <div className="heroLastLap">
+                  <small>LAST LAP</small>
+                  <strong>{lastLap ? formatLapTime(lastLap.durationMs) : "--:--"}</strong>
+                  <span>{lastLap ? `${lastLap.energyWh.toFixed(0)} Wh net` : "—"}</span>
+                </div>
                 <Metric label="Best" value={bestLap ? formatLapTime(bestLap.durationMs) : "--"} tone="purple" />
-                <Metric label="Lap" value={`${currentLapNumber} / ${targetLaps > 0 ? targetLaps : "—"}`} />
-                <Metric label="Energy" value={`${liveState.totalEnergyWh.toFixed(1)} Wh`} />
               </div>
               {/* Tier 2 — compact inline strip, smaller because they're checked
                   every few seconds, not every second. */}
@@ -3577,38 +3589,7 @@ function App() {
               <TractionControlPanel sample={filteredLiveState.lastSample} />
             </div>
             <div className="liveMainColumn">
-              {/* Live Position hidden until chudpi/GPS is reliable. The RadioLion
-                  receiver's draw browns out the chudpi rail, so no fix reaches
-                  the website. Re-enable this Panel block once chudpi power is
-                  fixed. */}
-              {/*
-              <Panel title="Live Position" icon={<MapPinned size={18} />} className="liveMapPanel">
-                <TrackBuilderMap
-                  points={filteredLiveState.samples.filter(hasGps).map((sample) => ({ t: sample.t, lat: sample.lat ?? 0, lon: sample.lon ?? 0 }))}
-                  liveSample={filteredLiveState.lastSample}
-                  gates={track.gates}
-                  drawMode={null}
-                  onDrawGate={handleDrawGate}
-                  center={builderCenter}
-                  onCenter={setBuilderCenter}
-                  targetSpanM={selectedTrackView?.spanM}
-                  gpsUnavailable={filteredLiveState.lastSample != null && !filteredLiveState.samples.some(hasGps)}
-                />
-              </Panel>
-              */}
-              <Panel title="Energy Window" icon={<Zap size={18} />}>
-                <EnergyWindowChart
-                  state={filteredLiveState}
-                  windowS={energyWindowS}
-                  onWindowS={setEnergyWindowS}
-                />
-              </Panel>
-              <Panel title="Temperature Window" icon={<Thermometer size={18} />}>
-                <TemperatureWindowChart
-                  state={filteredLiveState}
-                  windowS={energyWindowS}
-                />
-              </Panel>
+              {/* Primary glance: battery thermals + vitals up top. */}
               <BatteryThermalProjectionPanel
                 projection={batteryThermalProjection}
                 targetLaps={targetLaps}
@@ -3620,13 +3601,39 @@ function App() {
               <Panel title="Vitals Window" icon={<Gauge size={18} />}>
                 <VitalsWindowChart state={filteredLiveState} windowS={energyWindowS} />
               </Panel>
-              {/* G-Forces hidden until the chudpi power issue is fixed — the
-                  RadioLion GPS receiver's draw is browning out the chudpi rail
-                  so no PIMU sentences reach cand. Re-enable with <GForcePanel
-                  state={filteredLiveState} /> once the chudpi holds a stable
-                  link. */}
+              {/* Cool-to-see, lower priority — kept visible but below the glance set. */}
               <DriverControlsPanel sample={filteredLiveState.lastSample} torqueParamSet={torqueParamSet} />
-              <TempsStatusPanel sample={filteredLiveState.lastSample} />
+              {/* Diagnostics & charts — collapsed by default so the glance panels
+                  fit without scrolling. Live Data (right rail) collapses too. */}
+              <button
+                type="button"
+                className="diagToggle"
+                onClick={() => setShowDiagnostics((v) => { const n = !v; localStorage.setItem("live-show-diagnostics", n ? "1" : "0"); return n; })}
+                aria-expanded={showDiagnostics}
+              >
+                <ChevronRight size={15} style={{ transform: showDiagnostics ? "rotate(90deg)" : "none", transition: "transform 0.15s" }} />
+                Diagnostics &amp; charts
+              </button>
+              {showDiagnostics ? (
+                <>
+                  <Panel title="Energy Window" icon={<Zap size={18} />}>
+                    <EnergyWindowChart
+                      state={filteredLiveState}
+                      windowS={energyWindowS}
+                      onWindowS={setEnergyWindowS}
+                    />
+                  </Panel>
+                  <Panel title="Temperature Window" icon={<Thermometer size={18} />}>
+                    <TemperatureWindowChart
+                      state={filteredLiveState}
+                      windowS={energyWindowS}
+                    />
+                  </Panel>
+                  {/* Non-battery temps (motor/inverter/coolant) — battery is the
+                      thermal priority; these live in diagnostics. */}
+                  <TempsStatusPanel sample={filteredLiveState.lastSample} />
+                </>
+              ) : null}
             </div>
             <div className="rightRail">
               {/* Energy Strategy widget hidden for now — revisit later.
@@ -3639,9 +3646,11 @@ function App() {
                 averages={lapAverages}
               />
               */}
-              <Panel title="Live Data" icon={<Gauge size={18} />}>
-                <LiveDataPanel state={filteredLiveState} />
-              </Panel>
+              {showDiagnostics ? (
+                <Panel title="Live Data" icon={<Gauge size={18} />}>
+                  <LiveDataPanel state={filteredLiveState} />
+                </Panel>
+              ) : null}
               <Panel title="Live Setup" icon={<SlidersHorizontal size={18} />}>
                 <div className="trackForm">
                   <label>
@@ -5253,7 +5262,23 @@ function LiveLapTable({
             </tr>
           </thead>
           <tbody>
-            {laps.map((lap) => {
+            {/* Recent-at-top: in-progress lap first, then completed laps newest-first. */}
+            {currentLapElapsedMs > 0 ? (
+              <tr className="currentLapRow">
+                <td>
+                  <span className="lapCurrentDot" aria-hidden="true" />
+                </td>
+                <td>Current</td>
+                <td>{formatLapTime(currentLapElapsedMs)}</td>
+                {Array.from({ length: columns }, (_unused, index) => (
+                  <td key={`current-sector-${index}`}>{currentSectors[index] == null ? "--" : formatLapTime(currentSectors[index])}</td>
+                ))}
+                <td>{currentLapEnergyWh.toFixed(1)} Wh</td>
+                {targetEnergyPerLapWh != null ? <td>{formatEnergyDelta(currentTargetEnergyWh - targetEnergyPerLapWh)}</td> : null}
+                <td />
+              </tr>
+            ) : null}
+            {[...laps].reverse().map((lap) => {
               const selected = selectedLapIds.has(lap.id);
               const targetEnergyWh = lap.energyWh;
               const delta = targetEnergyPerLapWh != null ? targetEnergyWh - targetEnergyPerLapWh : null;
@@ -5317,21 +5342,6 @@ function LiveLapTable({
             {!laps.length && currentLapElapsedMs <= 0 ? (
               <tr>
                 <td colSpan={totalCols}>No completed flying laps yet. Out lap and in lap are excluded from best lap.</td>
-              </tr>
-            ) : null}
-            {currentLapElapsedMs > 0 ? (
-              <tr className="currentLapRow">
-                <td>
-                  <span className="lapCurrentDot" aria-hidden="true" />
-                </td>
-                <td>Current</td>
-                <td>{formatLapTime(currentLapElapsedMs)}</td>
-                {Array.from({ length: columns }, (_unused, index) => (
-                  <td key={`current-sector-${index}`}>{currentSectors[index] == null ? "--" : formatLapTime(currentSectors[index])}</td>
-                ))}
-                <td>{currentLapEnergyWh.toFixed(1)} Wh</td>
-                {targetEnergyPerLapWh != null ? <td>{formatEnergyDelta(currentTargetEnergyWh - targetEnergyPerLapWh)}</td> : null}
-                <td />
               </tr>
             ) : null}
           </tbody>

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/TracksideApp.tsx
@@ -3482,6 +3482,7 @@ function App() {
                 />
               </Panel>
               <PackStatusPanel state={liveState} displayState={filteredLiveState} soeCutoffCellV={soeCutoffCellV} />
+              <CellThermalsPanel sample={filteredLiveState.lastSample} />
               {/* Live energy-plan tiles: used vs remaining + laps done/left +
                   live per-lap budget that recomputes from energy used each
                   completed lap. Configured up in Live Setup; surfaced here
@@ -4517,6 +4518,60 @@ function TractionControlPanel({ sample }: { sample: LiveSample | null }) {
         <Metric label="Final (TC)" value={fmtNm(finalTq)} tone={tcActive ? "" : "good"} />
       </div>
       <small className="muted">VCU torque path: lookup → derated → power-limited → traction-controlled.</small>
+    </Panel>
+  );
+}
+
+// Realtime per-cell thermal grid (Grafana-style heatmap). Reads the cellTemps
+// array carried through the derived feed — same data dashd uses on-car. Each
+// populated cell (temp > 0; the array is zero-padded for cells not yet reported)
+// is a colored tile on a fixed 20-60 °C blue→red scale so colors mean the same
+// thing across sessions.
+function CellThermalsPanel({ sample }: { sample: LiveSample | null }) {
+  const populated = (sample?.cellTemps ?? [])
+    .map((t, i) => ({ i, t }))
+    .filter((c) => c.t > 0);
+  if (!populated.length) {
+    return (
+      <Panel title="Cell Thermals" icon={<Thermometer size={18} />}>
+        <small className="muted">No per-cell temperatures in the live feed yet.</small>
+      </Panel>
+    );
+  }
+  const vals = populated.map((c) => c.t);
+  const min = Math.min(...vals);
+  const max = Math.max(...vals);
+  const avg = vals.reduce((a, b) => a + b, 0) / vals.length;
+  const LO = 20, HI = 60; // fixed color domain (°C)
+  const cellColor = (t: number) => {
+    const frac = Math.max(0, Math.min(1, (t - LO) / (HI - LO)));
+    return `hsl(${Math.round(220 - 220 * frac)}, 70%, 45%)`; // 220 blue (cool) → 0 red (hot)
+  };
+  return (
+    <Panel
+      title="Cell Thermals"
+      icon={<Thermometer size={18} />}
+      headerRight={
+        <>{populated.length} cells · min <strong>{min.toFixed(0)}</strong> · avg <strong>{avg.toFixed(0)}</strong> · max <strong style={{ color: "#ff6b4a" }}>{max.toFixed(0)}</strong> °C</>
+      }
+    >
+      <div className="cellThermalGrid">
+        {populated.map((c) => (
+          <div
+            key={c.i}
+            className="cellThermalCell"
+            style={{ background: cellColor(c.t) }}
+            title={`Cell ${c.i}: ${c.t.toFixed(1)} °C`}
+          >
+            {c.t.toFixed(0)}
+          </div>
+        ))}
+      </div>
+      <div className="cellThermalLegend">
+        <span>{LO}°C</span>
+        <div className="cellThermalScale" />
+        <span>≥{HI}°C</span>
+      </div>
     </Panel>
   );
 }
@@ -6609,10 +6664,19 @@ function validCellVoltage(value: number | null | undefined): value is number {
 
 function maxCellTempFor(sample: LiveSample | null) {
   if (!sample) return null;
+  // Prefer the per-cell array — the same source dashd uses — taking the max over
+  // POSITIVE temps so the zero-padded unreported slots don't count. This is the
+  // fix for "Max Cell T stuck at 0": the old path read cell_top_temp (CAN 0x132),
+  // which HVC doesn't emit, so it sat at 0. Fall back to the enricher's
+  // max_cell_temp scalar, then the legacy 0x132 fields; require > 0 so a no-data
+  // 0 reads as "--" instead of a misleading 0.
+  const fromArray = sample.cellTemps?.filter((t) => t > 0) ?? [];
+  if (fromArray.length) return Math.max(...fromArray);
   const candidates = [
+    firstLiveValue(sample.values, ["max_cell_temp"]),
     firstLiveValue(sample.values, ["cell_top_temp", "thermal_cell_top_temp"]),
     firstLiveValue(sample.values, ["cell_bottom_temp", "thermal_cell_bottom_temp"]),
-  ].map(validTemp).filter((value): value is number => value != null);
+  ].map(validTemp).filter((value): value is number => value != null && value > 0);
   return candidates.length ? Math.max(...candidates) : null;
 }
 

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/trackside.css
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/trackside.css
@@ -1183,6 +1183,43 @@ textarea:focus-visible,
 }
 .opsCards, .liveHeroStats { min-width: 0; }
 .opsCards { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: var(--s-2); }
+
+/* Cell-thermals heatmap grid (realtime per-cell pack temps). */
+.cellThermalGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(34px, 1fr));
+  gap: 3px;
+}
+.cellThermalCell {
+  aspect-ratio: 1 / 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--r-sm);
+  font-size: 0.72rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: #fff;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.55);
+  cursor: default;
+}
+.cellThermalLegend {
+  display: flex;
+  align-items: center;
+  gap: var(--s-2);
+  margin-top: var(--s-2);
+  font-size: var(--fs-sm);
+  opacity: 0.75;
+  font-variant-numeric: tabular-nums;
+}
+.cellThermalScale {
+  flex: 1;
+  height: 8px;
+  border-radius: 4px;
+  /* Match cellColor(): hsl 220 (cool) -> 0 (hot). */
+  background: linear-gradient(to right,
+    hsl(220, 70%, 45%), hsl(165, 70%, 45%), hsl(110, 70%, 45%), hsl(55, 70%, 45%), hsl(0, 70%, 45%));
+}
 /* Energy Plan tiles live in the leftRail (narrow), so the values like
    "450 / 4150 Wh" don't fit a 4-col grid. Use horizontal pills: small
    label on top of the value, font sized to fit a compact tile, and the

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/trackside.css
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/trackside.css
@@ -883,6 +883,11 @@ textarea:focus-visible,
 .widgetItem.sel { border-color: #4ea1ff; background: color-mix(in srgb, #4ea1ff 14%, transparent); }
 .widgetItem .widgetKind { font-size: 0.7rem; text-transform: uppercase; letter-spacing: 1px; color: var(--muted-text); }
 .widgetItem .widgetBind { font-size: var(--fs-sm); font-family: ui-monospace, monospace; word-break: break-all; }
+/* Data-source provenance caption under the field picker (DashLayoutEditor). */
+.fieldSource { font-size: 0.68rem; line-height: 1.3; color: var(--muted-text); margin: 2px 0 6px; padding: 3px 7px; background: color-mix(in srgb, var(--muted-text) 9%, transparent); border-radius: 4px; font-family: ui-monospace, monospace; word-break: break-word; }
+.fieldSource .fieldSourceTag { font-weight: 700; letter-spacing: 1px; color: var(--accent, #d97757); margin-right: 5px; }
+.fieldSource.fieldSourceWarn { color: #b58900; background: color-mix(in srgb, #FFCC00 14%, transparent); }
+.fieldSource.fieldSourceWarn .fieldSourceTag { color: #b58900; }
 .dashEditorStage { display: flex; flex-direction: column; align-items: center; justify-content: center; padding: var(--s-3); background: #0b0c0e; overflow: auto; }
 .dashEditorProps { border-left: 1px solid var(--border); overflow-y: auto; }
 .propPanel { display: flex; flex-direction: column; gap: var(--s-2); padding: var(--s-3); }

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/trackside.css
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/trackside.css
@@ -919,6 +919,9 @@ textarea:focus-visible,
 }
 
 .gateButtons { display: flex; flex-wrap: wrap; gap: var(--s-2); margin: var(--s-3) 0; }
+.screenOverrideButtons { display: grid; grid-template-columns: repeat(2, 1fr); gap: var(--s-2); }
+.screenOverrideButtons .tool { justify-content: center; }
+.screenOverrideButtons .tool.active { border-color: var(--accent); color: var(--accent); background: color-mix(in srgb, var(--accent) 14%, transparent); }
 .fileTool { position: relative; overflow: hidden; }
 .fileTool input { position: absolute; inset: 0; opacity: 0; cursor: pointer; }
 

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/trackside.css
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/trackside.css
@@ -670,6 +670,16 @@ textarea:focus-visible,
 }
 .map.drawing, .builderMap.drawing { cursor: crosshair; }
 .builderMap { height: auto; max-height: 72vh; cursor: grab; }
+/* Map zoom controls — replace scroll-wheel zoom (which hijacked page scroll). */
+.mapWrap { position: relative; }
+.mapZoomBtns { position: absolute; top: var(--s-2); right: var(--s-2); display: flex; flex-direction: column; gap: 4px; }
+.mapZoomBtns button {
+  width: 32px; height: 32px; display: flex; align-items: center; justify-content: center;
+  border: 1px solid var(--border); border-radius: var(--r-sm);
+  background: color-mix(in srgb, var(--surface) 88%, transparent); color: var(--text);
+  cursor: pointer; backdrop-filter: blur(3px); padding: 0;
+}
+.mapZoomBtns button:hover { background: var(--surface); border-color: var(--accent); }
 .map .startGate { stroke: #ff5a40; stroke-width: 3; }
 .map .splitGate { stroke: #5bc7ff; stroke-width: 2.4; }
 .map .drawingGate { stroke-dasharray: 7 5; filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.7)); }
@@ -702,6 +712,17 @@ textarea:focus-visible,
 }
 
 .gpsPanel, .liveMapPanel, .builderMapPanel { align-self: start; }
+
+/* Raw lat/lon + freshness readout above the Live Position map. */
+.gpsReadout { display: flex; align-items: center; gap: var(--s-3); flex-wrap: wrap;
+  margin-bottom: var(--s-2); font-size: var(--fs-sm); }
+.gpsReadout .gpsDot { width: 9px; height: 9px; border-radius: 50%; flex: 0 0 auto; background: var(--dead); }
+.gpsReadout .gpsDot.live { background: var(--fresh); box-shadow: 0 0 0 3px color-mix(in srgb, var(--fresh) 26%, transparent); }
+.gpsReadout .gpsDot.stale { background: var(--stale); box-shadow: 0 0 0 3px color-mix(in srgb, var(--stale) 26%, transparent); }
+.gpsReadout .gpsDot.dead { background: var(--dead); }
+.gpsReadout .gpsCoord { font-variant-numeric: tabular-nums; letter-spacing: 0.3px; opacity: 0.85; }
+.gpsReadout .gpsCoord strong { font-variant-numeric: tabular-nums; opacity: 1; }
+.gpsReadout .gpsAge { margin-left: auto; opacity: 0.6; font-variant-numeric: tabular-nums; }
 
 /* ── Metadata grids ────────────────────────────────────────────────────────── */
 .metadataGrid {

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/trackside.css
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/trackside.css
@@ -1460,8 +1460,7 @@ textarea:focus-visible,
 .energyChart rect { fill: var(--surface-alt); stroke: var(--border); }
 .energyChart line { stroke: var(--border); stroke-width: 1; }
 .energyChart polyline { fill: none; stroke: var(--info); stroke-width: 3; stroke-linejoin: round; stroke-linecap: round; }
-.energyChart .energyInLine { stroke: var(--good); }
-.energyChart .energyOutLine { stroke: var(--info); }
+.energyChart .energyNetLine { stroke: var(--accent); }
 .energyChart text { font-weight: 800; }
 .energyChart .lapBreak line { stroke: var(--best); stroke-dasharray: 4 4; }
 .energyChart .lapBreak text { fill: var(--best); }

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/trackside.css
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/trackside.css
@@ -1080,6 +1080,25 @@ textarea:focus-visible,
   gap: var(--s-2);
 }
 .heroMetricRow .metric { min-height: 52px; }
+/* Hero: dominant lap counter + prominent last-lap (net + time). */
+.heroLapBig, .heroLastLap {
+  display: flex; flex-direction: column; justify-content: center; min-width: 0;
+  background: var(--surface-alt); border: 1px solid var(--border);
+  border-radius: var(--r-md); padding: 6px 12px; min-height: 52px;
+}
+.heroLapBig small, .heroLastLap small { color: var(--muted-text); font-size: var(--fs-sm); letter-spacing: 1.5px; }
+.heroLapBig strong { font-size: clamp(2.2rem, 5vw, 3.4rem); line-height: 1; font-variant-numeric: tabular-nums; }
+.heroLapBig .heroLapTarget { font-size: 0.5em; color: var(--muted-text); font-weight: 600; }
+.heroLastLap strong { font-size: clamp(1.6rem, 3.4vw, 2.3rem); line-height: 1.05; font-variant-numeric: tabular-nums; }
+.heroLastLap span { color: var(--muted-text); font-size: var(--fs-sm); font-variant-numeric: tabular-nums; }
+/* Diagnostics & charts collapse toggle. */
+.diagToggle {
+  display: flex; align-items: center; gap: 6px; width: 100%;
+  background: var(--surface-alt); border: 1px solid var(--border); border-radius: var(--r-md);
+  color: var(--muted-text); padding: 8px 12px; margin-top: var(--s-2);
+  cursor: pointer; font-size: var(--fs-sm); font-weight: 600; letter-spacing: 0.3px;
+}
+.diagToggle:hover { border-color: var(--accent); color: var(--text); }
 /* Tier 2: Regen In + Torque — compact inline label/value pairs, no tile chrome
    so they're visibly subordinate to Tier 1. */
 .heroMetricStrip {

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/trackside.css
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/trackside.css
@@ -680,6 +680,9 @@ textarea:focus-visible,
   cursor: pointer; backdrop-filter: blur(3px); padding: 0;
 }
 .mapZoomBtns button:hover { background: var(--surface); border-color: var(--accent); }
+.mapZoomBtns button.follow.active { background: var(--accent); border-color: var(--accent); color: #fff; }
+.mapZoomBtns button:disabled { opacity: 0.45; cursor: default; }
+.mapZoomBtns button:disabled:hover { background: color-mix(in srgb, var(--surface) 88%, transparent); border-color: var(--border); }
 .map .startGate { stroke: #ff5a40; stroke-width: 3; }
 .map .splitGate { stroke: #5bc7ff; stroke-width: 2.4; }
 .map .drawingGate { stroke-dasharray: 7 5; filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.7)); }

--- a/telemtry/analysis/database/viewer_tool/src/app/trackside-live/trackside.css
+++ b/telemtry/analysis/database/viewer_tool/src/app/trackside-live/trackside.css
@@ -1461,6 +1461,10 @@ textarea:focus-visible,
 .energyChart line { stroke: var(--border); stroke-width: 1; }
 .energyChart polyline { fill: none; stroke: var(--info); stroke-width: 3; stroke-linejoin: round; stroke-linecap: round; }
 .energyChart .energyNetLine { stroke: var(--accent); }
+/* Battery thermal projection chart */
+.energyChart .thermalLimitLine { stroke: #ff4d4f; stroke-width: 1.5; stroke-dasharray: 6 5; opacity: 0.85; }
+.energyChart .thermalProjLine { stroke-width: 2.6; stroke-dasharray: 7 5; fill: none; stroke-linecap: round; } /* stroke color set inline by margin */
+.energyChart .thermalNowDot { fill: var(--text); }
 .energyChart text { font-weight: 800; }
 .energyChart .lapBreak line { stroke: var(--best); stroke-dasharray: 4 4; }
 .energyChart .lapBreak text { fill: var(--best); }

--- a/telemtry/analysis/database/viewer_tool/src/components/dashlayout/DashLayoutEditor.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/components/dashlayout/DashLayoutEditor.tsx
@@ -395,6 +395,7 @@ function PropertyPanel({ w, fields, onChange, onDelete }: { w: Widget; fields: F
         <Row label="Text"><input value={w.text} onChange={(e) => onChange({ text: e.target.value })} /></Row>
       )}
       {hasBind && (
+        <>
         <Row label="Data field">
           <select value={(w as { bind: string }).bind} onChange={(e) => {
             const fd = fieldDef(e.target.value);
@@ -415,11 +416,25 @@ function PropertyPanel({ w, fields, onChange, onDelete }: { w: Widget; fields: F
           }}>
             {Array.from(new Set(fields.map((f) => f.group))).map((g) => (
               <optgroup key={g} label={g}>
-                {fields.filter((f) => f.group === g).map((f) => <option key={f.bind} value={f.bind}>{f.label}{f.unit ? ` (${f.unit})` : ''}</option>)}
+                {fields.filter((f) => f.group === g).map((f) => <option key={f.bind} value={f.bind} title={f.source}>{f.label}{f.unit ? ` (${f.unit})` : ''}</option>)}
               </optgroup>
             ))}
           </select>
         </Row>
+        {/* True data-source provenance for the selected field — the CAN packet /
+            derivation / trackside topic, so the strategist isn't misled by the
+            abstract `can.*` bind path. "demo-only" fields never carry real data. */}
+        {(() => {
+          const fd = fieldDef((w as { bind?: string }).bind ?? '');
+          if (!fd?.source) return null;
+          const demo = fd.source.startsWith('demo-only');
+          return (
+            <div className={`fieldSource${demo ? ' fieldSourceWarn' : ''}`} title={fd.source}>
+              <span className="fieldSourceTag">SRC</span> {fd.source}
+            </div>
+          );
+        })()}
+        </>
       )}
       {(w.type === 'value' || w.type === 'gauge' || w.type === 'delta') && (
         <Row label="Format">

--- a/telemtry/analysis/database/viewer_tool/src/components/dashlayout/DashLayoutEditor.tsx
+++ b/telemtry/analysis/database/viewer_tool/src/components/dashlayout/DashLayoutEditor.tsx
@@ -46,7 +46,7 @@ function snapMove(nx: number, ny: number, ow: number, oh: number, others: Widget
     guides,
   };
 }
-const FORMATS: FormatId[] = ['raw', 'int', 'float1', 'float2', 'laptime', 'wh', 'whSigned', 'kwh', 'kw', 'pct', 'temp', 'volt', 'amp', 'mph'];
+const FORMATS: FormatId[] = ['raw', 'int', 'float1', 'float2', 'laptime', 'wh', 'whSigned', 'kwh', 'kw', 'pct', 'temp', 'volt', 'amp', 'mph', 'bool'];
 
 function genLayoutId(): string {
   return `lay-${Date.now().toString(36)}-${Math.floor(Math.random() * 1e6).toString(36)}`;

--- a/telemtry/analysis/database/viewer_tool/src/lib/dash/dashLayout.ts
+++ b/telemtry/analysis/database/viewer_tool/src/lib/dash/dashLayout.ts
@@ -378,9 +378,38 @@ export function defaultParkLayout(): LapCardLayout {
   };
 }
 
+// Default starter for the Primary / Driving screen — speed + power gauges, SoE,
+// lap delta, and per-lap energy used vs budget. Binds can.* + pacing.* + mqtt.*
+// (no lapCard.* — the lap card is its own overlay). The on-car built-in driving
+// view stays as the fallback whenever no custom driving layout is published.
+export function defaultDrivingLayout(): LapCardLayout {
+  return {
+    version: DASH_LAYOUT_VERSION,
+    name: 'Default driving screen',
+    background: 'auto',
+    widgets: [
+      { id: 'soe', type: 'value', bind: 'can.soc', format: 'pct', label: 'SoE',
+        x: 300, y: 6, w: 200, h: 60, fontSize: 40, color: 'auto', align: 'center', bold: true,
+        thresholds: [{ cmp: 'lt', value: 20, color: '#FFD700' }, { cmp: 'lt', value: 10, color: '#FF3333' }] },
+      { id: 'speed', type: 'gauge', bind: 'can.speed', min: 0, max: 80, label: 'MPH', color: 'gradient', format: 'int',
+        x: 40, y: 80, w: 320, h: 300 },
+      { id: 'power', type: 'gauge', bind: 'can.power', min: -80, max: 80, label: 'kW', mode: 'bidirectional', format: 'kw',
+        x: 440, y: 80, w: 320, h: 300 },
+      { id: 'delta', type: 'delta', bind: 'mqtt.lapDelta', format: 'laptime', label: 'Δ LAP', fontSize: 44,
+        x: 40, y: 396, w: 240, h: 76, goodSign: 'negative', showArrow: true },
+      { id: 'used', type: 'value', bind: 'pacing.lapEnergyWh', format: 'wh', label: 'USED Wh', fontSize: 40,
+        x: 300, y: 396, w: 200, h: 76, color: 'auto', align: 'center', bold: true },
+      { id: 'budget', type: 'delta', bind: 'pacing.budgetDeltaWh', format: 'whSigned', label: 'BUDGET Δ', fontSize: 40,
+        x: 520, y: 396, w: 240, h: 76, goodSign: 'negative', showArrow: false },
+    ],
+  };
+}
+
 export const DASH_SCREENS: ScreenDef[] = [
   { id: 'lapCard', name: 'Lap Card', topic: 'layout', libraryKey: 'dash-lap-layouts',
     contextRoots: ['lapCard', 'pacing', 'can', 'mqtt'], build: defaultLapCardLayout },
+  { id: 'driving', name: 'Primary / Driving', topic: 'drivingLayout', libraryKey: 'dash-driving-layouts',
+    contextRoots: ['can', 'pacing', 'mqtt'], build: defaultDrivingLayout },
   { id: 'park', name: 'Park / Pit', topic: 'parkLayout', libraryKey: 'dash-park-layouts',
     contextRoots: ['can', 'pacing', 'mqtt'], build: defaultParkLayout },
 ];

--- a/telemtry/analysis/database/viewer_tool/src/lib/dash/dashLayout.ts
+++ b/telemtry/analysis/database/viewer_tool/src/lib/dash/dashLayout.ts
@@ -190,9 +190,15 @@ export const FIELD_CATALOG: FieldDef[] = [
   { bind: 'lapCard.lapNumber', label: 'Lap number', group: 'Lap', defaultFormat: 'int', min: 0, max: 30, source: 'on-car lap counter (GPS gate / trackside lapTrigger)' },
   { bind: 'lapCard.timeS', label: 'Lap time', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120, source: 'on-car: wall-clock since lap start' },
   { bind: 'lapCard.energyWh', label: 'Lap energy', group: 'Lap', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 400, source: 'on-car: ∫ CAN power over the lap' },
-  { bind: 'mqtt.bestLapTime', label: 'Best lap', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120, source: 'demo-only — dashd does not track best lap (always —)' },
-  { bind: 'mqtt.lastLapTime', label: 'Last lap', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120, source: 'demo-only — not emitted; real last-lap time is the lap card (lapCard.timeS), timed on-car' },
-  { bind: 'mqtt.currentLapTime', label: 'Current lap time', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120, source: 'demo-only — not emitted; use pacing.lapElapsedS for the live lap time' },
+  // Last completed lap — REAL, on-car (PacingData), forwarded every frame on ALL
+  // screens (unlike lapCard.* which only exists on the lap card). Prefer these over
+  // the mqtt.* lap stubs below. Null until the first lap completes.
+  { bind: 'pacing.lastLapTimeS', label: 'Last lap time', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120, source: 'on-car: time of the last completed lap (PacingData — any screen)' },
+  { bind: 'pacing.lastLapEnergyWh', label: 'Last lap energy', group: 'Lap', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 400, source: 'on-car: net Wh of the last completed lap (PacingData)' },
+  { bind: 'pacing.lastLapNumber', label: 'Last lap #', group: 'Lap', defaultFormat: 'int', min: 0, max: 30, source: 'on-car: number of the last completed lap (PacingData)' },
+  { bind: 'mqtt.bestLapTime', label: 'Best lap (demo)', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120, source: 'demo-only — best lap not tracked on-car yet (always —)' },
+  { bind: 'mqtt.lastLapTime', label: 'Last lap (demo)', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120, source: 'demo-only — not emitted; use pacing.lastLapTimeS instead (real, any screen)' },
+  { bind: 'mqtt.currentLapTime', label: 'Current lap (demo)', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120, source: 'demo-only — not emitted; use pacing.lapElapsedS for the live lap time' },
   { bind: 'mqtt.lapTrigger', label: 'Lap count', group: 'Lap', defaultFormat: 'int', min: 0, max: 30, source: 'on-car monotonic lap count (lhre/dash/lapTrigger)' },
   // Pacing / strategy (on-car authoritative pacing snapshot)
   { bind: 'pacing.lapEnergyWh', label: 'Energy (this lap)', group: 'Pacing', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 400, source: 'on-car: ∫ CAN power this lap' },

--- a/telemtry/analysis/database/viewer_tool/src/lib/dash/dashLayout.ts
+++ b/telemtry/analysis/database/viewer_tool/src/lib/dash/dashLayout.ts
@@ -174,67 +174,76 @@ export interface FieldDef {
   // enum/bitfield fields: value -> label map. When bound, the editor pre-fills a
   // value widget's valueMap with this so it renders labels instead of raw ints.
   enumMap?: Record<string, string>;
+  // Data-source provenance, shown in the editor so the strategist sees the REAL
+  // origin of a value — not the abstract `can.*` bind path. Traced through dashd's
+  // extract_can_data()/PacingData + drivers/longhorn-lib/config/can_packets.csv.
+  // Notes the CAN packet (0x___) + signal, derivation/aggregation formula, the
+  // trackside MQTT topic, or "demo-only" for fields dashd does not actually emit.
+  source?: string;
 }
 
+// `source` traces each value to its REAL origin (CAN packet 0x___ + signal,
+// derivation/aggregation, trackside MQTT topic, or demo-only) — see the
+// FieldDef.source comment. Traced through dashd extract_can_data + can_packets.csv.
 export const FIELD_CATALOG: FieldDef[] = [
   // The just-finished lap (lap card only — lapCard.* is null on other screens)
-  { bind: 'lapCard.lapNumber', label: 'Lap number', group: 'Lap', defaultFormat: 'int', min: 0, max: 30 },
-  { bind: 'lapCard.timeS', label: 'Lap time', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120 },
-  { bind: 'lapCard.energyWh', label: 'Lap energy', group: 'Lap', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 400 },
-  { bind: 'mqtt.bestLapTime', label: 'Best lap', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120 },
-  { bind: 'mqtt.lastLapTime', label: 'Last lap', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120 },
-  { bind: 'mqtt.currentLapTime', label: 'Current lap time', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120 },
-  { bind: 'mqtt.lapTrigger', label: 'Lap count', group: 'Lap', defaultFormat: 'int', min: 0, max: 30 },
+  { bind: 'lapCard.lapNumber', label: 'Lap number', group: 'Lap', defaultFormat: 'int', min: 0, max: 30, source: 'on-car lap counter (GPS gate / trackside lapTrigger)' },
+  { bind: 'lapCard.timeS', label: 'Lap time', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120, source: 'on-car: wall-clock since lap start' },
+  { bind: 'lapCard.energyWh', label: 'Lap energy', group: 'Lap', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 400, source: 'on-car: ∫ CAN power over the lap' },
+  { bind: 'mqtt.bestLapTime', label: 'Best lap', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120, source: 'demo-only — dashd does not track best lap (always —)' },
+  { bind: 'mqtt.lastLapTime', label: 'Last lap', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120, source: 'demo-only — not emitted; real last-lap time is the lap card (lapCard.timeS), timed on-car' },
+  { bind: 'mqtt.currentLapTime', label: 'Current lap time', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120, source: 'demo-only — not emitted; use pacing.lapElapsedS for the live lap time' },
+  { bind: 'mqtt.lapTrigger', label: 'Lap count', group: 'Lap', defaultFormat: 'int', min: 0, max: 30, source: 'on-car monotonic lap count (lhre/dash/lapTrigger)' },
   // Pacing / strategy (on-car authoritative pacing snapshot)
-  { bind: 'pacing.lapEnergyWh', label: 'Energy (this lap)', group: 'Pacing', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 400 },
-  { bind: 'pacing.lapBudgetWh', label: 'Per-lap budget', group: 'Pacing', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 400 },
-  { bind: 'pacing.lapElapsedS', label: 'Lap elapsed', group: 'Pacing', unit: 's', defaultFormat: 'laptime', min: 0, max: 120 },
-  { bind: 'pacing.lapNumber', label: 'Lap (in progress)', group: 'Pacing', defaultFormat: 'int', min: 0, max: 30 },
-  { bind: 'mqtt.lapsRemaining', label: 'Laps remaining', group: 'Pacing', defaultFormat: 'int', min: 0, max: 30 },
-  { bind: 'mqtt.lapsRemainingEnergy', label: 'Laps left (energy)', group: 'Pacing', defaultFormat: 'int', min: 0, max: 30 },
-  { bind: 'mqtt.targetPower', label: 'Target power', group: 'Pacing', unit: 'kW', defaultFormat: 'kw', min: 0, max: 80 },
+  { bind: 'pacing.lapEnergyWh', label: 'Energy (this lap)', group: 'Pacing', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 400, source: 'on-car: ∫ CAN power this lap' },
+  { bind: 'pacing.lapBudgetWh', label: 'Per-lap budget', group: 'Pacing', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 400, source: 'trackside (lhre/dash/lapBudgetWh)' },
+  { bind: 'pacing.lapElapsedS', label: 'Lap elapsed', group: 'Pacing', unit: 's', defaultFormat: 'laptime', min: 0, max: 120, source: 'on-car: wall-clock since lap start' },
+  { bind: 'pacing.lapNumber', label: 'Lap (in progress)', group: 'Pacing', defaultFormat: 'int', min: 0, max: 30, source: 'on-car: lap_count + 1' },
+  { bind: 'mqtt.lapsRemaining', label: 'Laps remaining', group: 'Pacing', defaultFormat: 'int', min: 0, max: 30, source: 'trackside (lhre/dash/lapsRemaining) — no current publisher' },
+  { bind: 'mqtt.lapsRemainingEnergy', label: 'Laps left (energy)', group: 'Pacing', defaultFormat: 'int', min: 0, max: 30, source: 'demo-only — dashd does not emit this (always —)' },
+  { bind: 'mqtt.targetPower', label: 'Target power', group: 'Pacing', unit: 'kW', defaultFormat: 'kw', min: 0, max: 80, source: 'trackside (lhre/dash/targetPower)' },
   // Deltas (signed — green/red by sign; lower/negative is "good" by default)
-  { bind: 'mqtt.lapDelta', label: 'Lap Δ vs ref', group: 'Deltas', unit: 's', defaultFormat: 'float2', min: -5, max: 5, bidirectional: true, isDelta: true, goodSign: 'negative' },
-  { bind: 'pacing.budgetDeltaWh', label: 'Energy budget Δ', group: 'Deltas', unit: 'Wh', defaultFormat: 'whSigned', min: -100, max: 100, bidirectional: true, isDelta: true, goodSign: 'negative' },
-  { bind: 'mqtt.energyDelta', label: 'Energy Δ vs target', group: 'Deltas', unit: 'Wh', defaultFormat: 'whSigned', min: -100, max: 100, bidirectional: true, isDelta: true, goodSign: 'negative' },
-  { bind: 'mqtt.lapDeltaRate', label: 'Lap Δ rate', group: 'Deltas', unit: 's/s', defaultFormat: 'float2', min: -2, max: 2, bidirectional: true, isDelta: true, goodSign: 'negative' },
+  { bind: 'mqtt.lapDelta', label: 'Lap Δ vs ref', group: 'Deltas', unit: 's', defaultFormat: 'float2', min: -5, max: 5, bidirectional: true, isDelta: true, goodSign: 'negative', source: 'trackside (lhre/dash/lapDelta) — no current publisher' },
+  { bind: 'pacing.budgetDeltaWh', label: 'Energy budget Δ', group: 'Deltas', unit: 'Wh', defaultFormat: 'whSigned', min: -100, max: 100, bidirectional: true, isDelta: true, goodSign: 'negative', source: 'on-car derived: lapEnergyWh − targetPower·elapsed' },
+  { bind: 'mqtt.energyDelta', label: 'Energy Δ vs target', group: 'Deltas', unit: 'Wh', defaultFormat: 'whSigned', min: -100, max: 100, bidirectional: true, isDelta: true, goodSign: 'negative', source: 'trackside (lhre/dash/energyDelta) — no current publisher' },
+  { bind: 'mqtt.lapDeltaRate', label: 'Lap Δ rate', group: 'Deltas', unit: 's/s', defaultFormat: 'float2', min: -2, max: 2, bidirectional: true, isDelta: true, goodSign: 'negative', source: 'demo-only — dashd does not emit this (always —)' },
   // Energy / charge (VCU is the source of truth for running energy)
-  { bind: 'can.soc', label: 'State of energy', group: 'Energy', unit: '%', defaultFormat: 'pct', min: 0, max: 100 },
-  { bind: 'can.vcuNetEnergyWh', label: 'VCU net energy', group: 'Energy', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 8000 },
-  { bind: 'can.vcuRegenEnergyWh', label: 'VCU regen energy', group: 'Energy', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 2000 },
-  { bind: 'can.power', label: 'Pack power', group: 'Energy', unit: 'kW', defaultFormat: 'kw', min: -80, max: 80, bidirectional: true },
+  { bind: 'can.soc', label: 'State of energy', group: 'Energy', unit: '%', defaultFormat: 'pct', min: 0, max: 100, source: '0x1C7 soc_estimate (VCU State)' },
+  { bind: 'can.vcuNetEnergyWh', label: 'VCU net energy', group: 'Energy', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 8000, source: '0x1C9 net_energy (VCU Energy Estimate)' },
+  { bind: 'can.vcuRegenEnergyWh', label: 'VCU regen energy', group: 'Energy', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 2000, source: '0x1C9 regen_energy (VCU Energy Estimate)' },
+  { bind: 'can.power', label: 'Pack power', group: 'Energy', unit: 'kW', defaultFormat: 'kw', min: -80, max: 80, bidirectional: true, source: 'derived: 0x0A7 dc_bus_v × 0x0A6 dc_bus_current ÷ 1000' },
   // Cell voltages (pack health)
-  { bind: 'can.cellVMax', label: 'Cell V max', group: 'Cells', unit: 'V', defaultFormat: 'volt', min: 2.5, max: 4.3 },
-  { bind: 'can.cellVMin', label: 'Cell V min', group: 'Cells', unit: 'V', defaultFormat: 'volt', min: 2.5, max: 4.3 },
-  { bind: 'can.cellVSpread', label: 'Cell V spread', group: 'Cells', unit: 'V', defaultFormat: 'float2', min: 0, max: 0.5 },
+  { bind: 'can.cellVMax', label: 'Cell V max', group: 'Cells', unit: 'V', defaultFormat: 'volt', min: 2.5, max: 4.3, source: 'max of 0x0D0 cells_v[] (BMS)' },
+  { bind: 'can.cellVMin', label: 'Cell V min', group: 'Cells', unit: 'V', defaultFormat: 'volt', min: 2.5, max: 4.3, source: 'min of 0x0D0 cells_v[] (BMS)' },
+  { bind: 'can.cellVSpread', label: 'Cell V spread', group: 'Cells', unit: 'V', defaultFormat: 'float2', min: 0, max: 0.5, source: 'derived: max − min of 0x0D0 cells_v[]' },
   // Cell + pack temps
-  { bind: 'can.cellTempMax', label: 'Cell T max', group: 'Temps', unit: '°C', defaultFormat: 'temp', min: 0, max: 80 },
-  { bind: 'can.cellTempAvg', label: 'Cell T avg', group: 'Temps', unit: '°C', defaultFormat: 'temp', min: 0, max: 80 },
-  { bind: 'can.cellTempMin', label: 'Cell T min', group: 'Temps', unit: '°C', defaultFormat: 'temp', min: 0, max: 80 },
-  { bind: 'can.temperature', label: 'Battery temp', group: 'Temps', unit: '°C', defaultFormat: 'temp', min: 0, max: 80 },
+  { bind: 'can.cellTempMax', label: 'Cell T max', group: 'Temps', unit: '°C', defaultFormat: 'temp', min: 0, max: 80, source: 'max of 0x100 cells_temps[] (BMS)' },
+  { bind: 'can.cellTempAvg', label: 'Cell T avg', group: 'Temps', unit: '°C', defaultFormat: 'temp', min: 0, max: 80, source: 'mean of 0x100 cells_temps[] (BMS)' },
+  { bind: 'can.cellTempMin', label: 'Cell T min', group: 'Temps', unit: '°C', defaultFormat: 'temp', min: 0, max: 80, source: 'min of 0x100 cells_temps[] (BMS)' },
+  { bind: 'can.temperature', label: 'Battery temp', group: 'Temps', unit: '°C', defaultFormat: 'temp', min: 0, max: 80, source: '= cell T max (0x100 cells_temps[])' },
   // Powertrain temps
-  { bind: 'can.motorTemp', label: 'Motor temp', group: 'Temps', unit: '°C', defaultFormat: 'temp', min: 0, max: 120 },
-  { bind: 'can.inverterTemp', label: 'Inverter temp', group: 'Temps', unit: '°C', defaultFormat: 'temp', min: 0, max: 100 },
-  { bind: 'can.coolantTemp', label: 'Coolant temp', group: 'Temps', unit: '°C', defaultFormat: 'temp', min: 0, max: 80 },
+  { bind: 'can.motorTemp', label: 'Motor temp', group: 'Temps', unit: '°C', defaultFormat: 'temp', min: 0, max: 120, source: '0x0A2 motor_temp (thermal)' },
+  { bind: 'can.inverterTemp', label: 'Inverter temp', group: 'Temps', unit: '°C', defaultFormat: 'temp', min: 0, max: 100, source: '0x182 inverter_temp (PDU Temps)' },
+  { bind: 'can.coolantTemp', label: 'Coolant temp', group: 'Temps', unit: '°C', defaultFormat: 'temp', min: 0, max: 80, source: '0x0A2 coolant_temp (thermal)' },
   // Driver inputs
-  { bind: 'can.apps', label: 'APPS (accel)', group: 'Driver', unit: '%', defaultFormat: 'pct', min: 0, max: 100 },
-  { bind: 'can.bpps', label: 'BPPS (brake)', group: 'Driver', unit: '%', defaultFormat: 'pct', min: 0, max: 100 },
-  { bind: 'can.brakeBias', label: 'Brake bias (front)', group: 'Driver', unit: '%', defaultFormat: 'pct', min: 0, max: 100 },
-  { bind: 'can.brakePressureFront', label: 'Brake pressure F', group: 'Driver', unit: 'psi', defaultFormat: 'int', min: 0, max: 1000 },
-  { bind: 'can.brakePressureRear', label: 'Brake pressure R', group: 'Driver', unit: 'psi', defaultFormat: 'int', min: 0, max: 1000 },
+  { bind: 'can.apps', label: 'APPS (accel)', group: 'Driver', unit: '%', defaultFormat: 'pct', min: 0, max: 100, source: '0x1C0 apps1_travel (APPS Voltages)' },
+  { bind: 'can.bpps', label: 'BPPS (brake)', group: 'Driver', unit: '%', defaultFormat: 'pct', min: 0, max: 100, source: '0x1C2 bpps1_travel (BPPS Voltages)' },
+  { bind: 'can.brakeBias', label: 'Brake bias (front)', group: 'Driver', unit: '%', defaultFormat: 'pct', min: 0, max: 100, source: 'derived: 0x1C5 brake_bias × 100' },
+  { bind: 'can.brakePressureFront', label: 'Brake pressure F', group: 'Driver', unit: 'psi', defaultFormat: 'int', min: 0, max: 1000, source: '0x1C5 brake_pressure_f (Brakes)' },
+  { bind: 'can.brakePressureRear', label: 'Brake pressure R', group: 'Driver', unit: 'psi', defaultFormat: 'int', min: 0, max: 1000, source: 'derived: mean of 0x1C5 brake_pressure_rall/rbll' },
   // Rails
-  { bind: 'can.hvVoltage', label: 'HV voltage', group: 'Rails', unit: 'V', defaultFormat: 'volt', min: 0, max: 600 },
-  { bind: 'can.hvCurrent', label: 'HV current', group: 'Rails', unit: 'A', defaultFormat: 'amp', min: -400, max: 400, bidirectional: true },
-  { bind: 'can.lvVoltage', label: 'LV voltage', group: 'Rails', unit: 'V', defaultFormat: 'volt', min: 0, max: 30 },
-  { bind: 'can.lvCurrent', label: 'LV current', group: 'Rails', unit: 'A', defaultFormat: 'amp', min: 0, max: 30 },
+  { bind: 'can.hvVoltage', label: 'HV voltage', group: 'Rails', unit: 'V', defaultFormat: 'volt', min: 0, max: 600, source: '0x132 hv_pack_v (HVC — not currently emitted)' },
+  { bind: 'can.hvCurrent', label: 'HV current', group: 'Rails', unit: 'A', defaultFormat: 'amp', min: -400, max: 400, bidirectional: true, source: '0x132 hv_c (HVC — not currently emitted)' },
+  { bind: 'can.lvVoltage', label: 'LV voltage', group: 'Rails', unit: 'V', defaultFormat: 'volt', min: 0, max: 30, source: '0x183 lv_batt_v (LV Battery)' },
+  { bind: 'can.lvCurrent', label: 'LV current', group: 'Rails', unit: 'A', defaultFormat: 'amp', min: 0, max: 30, source: '0x183 lv_batt_c (LV Battery)' },
   // Dynamics + wheels
-  { bind: 'can.speed', label: 'Speed', group: 'Dynamics', unit: 'mph', defaultFormat: 'mph', min: 0, max: 100 },
+  { bind: 'can.speed', label: 'Speed', group: 'Dynamics', unit: 'mph', defaultFormat: 'mph', min: 0, max: 100, source: 'derived: 0x0A5 motor_speed × 0.0142 → mph' },
   { bind: 'can.eventMode', label: 'VCU event mode', group: 'Dynamics', defaultFormat: 'int', min: 0, max: 4,
-    enumMap: { '0': '—', '1': 'ACCEL', '2': 'SKID', '3': 'AUTOX', '4': 'ENDUR' } },
-  { bind: 'can.wheelSpeedFL', label: 'Wheel FL', group: 'Wheels', defaultFormat: 'float1', min: 0, max: 100 },
-  { bind: 'can.wheelSpeedFR', label: 'Wheel FR', group: 'Wheels', defaultFormat: 'float1', min: 0, max: 100 },
-  { bind: 'can.wheelSpeedRL', label: 'Wheel RL', group: 'Wheels', defaultFormat: 'float1', min: 0, max: 100 },
-  { bind: 'can.wheelSpeedRR', label: 'Wheel RR', group: 'Wheels', defaultFormat: 'float1', min: 0, max: 100 },
+    enumMap: { '0': '—', '1': 'ACCEL', '2': 'SKID', '3': 'AUTOX', '4': 'ENDUR' }, source: '0x1C7 event_mode (VCU State)' },
+  { bind: 'can.wheelSpeedFL', label: 'Wheel FL', group: 'Wheels', defaultFormat: 'float1', min: 0, max: 100, source: '0x402 fl_wheel_speed (USM)' },
+  { bind: 'can.wheelSpeedFR', label: 'Wheel FR', group: 'Wheels', defaultFormat: 'float1', min: 0, max: 100, source: '0x403 fr_wheel_speed (USM)' },
+  { bind: 'can.wheelSpeedRL', label: 'Wheel RL', group: 'Wheels', defaultFormat: 'float1', min: 0, max: 100, source: '0x404 bl_wheel_speed (USM rear-left)' },
+  { bind: 'can.wheelSpeedRR', label: 'Wheel RR', group: 'Wheels', defaultFormat: 'float1', min: 0, max: 100, source: '0x405 br_wheel_speed (USM rear-right)' },
 ];
 
 export function fieldDef(bind: string): FieldDef | undefined {

--- a/telemtry/analysis/database/viewer_tool/src/lib/dash/dashLayout.ts
+++ b/telemtry/analysis/database/viewer_tool/src/lib/dash/dashLayout.ts
@@ -191,28 +191,24 @@ export const FIELD_CATALOG: FieldDef[] = [
   { bind: 'lapCard.timeS', label: 'Lap time', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120, source: 'on-car: wall-clock since lap start' },
   { bind: 'lapCard.energyWh', label: 'Lap energy', group: 'Lap', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 400, source: 'on-car: ∫ CAN power over the lap' },
   // Last completed lap — REAL, on-car (PacingData), forwarded every frame on ALL
-  // screens (unlike lapCard.* which only exists on the lap card). Prefer these over
-  // the mqtt.* lap stubs below. Null until the first lap completes.
+  // screens (unlike lapCard.* which only exists on the lap card). Null until the
+  // first lap completes.
   { bind: 'pacing.lastLapTimeS', label: 'Last lap time', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120, source: 'on-car: time of the last completed lap (PacingData — any screen)' },
   { bind: 'pacing.lastLapEnergyWh', label: 'Last lap energy', group: 'Lap', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 400, source: 'on-car: net Wh of the last completed lap (PacingData)' },
   { bind: 'pacing.lastLapNumber', label: 'Last lap #', group: 'Lap', defaultFormat: 'int', min: 0, max: 30, source: 'on-car: number of the last completed lap (PacingData)' },
-  { bind: 'mqtt.bestLapTime', label: 'Best lap (demo)', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120, source: 'demo-only — best lap not tracked on-car yet (always —)' },
-  { bind: 'mqtt.lastLapTime', label: 'Last lap (demo)', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120, source: 'demo-only — not emitted; use pacing.lastLapTimeS instead (real, any screen)' },
-  { bind: 'mqtt.currentLapTime', label: 'Current lap (demo)', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120, source: 'demo-only — not emitted; use pacing.lapElapsedS for the live lap time' },
   { bind: 'mqtt.lapTrigger', label: 'Lap count', group: 'Lap', defaultFormat: 'int', min: 0, max: 30, source: 'on-car monotonic lap count (lhre/dash/lapTrigger)' },
   // Pacing / strategy (on-car authoritative pacing snapshot)
   { bind: 'pacing.lapEnergyWh', label: 'Energy (this lap)', group: 'Pacing', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 400, source: 'on-car: ∫ CAN power this lap' },
   { bind: 'pacing.lapBudgetWh', label: 'Per-lap budget', group: 'Pacing', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 400, source: 'trackside (lhre/dash/lapBudgetWh)' },
   { bind: 'pacing.lapElapsedS', label: 'Lap elapsed', group: 'Pacing', unit: 's', defaultFormat: 'laptime', min: 0, max: 120, source: 'on-car: wall-clock since lap start' },
   { bind: 'pacing.lapNumber', label: 'Lap (in progress)', group: 'Pacing', defaultFormat: 'int', min: 0, max: 30, source: 'on-car: lap_count + 1' },
-  { bind: 'mqtt.lapsRemaining', label: 'Laps remaining', group: 'Pacing', defaultFormat: 'int', min: 0, max: 30, source: 'trackside (lhre/dash/lapsRemaining) — no current publisher' },
-  { bind: 'mqtt.lapsRemainingEnergy', label: 'Laps left (energy)', group: 'Pacing', defaultFormat: 'int', min: 0, max: 30, source: 'demo-only — dashd does not emit this (always —)' },
+  { bind: 'mqtt.lapsRemaining', label: 'Laps remaining', group: 'Pacing', defaultFormat: 'int', min: 0, max: 30, source: 'trackside: target laps − completed (lhre/dash/lapsRemaining)' },
   { bind: 'mqtt.targetPower', label: 'Target power', group: 'Pacing', unit: 'kW', defaultFormat: 'kw', min: 0, max: 80, source: 'trackside (lhre/dash/targetPower)' },
   // Deltas (signed — green/red by sign; lower/negative is "good" by default)
-  { bind: 'mqtt.lapDelta', label: 'Lap Δ vs ref', group: 'Deltas', unit: 's', defaultFormat: 'float2', min: -5, max: 5, bidirectional: true, isDelta: true, goodSign: 'negative', source: 'trackside (lhre/dash/lapDelta) — no current publisher' },
-  { bind: 'pacing.budgetDeltaWh', label: 'Energy budget Δ', group: 'Deltas', unit: 'Wh', defaultFormat: 'whSigned', min: -100, max: 100, bidirectional: true, isDelta: true, goodSign: 'negative', source: 'on-car derived: lapEnergyWh − targetPower·elapsed' },
-  { bind: 'mqtt.energyDelta', label: 'Energy Δ vs target', group: 'Deltas', unit: 'Wh', defaultFormat: 'whSigned', min: -100, max: 100, bidirectional: true, isDelta: true, goodSign: 'negative', source: 'trackside (lhre/dash/energyDelta) — no current publisher' },
-  { bind: 'mqtt.lapDeltaRate', label: 'Lap Δ rate', group: 'Deltas', unit: 's/s', defaultFormat: 'float2', min: -2, max: 2, bidirectional: true, isDelta: true, goodSign: 'negative', source: 'demo-only — dashd does not emit this (always —)' },
+  { bind: 'mqtt.lapDelta', label: 'Lap Δ vs best', group: 'Deltas', unit: 's', defaultFormat: 'float2', min: -5, max: 5, bidirectional: true, isDelta: true, goodSign: 'negative', source: 'trackside: last lap − best lap (lhre/dash/lapDelta)' },
+  { bind: 'pacing.budgetDeltaWh', label: 'Energy budget Δ (power)', group: 'Deltas', unit: 'Wh', defaultFormat: 'whSigned', min: -100, max: 100, bidirectional: true, isDelta: true, goodSign: 'negative', source: 'on-car: lapEnergyWh − targetPower·elapsed (POWER-based, live within lap)' },
+  { bind: 'mqtt.energyDelta', label: 'Energy Δ vs dyn budget', group: 'Deltas', unit: 'Wh', defaultFormat: 'whSigned', min: -100, max: 100, bidirectional: true, isDelta: true, goodSign: 'negative', source: 'trackside: last lap − DYNAMIC budget (remaining ÷ laps left); lhre/dash/energyDelta' },
+  { bind: 'mqtt.energyDeltaStatic', label: 'Energy Δ vs plan', group: 'Deltas', unit: 'Wh', defaultFormat: 'whSigned', min: -100, max: 100, bidirectional: true, isDelta: true, goodSign: 'negative', source: 'trackside: last lap − STATIC plan budget (kWh ÷ laps); lhre/dash/energyDeltaStatic' },
   // Energy / charge (VCU is the source of truth for running energy)
   { bind: 'can.soc', label: 'State of energy', group: 'Energy', unit: '%', defaultFormat: 'pct', min: 0, max: 100, source: '0x1C7 soc_estimate (VCU State)' },
   { bind: 'can.vcuNetEnergyWh', label: 'VCU net energy', group: 'Energy', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 8000, source: '0x1C9 net_energy (VCU Energy Estimate)' },

--- a/telemtry/analysis/database/viewer_tool/src/lib/dash/dashLayout.ts
+++ b/telemtry/analysis/database/viewer_tool/src/lib/dash/dashLayout.ts
@@ -59,7 +59,8 @@ export type FormatId =
   | 'raw' | 'int' | 'float1' | 'float2'
   | 'laptime'   // M:SS.ss
   | 'wh' | 'whSigned' | 'kwh'
-  | 'kw' | 'pct' | 'temp' | 'volt' | 'amp' | 'mph';
+  | 'kw' | 'pct' | 'temp' | 'volt' | 'amp' | 'mph'
+  | 'bool';     // ON/OFF — booleans (e.g. can.regenEnabled) coerce to 1/0 in getByPath
 
 export interface BaseWidget {
   id: string;
@@ -246,6 +247,13 @@ export const FIELD_CATALOG: FieldDef[] = [
   { bind: 'can.wheelSpeedFR', label: 'Wheel FR', group: 'Wheels', defaultFormat: 'float1', min: 0, max: 100, source: '0x403 fr_wheel_speed (USM)' },
   { bind: 'can.wheelSpeedRL', label: 'Wheel RL', group: 'Wheels', defaultFormat: 'float1', min: 0, max: 100, source: '0x404 bl_wheel_speed (USM rear-left)' },
   { bind: 'can.wheelSpeedRR', label: 'Wheel RR', group: 'Wheels', defaultFormat: 'float1', min: 0, max: 100, source: '0x405 br_wheel_speed (USM rear-right)' },
+  // Boolean status flags (rendered ON/OFF; booleans → 1/0 in getByPath). The
+  // editor pre-fills each widget's valueMap from enumMap, so the labels (and
+  // colors, via thresholds) are editable per widget.
+  { bind: 'can.regenEnabled', label: 'Regen', group: 'Controls', defaultFormat: 'bool', min: 0, max: 1, enumMap: { '0': 'OFF', '1': 'ON' }, source: '0x1C7 byte 5 (VCU State) — "line_lock_enabled" bit, used as the regen-armed flag' },
+  { bind: 'can.posContactor', label: 'HV+ contactor', group: 'Contactors', defaultFormat: 'bool', min: 0, max: 1, enumMap: { '0': 'OPEN', '1': 'CLOSED' }, source: '0x131 pos contactor (HVC)' },
+  { bind: 'can.negContactor', label: 'HV− contactor', group: 'Contactors', defaultFormat: 'bool', min: 0, max: 1, enumMap: { '0': 'OPEN', '1': 'CLOSED' }, source: '0x131 neg contactor (HVC)' },
+  { bind: 'can.prechargeContactor', label: 'Precharge', group: 'Contactors', defaultFormat: 'bool', min: 0, max: 1, enumMap: { '0': 'OPEN', '1': 'CLOSED' }, source: '0x131 precharge contactor (HVC)' },
 ];
 
 export function fieldDef(bind: string): FieldDef | undefined {
@@ -264,6 +272,9 @@ export function getByPath(ctx: unknown, path: string): number | null {
     if (cur == null || typeof cur !== 'object') return null;
     cur = (cur as Record<string, unknown>)[key];
   }
+  // Booleans (e.g. can.regenEnabled, contactors) are exposed as 1/0 so they can
+  // bind to value widgets — rendered ON/OFF via the 'bool' format or a valueMap.
+  if (typeof cur === 'boolean') return cur ? 1 : 0;
   return typeof cur === 'number' && Number.isFinite(cur) ? cur : null;
 }
 
@@ -279,6 +290,9 @@ export function valueColor(v: number | null | undefined, base: string, rules?: C
 
 export function formatValue(v: number | null | undefined, fmt: FormatId, decimals?: number): string {
   if (v == null || !Number.isFinite(v)) return '--';
+  // ON/OFF for booleans (already coerced to 1/0 by getByPath). A widget valueMap
+  // (e.g. {0:'OPEN',1:'CLOSED'}) overrides these via applyValueMap.
+  if (fmt === 'bool') return v >= 0.5 ? 'ON' : 'OFF';
   // Optional per-widget precision override. Applies to the numeric formats —
   // keeps kwh's /1000 scaling and whSigned's +/- sign; lap-time ignores it.
   if (decimals != null && Number.isFinite(decimals) && fmt !== 'laptime') {

--- a/telemtry/analysis/database/viewer_tool/src/lib/dash/dashLayout.ts
+++ b/telemtry/analysis/database/viewer_tool/src/lib/dash/dashLayout.ts
@@ -178,13 +178,16 @@ export interface FieldDef {
 
 export const FIELD_CATALOG: FieldDef[] = [
   // The just-finished lap (lap card only — lapCard.* is null on other screens)
-  { bind: 'lapCard.lapNumber', label: 'Lap number', group: 'Lap', defaultFormat: 'int', min: 0, max: 30 },
+  { bind: 'lapCard.lapNumber', label: 'Lap number (card only)', group: 'Lap', defaultFormat: 'int', min: 0, max: 30 },
   { bind: 'lapCard.timeS', label: 'Lap time', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120 },
   { bind: 'lapCard.energyWh', label: 'Lap energy', group: 'Lap', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 400 },
   { bind: 'mqtt.bestLapTime', label: 'Best lap', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120 },
   { bind: 'mqtt.lastLapTime', label: 'Last lap', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120 },
   { bind: 'mqtt.currentLapTime', label: 'Current lap time', group: 'Lap', unit: 's', defaultFormat: 'laptime', min: 0, max: 120 },
-  { bind: 'mqtt.lapTrigger', label: 'Lap count', group: 'Lap', defaultFormat: 'int', min: 0, max: 30 },
+  // Live running count of laps COMPLETED (dashd lap_count). Corrects up/down with
+  // trackside in real time — e.g. a deselected double-count / driver-change lap —
+  // so use THIS for a persistent "laps done" readout, not the card-only number.
+  { bind: 'mqtt.lapTrigger', label: 'Laps completed (live)', group: 'Lap', defaultFormat: 'int', min: 0, max: 30 },
   // Pacing / strategy (on-car authoritative pacing snapshot)
   { bind: 'pacing.lapEnergyWh', label: 'Energy (this lap)', group: 'Pacing', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 400 },
   { bind: 'pacing.lapBudgetWh', label: 'Per-lap budget', group: 'Pacing', unit: 'Wh', defaultFormat: 'wh', min: 0, max: 400 },

--- a/telemtry/analysis/database/viewer_tool/src/lib/dash/dashSignals.ts
+++ b/telemtry/analysis/database/viewer_tool/src/lib/dash/dashSignals.ts
@@ -77,6 +77,11 @@ export interface DashSignals {
     disconnect: () => void;
     /** Set the live power budget (kW) shown on the dash energy bar. */
     publishTargetPower: (kw: number) => void;
+    /** Trackside strategy deltas (re-sent on keepalive; pass null to stop sending). */
+    publishLapDelta: (seconds: number | null) => void;
+    publishEnergyDelta: (wh: number | null) => void;
+    publishEnergyDeltaStatic: (wh: number | null) => void;
+    publishLapsRemaining: (laps: number | null) => void;
     /** Bump the lap counter — fires the dash's full-screen lap card + per-lap reset. */
     sendLap: (value?: number) => void;
     /** Re-publish a lap value without bumping the internal counter — for the drain
@@ -132,6 +137,12 @@ export function useDashSignals(): DashSignals {
 
     const clientRef = useRef<MqttClient | null>(null);
     const targetPowerRef = useRef<number | null>(null);
+    // Trackside-computed strategy deltas; re-sent each keepalive tick because dashd
+    // nulls them after 5 s of silence (MqttState staleness).
+    const lapDeltaRef = useRef<number | null>(null);
+    const energyDeltaRef = useRef<number | null>(null);
+    const energyDeltaStaticRef = useRef<number | null>(null);
+    const lapsRemainingRef = useRef<number | null>(null);
     const lapCounterRef = useRef(0);
     const keepaliveRef = useRef<number | null>(null);
 
@@ -233,12 +244,37 @@ export function useDashSignals(): DashSignals {
 
         keepaliveRef.current = window.setInterval(() => {
             if (targetPowerRef.current !== null) publish('targetPower', targetPowerRef.current);
+            // Re-send the strategy deltas so dashd's 5 s staleness gate doesn't blank them.
+            if (lapDeltaRef.current !== null) publish('lapDelta', lapDeltaRef.current);
+            if (energyDeltaRef.current !== null) publish('energyDelta', energyDeltaRef.current);
+            if (energyDeltaStaticRef.current !== null) publish('energyDeltaStatic', energyDeltaStaticRef.current);
+            if (lapsRemainingRef.current !== null) publish('lapsRemaining', lapsRemainingRef.current);
         }, KEEPALIVE_MS);
     }, [brokerUrl, publish]);
 
     const publishTargetPower = useCallback((kw: number) => {
         targetPowerRef.current = kw;
         publish('targetPower', kw);
+    }, [publish]);
+
+    // Trackside-computed strategy deltas. Each stores its value (for the keepalive
+    // re-send) and publishes immediately; pass null to stop sending (dashd nulls it
+    // out after the staleness window).
+    const publishLapDelta = useCallback((seconds: number | null) => {
+        lapDeltaRef.current = seconds;
+        if (seconds !== null) publish('lapDelta', seconds);
+    }, [publish]);
+    const publishEnergyDelta = useCallback((wh: number | null) => {
+        energyDeltaRef.current = wh;
+        if (wh !== null) publish('energyDelta', wh);
+    }, [publish]);
+    const publishEnergyDeltaStatic = useCallback((wh: number | null) => {
+        energyDeltaStaticRef.current = wh;
+        if (wh !== null) publish('energyDeltaStatic', wh);
+    }, [publish]);
+    const publishLapsRemaining = useCallback((laps: number | null) => {
+        lapsRemainingRef.current = laps;
+        if (laps !== null) publish('lapsRemaining', laps);
     }, [publish]);
 
     const sendLap = useCallback((value?: number) => {
@@ -381,6 +417,10 @@ export function useDashSignals(): DashSignals {
         connect,
         disconnect,
         publishTargetPower,
+        publishLapDelta,
+        publishEnergyDelta,
+        publishEnergyDeltaStatic,
+        publishLapsRemaining,
         sendLap,
         republishLap,
         resetLapCounter,

--- a/telemtry/analysis/database/viewer_tool/src/lib/dash/dashSignals.ts
+++ b/telemtry/analysis/database/viewer_tool/src/lib/dash/dashSignals.ts
@@ -83,6 +83,10 @@ export interface DashSignals {
      *  effect that catches up the car after a missed publish. dashd's forward-only
      *  edge check makes a duplicate publish harmless. */
     republishLap: (value: number) => void;
+    /** Set the dash's absolute completed-lap count WITHOUT firing a card. Used to
+     *  pull the count DOWN when a lap is deselected on the live list (lapTrigger
+     *  is forward-only); dashd adopts this value in either direction. */
+    publishLapCount: (count: number) => void;
     resetLapCounter: () => void;
     /** Push the start/finish gate [lat1,lon1,lat2,lon2] so the car counts laps itself (retained). */
     publishGate: (gate: [number, number, number, number]) => void;
@@ -267,6 +271,17 @@ export function useDashSignals(): DashSignals {
         publish('lapTrigger', value, 1);
     }, [publish]);
 
+    // Absolute lap-count set (no card). dashd adopts it in either direction, so
+    // this is how the count is pulled DOWN after a lap is deselected. Keep the
+    // local lapCounterRef aligned so the next forward sendLap still computes the
+    // right next number. qos 1 — a deliberate correction shouldn't be dropped.
+    const publishLapCount = useCallback((count: number) => {
+        const v = Math.max(0, Math.round(count));
+        lapCounterRef.current = v;
+        setLapsSent(v);
+        publish('lapCount', v, 1);
+    }, [publish]);
+
     // Tell dashd to drop its lap counter + baseline (new session on trackside).
     // Without this the FIRST few clicks of a fresh session would be silently
     // ignored on the car because dashd was still holding the prior session's
@@ -372,6 +387,7 @@ export function useDashSignals(): DashSignals {
         publishTargetPower,
         sendLap,
         republishLap,
+        publishLapCount,
         resetLapCounter,
         publishGate,
         publishLayout,

--- a/telemtry/analysis/database/viewer_tool/src/lib/dash/dashSignals.ts
+++ b/telemtry/analysis/database/viewer_tool/src/lib/dash/dashSignals.ts
@@ -77,6 +77,9 @@ export interface DashSignals {
     disconnect: () => void;
     /** Set the live power budget (kW) shown on the dash energy bar. */
     publishTargetPower: (kw: number) => void;
+    /** Command the VCU's params table by event_mode (1=accel 2=skid 3=autox 4=endur).
+     *  Relayed by dashd onto CAN as the 0x029 VCU Mode Command (byte0=mode). */
+    publishEventMode: (mode: number) => void;
     /** Bump the lap counter — fires the dash's full-screen lap card + per-lap reset. */
     sendLap: (value?: number) => void;
     /** Re-publish a lap value without bumping the internal counter — for the drain
@@ -239,6 +242,12 @@ export function useDashSignals(): DashSignals {
         publish('targetPower', kw);
     }, [publish]);
 
+    // VCU mode command. qos 1 so a momentary link blip can't drop a deliberate
+    // one-shot command (dashd relays it onto CAN as the 0x029 packet).
+    const publishEventMode = useCallback((mode: number) => {
+        publish('eventMode', Math.round(mode), 1);
+    }, [publish]);
+
     const sendLap = useCallback((value?: number) => {
         // Caller passes an ABSOLUTE lap number (the website's authoritative
         // count). dashd adopts this directly so the dash displays the same
@@ -370,6 +379,7 @@ export function useDashSignals(): DashSignals {
         connect,
         disconnect,
         publishTargetPower,
+        publishEventMode,
         sendLap,
         republishLap,
         resetLapCounter,

--- a/telemtry/analysis/database/viewer_tool/src/lib/dash/dashSignals.ts
+++ b/telemtry/analysis/database/viewer_tool/src/lib/dash/dashSignals.ts
@@ -106,6 +106,11 @@ export interface DashSignals {
     sendMessage: (message: DashMessage, durationS?: number) => boolean;
     /** Dismiss whatever message is currently on the dash. */
     clearMessage: () => boolean;
+    /** Debug: force the dash to show a named screen ("driving"/"park"/"shutdown"/
+     *  "settings"), or pass "auto"/null to release back to PRNDL routing. Not
+     *  retained, so a dash reboot returns to normal; dashd also auto-clears it on
+     *  a real gear change. */
+    publishScreen: (screen: string | null) => boolean;
     /** Latest mirror of the driver's screen (null until the car publishes state). */
     dashState: DashMirrorState | null;
     /** Wall-clock ms of the last lhre/dash/state message — for a link-silent warning. */
@@ -397,6 +402,17 @@ export function useDashSignals(): DashSignals {
         return true;
     }, []);
 
+    // Debug screen override (lhre/dash/screen). NOT retained: a one-shot string
+    // the dash applies as a precedence layer over PRNDL routing. dashd clears it
+    // on a real gear change and a dash reboot drops it (no replay), so it can't
+    // strand the driver. qos 1 so the press reliably lands. null/"auto" releases.
+    const publishScreen = useCallback((screen: string | null): boolean => {
+        const client = clientRef.current;
+        if (!client || !client.connected) return false;
+        client.publish(`${TOPIC_PREFIX}screen`, screen ?? 'auto', { qos: 1 });
+        return true;
+    }, []);
+
     const setBrokerUrl = useCallback((url: string) => {
         setBrokerUrlState(url);
         if (typeof window !== 'undefined') localStorage.setItem(BROKER_STORAGE_KEY, url);
@@ -433,6 +449,7 @@ export function useDashSignals(): DashSignals {
         publishMessages,
         sendMessage,
         clearMessage,
+        publishScreen,
         dashState,
         lastStateAt,
         acks,

--- a/telemtry/analysis/database/viewer_tool/src/lib/dash/dashSignals.ts
+++ b/telemtry/analysis/database/viewer_tool/src/lib/dash/dashSignals.ts
@@ -90,6 +90,8 @@ export interface DashSignals {
     publishLayout: (layout: unknown) => boolean;
     /** Push the park/pit-screen layout (retained, separate topic from the lap card). */
     publishParkLayout: (layout: unknown) => boolean;
+    /** Push the primary/driving-screen layout (retained, its own topic). */
+    publishDrivingLayout: (layout: unknown) => boolean;
     /** Push the live dynamic per-lap energy budget (Wh) the dash shows (retained). */
     publishLapBudget: (wh: number) => boolean;
     publishLapCardMs: (ms: number) => boolean;
@@ -303,6 +305,15 @@ export function useDashSignals(): DashSignals {
         return true;
     }, []);
 
+    // Primary / driving-screen layout — same retained pattern, its own topic so
+    // all three screens (lap card, driving, park) are authored independently.
+    const publishDrivingLayout = useCallback((layout: unknown): boolean => {
+        const client = clientRef.current;
+        if (!client || !client.connected) return false;
+        client.publish(`${TOPIC_PREFIX}drivingLayout`, JSON.stringify(layout), { qos: 1, retain: true });
+        return true;
+    }, []);
+
     // Retained: the live per-lap Wh budget (remaining energy / remaining laps),
     // republished by trackside whenever it changes. The dash holds it and shows
     // the driver the current Wh/lap target.
@@ -376,6 +387,7 @@ export function useDashSignals(): DashSignals {
         publishGate,
         publishLayout,
         publishParkLayout,
+        publishDrivingLayout,
         publishLapBudget,
         publishLapCardMs,
         publishMessages,

--- a/telemtry/analysis/database/viewer_tool/src/lib/motec/live.ts
+++ b/telemtry/analysis/database/viewer_tool/src/lib/motec/live.ts
@@ -63,6 +63,14 @@ function flattenNumeric(payload: Record<string, unknown>): Record<string, number
   return out;
 }
 
+// Coerce a JSON array of numbers, PRESERVING index/position (non-numeric -> 0).
+// cells_temps is a fixed-length, zero-padded array (cand fills slots as the
+// per-cell CAN frames arrive), so the index IS the cell id — don't compact it.
+function numArray(value: unknown): number[] | undefined {
+  if (!Array.isArray(value) || value.length === 0) return undefined;
+  return value.map((v) => { const n = num(v); return n === null ? 0 : n; });
+}
+
 function gpsOf(payload: Record<string, unknown>): [number | null, number | null] {
   const lat = num(first(payload, ["latitude", "lat", "gps_latitude", "dynamics_gps_latitude", "dynamics.latitude"]));
   const lon = num(first(payload, ["longitude", "lon", "lng", "gps_longitude", "dynamics_gps_longitude", "dynamics.longitude"]));
@@ -127,7 +135,11 @@ export function normalizeLivePayload(raw: string | Record<string, unknown>, sour
   if (hvC !== null && values.hv_c === undefined) values.hv_c = hvC;
   if (powerKw !== null && values.power_kw === undefined) values.power_kw = powerKw;
 
-  return { t, source, lat, lon, speed, hv_pack_v: hvV, hv_c: hvC, power_kw: powerKw, values };
+  // Per-cell temps: top-level `cells_temps` in the derived feed, `pack.cells_temps`
+  // in the raw sensor_data frames. flattenNumeric drops arrays, so pull it here.
+  const cellTemps = numArray(first(payload, ["cells_temps", "pack.cells_temps", "pack.cellsTemps", "pack_cells_temps"]));
+
+  return { t, source, lat, lon, speed, hv_pack_v: hvV, hv_c: hvC, power_kw: powerKw, values, cellTemps };
 }
 
 // ── Orion-schema enrichment ───────────────────────────────────────────────────

--- a/telemtry/analysis/database/viewer_tool/src/lib/motec/types.ts
+++ b/telemtry/analysis/database/viewer_tool/src/lib/motec/types.ts
@@ -108,6 +108,9 @@ export type LiveSample = {
   hv_c: number | null;
   power_kw: number | null;
   values: Record<string, number>;
+  /** Per-cell pack temperatures (°C) from pack.cells_temps[], carried through
+   *  the derived feed (zero-padded for cells not yet reported this frame). */
+  cellTemps?: number[];
 };
 
 export type LiveStreamEvent =

--- a/telemtry/analysis/database/viewer_tool/src/lib/trackside/types.ts
+++ b/telemtry/analysis/database/viewer_tool/src/lib/trackside/types.ts
@@ -110,6 +110,11 @@ export type LiveSample = {
   hv_c: number | null;
   power_kw: number | null;
   values: Record<string, number>;
+  /** Per-cell pack temperatures (°C) from pack.cells_temps[], carried through
+   *  the derived feed. Zero-padded for cells not yet reported this frame. Kept
+   *  as an array (values{} can't hold it) for the cell-thermals grid + a
+   *  dashd-equivalent zero-filtered max. */
+  cellTemps?: number[];
 };
 
 export type LiveStreamEvent =


### PR DESCRIPTION
Consolidates the trackside/dash work — **#300** (customizable primary screen + lap-card overlay), **#308** (Max Cell T fix + realtime Cell Thermals grid + layout reorg), and **#307** (VCU event-mode over CAN) — into a single review + merge, per post-competition cleanup ("all deploys follow main").

## What's in it
- **#300**: customizable primary/driving screen, `bool` dash format + regen/contactor catalog fields, GPS readout + follow-the-car Live Position map, dash-layout editor, dashd frontend.
- **#308**: Max-Cell-T fix, realtime Cell Thermals grid, Battery Thermal Projection panel, net-energy purge, lapcount↔selected-laps sync, layout reorg, cellTemps plumbing.
- **#307**: VCU event-mode control — web VCU-Mode dropdown + `dashSignals.publishEventMode` → MQTT `lhre/dash/eventMode` → dashd relays to CAN `0x029` (`send_can_mode_command`) → cand TX → VCU (echoes in `0x1C7`). Includes the CAN schema (`can.json`/`can_ids`/`can_packets.csv`), VCU firmware (`vcu_can.*`, `app_freertos.c`), and the cand TX listener.

## Conflict resolution
- `TracksideApp.tsx`: Battery Thermal Projection on top (#308); Energy/Temp windows → collapsible Diagnostics (#308); Live Position follow-the-car map at column bottom (#300); VCU-Mode dropdown (#307) auto-merged.
- `dashLayout.ts`: #308 relabels + demo lap fields + #300 `source:` provenance + `pacing.lastLap*`.
- `dashSignals.ts`: all of #300/#308's publishers + #307's `publishEventMode`.
- `BEVO/dashd/main.rs`: kept both the `screen` override (#300) and the `eventMode` relay (#307) handlers.
- Deduped the `const lastLap` both #300 and #308 added.

## CI note
`HIL - VCU` / `HIL - DFU` will be red because the HIL bench PC is off — not a code failure. #307's car-side was validated on the car during competition (VCU flashed; `0x029` TX + `0x1C7` echo verified end-to-end). The `no-main-push` ruleset requires an approving review, not passing checks.

Supersedes #300, #307, #308.