### PR TITLE
Autonomy: run the stack on a Mac (Docker)

### DIFF
--- a/autonomy/ros2/GETTING-STARTED.md
+++ b/autonomy/ros2/GETTING-STARTED.md
@@ -6,7 +6,9 @@ Goal: fresh machine to a simulated car lapping in RViz, in about 30 minutes.
 
 **Ubuntu 24.04, native install only.** ROS 2 Jazzy + Gazebo Harmonic.
 
-No WSL. We tried it, hit graphics and stability issues, and dropped it. No macOS, no other distros. If you only have a Windows machine, dual-boot or use a team machine.
+No WSL. We tried it, hit graphics and stability issues, and dropped it. No native macOS, no other distros. If you only have a Windows machine, dual-boot or use a team machine.
+
+On a Mac (Apple Silicon or Intel), use the Docker setup instead: see [docker/README.md](docker/README.md). Full stack including the Gazebo demo works, at ~0.7–0.8x real time.
 
 ## 1. Get the code
 

--- a/autonomy/ros2/docker/Dockerfile
+++ b/autonomy/ros2/docker/Dockerfile
@@ -1,0 +1,19 @@
+# Dev container for the autonomy stack on non-Ubuntu hosts (macOS, Windows).
+# Base: Ubuntu 24.04 + ROS 2 Jazzy desktop + a lightweight desktop served over
+# noVNC (browser at http://localhost:6080). Works on arm64 (Apple Silicon) and amd64.
+FROM tiryoh/ros2-desktop-vnc:jazzy
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-jazzy-ros-gz \
+    ros-jazzy-ackermann-msgs \
+    ros-jazzy-tf2-ros \
+    ros-jazzy-plotjuggler-ros \
+    python3-colcon-common-extensions \
+    python3-numpy \
+    python3-scipy \
+    && rm -rf /var/lib/apt/lists/*
+
+# The base image ships a pip numpy 2.x in /usr/local that shadows apt's numpy,
+# breaking apt's scipy (built against numpy 1.x). Shadow scipy the same way so
+# the pair is ABI-consistent.
+RUN pip install --no-cache-dir --break-system-packages --ignore-installed "scipy>=1.14"

--- a/autonomy/ros2/docker/README.md
+++ b/autonomy/ros2/docker/README.md
@@ -1,0 +1,46 @@
+# Running the stack on macOS (Docker)
+
+The supported platform is still native Ubuntu 24.04 ([GETTING-STARTED](../GETTING-STARTED.md)).
+This container is the workaround for Macs: Ubuntu 24.04 + ROS 2 Jazzy + Gazebo Harmonic
+in Docker, with the desktop (RViz, Gazebo GUI) served to your browser via noVNC.
+Runs at near-native speed on Apple Silicon (arm64 packages, software OpenGL for rendering).
+
+## One-time setup
+
+```bash
+brew install colima docker docker-compose
+# let docker find the compose plugin:
+mkdir -p ~/.docker && cat > ~/.docker/config.json <<'EOF'
+{ "cliPluginsExtraDirs": ["/opt/homebrew/lib/docker/cli-plugins"] }
+EOF
+colima start --cpu 6 --memory 8 --disk 60
+cd autonomy/ros2/docker
+docker compose up -d --build
+```
+
+## Daily use
+
+- Desktop in browser: **http://localhost:6080/vnc.html?autoconnect=true&resize=scale**
+- Shell into the container: `docker exec -it -u ubuntu lhr-autonomy bash`
+- The repo is bind-mounted at `~/autonomy` inside the container — edit on the Mac
+  with your normal editor, build/run inside the container:
+
+```bash
+cd ~/autonomy/ros2
+./scripts/build.sh
+./scripts/run_demo.sh                                  # kinematic demo
+./scripts/run_gazebo_demo.sh track_style:=oval perception:=lidar
+DISPLAY=:1 LIBGL_ALWAYS_SOFTWARE=1 ./scripts/rviz_demo.sh
+```
+
+(In a terminal opened inside the noVNC desktop, `DISPLAY` is already set.)
+
+After a reboot: `colima start && docker start lhr-autonomy`.
+
+## Notes
+
+- `ros2/build`, `ros2/install`, `ros2/log` are created by the container and are
+  Linux-only artifacts; delete them if you ever switch this checkout to native Ubuntu.
+- Gazebo renders on CPU (llvmpipe) — expect ~0.7–0.8x real-time factor. Fine for
+  development; use a native Ubuntu box for anything performance-sensitive.
+- The image layers a scipy fix over `tiryoh/ros2-desktop-vnc:jazzy` (see Dockerfile).

--- a/autonomy/ros2/docker/compose.yaml
+++ b/autonomy/ros2/docker/compose.yaml
@@ -1,0 +1,13 @@
+services:
+  autonomy:
+    build: .
+    image: lhr-autonomy-dev
+    container_name: lhr-autonomy
+    ports:
+      - "6080:80" # noVNC desktop -> http://localhost:6080
+    volumes:
+      # Mount the whole autonomy/ tree; build artifacts (ros2/build, ros2/install,
+      # ros2/log) land on the host but are Linux-only — don't use them natively.
+      - ../..:/home/ubuntu/autonomy
+    shm_size: "2gb" # RViz/Gazebo rendering needs more than the 64MB default
+    restart: unless-stopped


### PR DESCRIPTION
Lets anyone with a Mac run the full autonomy stack — no Ubuntu machine needed.

- Everything runs inside a Docker container, so your Mac stays untouched
- RViz and Gazebo show up right in your browser at `localhost:6080`
- You edit code on your Mac like normal; the container picks up changes instantly
- Setup is 3 commands, written up in `ros2/docker/README.md`
- Tested on an M5 MacBook Air: build works, the kinematic demo laps, and the Gazebo + lidar demo laps with no off-track events
- Runs a bit slower than a real Ubuntu box (~0.7x real time in Gazebo) — fine for dev work
- Getting-started guide now points Mac users here